### PR TITLE
Add support for IKEA TRADFRI bulb GU10 W 400lm

### DIFF
--- a/lib/converters/zigbee2mqtt.js
+++ b/lib/converters/zigbee2mqtt.js
@@ -131,7 +131,7 @@ const parsers = [
         convert: (msg) => {return {contact: msg.data.data['onOff'] === 0}}
     },
     {
-        devices: ['LED1545G12', '7146060PH', 'LED1537R6', 'LED1623G12'],
+        devices: ['LED1545G12', '7146060PH', 'LED1537R6', 'LED1623G12', 'LED1650R5'],
         cid: 'genLevelCtrl',
         type: 'devChange',
         convert: (msg) => {return {brightness: msg.data.data['currentLevel']}},
@@ -250,7 +250,7 @@ const parsers = [
 
     // Ignore parsers (these message dont need parsing).
     {
-        devices: ['WXKG11LM', 'MCCGQ11LM', 'MCCGQ01LM', 'WXKG01LM', 'LED1545G12', '7146060PH', 'LED1537R6', 'ZNCZ02LM', 'QBCZ11LM', 'QBKG04LM', 'QBKG03LM', 'LED1623G12'],
+        devices: ['WXKG11LM', 'MCCGQ11LM', 'MCCGQ01LM', 'WXKG01LM', 'LED1545G12', '7146060PH', 'LED1537R6', 'ZNCZ02LM', 'QBCZ11LM', 'QBKG04LM', 'QBKG03LM', 'LED1623G12', 'LED1650R5'],
         cid: 'genOnOff',
         type: 'devChange',
         convert: () => null

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -132,6 +132,13 @@ const devices = {
         supports: 'on/off, brightness, color temperature',
         homeassistant: [homeassistant.light_brightness_colortemp]
     },
+    'TRADFRI bulb GU10 W 400lm': {
+        model: 'LED1650R5',
+        vendor: 'IKEA',
+        description: 'TRADFRI LED bulb GU10 400 lumen, dimmable',
+        supports: 'on/off, brightness',
+        homeassistant: [homeassistant.light_brightness]
+    },
 
     // Philips
     'LLC020': {


### PR DESCRIPTION
This is the GU10 bulb without white level control.

Supports only dimming.