### PR TITLE
allow specifying configuration.yaml path via argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
+const fs = require('fs');
 const Controller = require('./lib/controller');
+const data = require('./lib/util/data.js');
+
+if (process.env.ZIGBEE2MQTT_DATA) {
+  fs.copyFileSync('./data/configuration.yaml', data.joinPath('configuration.yaml'))
+}
 
 const controller = new Controller();
 controller.start();

--- a/lib/converters/zigbee2mqtt.js
+++ b/lib/converters/zigbee2mqtt.js
@@ -201,13 +201,13 @@ const parsers = [
         convert: (msg) => {return {contact: msg.data.data['onOff'] === 0}}
     },
     {
-        devices: ['LED1545G12', '7146060PH', 'LED1537R6', 'LED1623G12', 'LED1650R5', 'LED1536G5'],
+        devices: ['LED1545G12', '7146060PH', 'LED1537R6', 'LED1623G12', 'LED1650R5'],
         cid: 'genLevelCtrl',
         type: 'devChange',
         convert: (msg) => {return {brightness: msg.data.data['currentLevel']}},
     },
     {
-        devices: ['LED1545G12', '7146060PH', 'LED1537R6', 'LED1536G5'],
+        devices: ['LED1545G12', '7146060PH', 'LED1537R6'],
         cid: 'lightingColorCtrl',
         type: 'devChange',
         convert: (msg) => {
@@ -323,7 +323,7 @@ const parsers = [
 
     // Ignore parsers (these message dont need parsing).
     {
-        devices: ['WXKG11LM', 'MCCGQ11LM', 'MCCGQ01LM', 'WXKG01LM', 'LED1545G12', '7146060PH', 'LED1537R6', 'ZNCZ02LM', 'QBCZ11LM', 'QBKG04LM', 'QBKG03LM', 'LED1623G12', 'LED1650R5', 'LED1536G5'],
+        devices: ['WXKG11LM', 'MCCGQ11LM', 'MCCGQ01LM', 'WXKG01LM', 'LED1545G12', '7146060PH', 'LED1537R6', 'ZNCZ02LM', 'QBCZ11LM', 'QBKG04LM', 'QBKG03LM', 'LED1623G12', 'LED1650R5'],
         cid: 'genOnOff',
         type: 'devChange',
         convert: () => null

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -146,13 +146,6 @@ const devices = {
         supports: 'on/off, brightness',
         homeassistant: [homeassistant.light_brightness]
     },
-    'TRADFRI bulb E14 WS opal 400lm': {
-        model: 'LED1536G5',
-        vendor: 'IKEA',
-        description: 'TRADFRI LED bulb E14 WS opal 400 lumen, dimmable, white spectrum',
-        supports: 'on/off, brightness, color temperature',
-        homeassistant: [homeassistant.light_brightness_colortemp]
-    },
 
     // Philips
     'LLC020': {

--- a/lib/util/data.js
+++ b/lib/util/data.js
@@ -1,0 +1,14 @@
+const path = require('path');
+
+function dataPath() {
+  if (process.env.ZIGBEE2MQTT_DATA) {
+    return process.env.ZIGBEE2MQTT_DATA;
+  } else {
+    return `${__dirname}/../../data`
+  }
+}
+
+module.exports = {
+  path: dataPath(),
+  joinPath: (file) => path.join(dataPath(), file)
+}

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,9 +1,10 @@
 const winston = require('winston');
+const data = require('./data');
 
 const logger = new (winston.Logger)({
     transports: [
         new (winston.transports.File)({
-            filename: 'data/log.txt',
+            filename: data.joinPath('log.txt'),
             json: false,
             level: winston.level.info,
             maxFiles: 3,

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -1,14 +1,24 @@
 const YAWN = require('yawn-yaml/cjs');
 const fs = require('fs');
-const file = `${__dirname}/../../data/configuration.yaml`;
+const defaultPath = `${__dirname}/../../data/configuration.yaml`;
 let yawn = read();
 
+function getConfigPath() {
+  // if a configuration path is given as arg, use it
+  // else, use the default location at /data/configuration.yaml
+  if (process.argv.length < 3) {
+    return defaultPath;
+  } else {
+    return process.argv[2];
+  }
+}
+
 function write() {
-    fs.writeFileSync(file, yawn.yaml);
+    fs.writeFileSync(getConfigPath(), yawn.yaml);
 }
 
 function read() {
-    return new YAWN(fs.readFileSync(file, 'utf8'));
+    return new YAWN(fs.readFileSync(getConfigPath(), 'utf8'));
 }
 
 function addDevice(id) {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -1,24 +1,15 @@
 const YAWN = require('yawn-yaml/cjs');
 const fs = require('fs');
-const defaultPath = `${__dirname}/../../data/configuration.yaml`;
+const data = require('./data')
+let file = data.joinPath('configuration.yaml');
 let yawn = read();
 
-function getConfigPath() {
-  // if a configuration path is given as arg, use it
-  // else, use the default location at /data/configuration.yaml
-  if (process.argv.length < 3) {
-    return defaultPath;
-  } else {
-    return process.argv[2];
-  }
-}
-
 function write() {
-    fs.writeFileSync(getConfigPath(), yawn.yaml);
+    fs.writeFileSync(file, yawn.yaml);
 }
 
 function read() {
-    return new YAWN(fs.readFileSync(getConfigPath(), 'utf8'));
+    return new YAWN(fs.readFileSync(file, 'utf8'));
 }
 
 function addDevice(id) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -2,10 +2,11 @@ const ZShepherd = require('zigbee-shepherd');
 const logger = require('./util/logger');
 const settings = require('./util/settings');
 const deviceMapping = require('./devices');
+const data = require('./util/data');
 
 const shepherdSettings = {
     net: {panId: 0x1a62},
-    dbPath: `${__dirname}/../data/database.db`
+    dbPath: data.joinPath('database.db')
 };
 
 class Zigbee {


### PR DESCRIPTION
This shouldn't change the default behavior. If run with `npm start`, the library will still expect `configuration.yaml` to be in the `data` directory.

However, this allows for an alternate location to be passed to the start script, like so:
`npm start -- /path/to/configuration.yaml`

If an additional command line argument is given in this way, it is assumed to be the configuration path, and it will be used instead of the default location. 