### PR TITLE
Added loging level through mqtt

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -14,6 +14,8 @@ const mqttDevicePrefixRegex = new RegExp(`${settings.get().mqtt.base_topic}/[\\w
 const pollInterval = 60 * 1000; // seconds * 1000.
 const softResetTimeout = 3600 * 1000; // seconds * 1000.
 
+const allowedLogLevels = ['error', 'warn', 'info', 'debug'];
+
 /**
  * Home Assistant requires ALL attributes to be present in ALL MQTT messages send by the device.
  * https://community.home-assistant.io/t/missing-value-with-mqtt-only-last-data-set-is-shown/47070/9
@@ -340,11 +342,11 @@ class Controller {
         if (option === 'permit_join') {
             this.zigbee.permitJoin(message.toString().toLowerCase() === 'true');
         } else if (option === 'log_level') {
-            let level = message.toString().toLowerCase();
-            if (['error', 'warn', 'info', 'debug'].indexOf(level) > -1) {
+            const level = message.toString().toLowerCase();
+            if (allowedLogLevels.includes(level)) {
                 logger.warn(`Switching log level to '${level}'`);
-                logger.transports.console.level = message.toString().toLowerCase();
-                logger.transports.file.level = message.toString().toLowerCase();
+                logger.transports.console.level = level;
+                logger.transports.file.level = level;
             } else {
                 logger.error(`Could not set log level to '${level}'`);
             }

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -340,16 +340,14 @@ class Controller {
         if (option === 'permit_join') {
             this.zigbee.permitJoin(message.toString().toLowerCase() === 'true');
         } else if (option === 'log_level') {
-            let level = message.toString().toLowerCase()
-            if (["error", "warn", "info", "debug"].indexOf(level) > -1) {
-                console.log(`Switching log level to '${level}'`);
+            let level = message.toString().toLowerCase();
+            if (['error', 'warn', 'info', 'debug'].indexOf(level) > -1) {
+                logger.warn(`Switching log level to '${level}'`);
                 logger.transports.console.level = message.toString().toLowerCase();
                 logger.transports.file.level = message.toString().toLowerCase();
+            } else {
+                logger.error(`Could not set log level to '${level}'`);
             }
-            else {
-                logger.error(`Could not set log level to '${level}'`)
-            }
-
         } else if (option === 'devices') {
             const devices = this.zigbee.getAllClients().map((device) => {
                 const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -317,7 +317,7 @@ class Controller {
     }
 
     handleMQTTMessage(topic, message) {
-        logger.debug(`Incoming MQTT message '${topic}' '${message.toString()}'`);
+        logger.debug(`Recieved mqtt message on topic '${topic}' with data '${message}'`);
 
         if (topic.match(mqttConfigRegex)) {
             this.handleMQTTMessageConfig(topic, message);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -348,7 +348,7 @@ class Controller {
                 logger.transports.console.level = level;
                 logger.transports.file.level = level;
             } else {
-                logger.error(`Could not set log level to '${level}'`);
+                logger.error(`Could not set log level to '${level}'. Allowed level: '${allowedLogLevels.join(',')}'`);
             }
         } else if (option === 'devices') {
             const devices = this.zigbee.getAllClients().map((device) => {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -5,7 +5,6 @@ const settings = require('./util/settings');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 const homeassistant = require('./homeassistant');
 const objectAssignDeep = require(`object-assign-deep`);
-const debug = require('debug')('zigbee2mqtt:controller');
 
 const mqttConfigRegex = new RegExp(`${settings.get().mqtt.base_topic}/bridge/config/\\w+`, 'g');
 const mqttDeviceRegex = new RegExp(`${settings.get().mqtt.base_topic}/[\\w\\s\\d]+/set`, 'g');
@@ -207,7 +206,7 @@ class Controller {
         // Zigbee message receieved, reset soft reset timeout.
         this.softResetTimeout(true);
 
-        debug('Recieved zigbee message with data', message.data);
+        logger.debug('Recieved zigbee message with data', message.data);
 
         if (message.type == 'devInterview') {
             logger.info('Connecting with device...');
@@ -344,7 +343,7 @@ class Controller {
         } else if (option === 'log_level') {
             const level = message.toString().toLowerCase();
             if (allowedLogLevels.includes(level)) {
-                logger.warn(`Switching log level to '${level}'`);
+                logger.info(`Switching log level to '${level}'`);
                 logger.transports.console.level = level;
                 logger.transports.file.level = level;
             } else {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -339,6 +339,17 @@ class Controller {
 
         if (option === 'permit_join') {
             this.zigbee.permitJoin(message.toString().toLowerCase() === 'true');
+        } else if (option === 'log_level') {
+            let level = message.toString().toLowerCase()
+            if (["error", "warn", "info", "debug"].indexOf(level) > -1) {
+                console.log(`Switching log level to '${level}'`);
+                logger.transports.console.level = message.toString().toLowerCase();
+                logger.transports.file.level = message.toString().toLowerCase();
+            }
+            else {
+                logger.error(`Could not set log level to '${level}'`)
+            }
+
         } else if (option === 'devices') {
             const devices = this.zigbee.getAllClients().map((device) => {
                 const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -5,6 +5,7 @@ const settings = require('./util/settings');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 const homeassistant = require('./homeassistant');
 const objectAssignDeep = require(`object-assign-deep`);
+const debug = require('debug')('zigbee2mqtt:controller');
 
 const mqttConfigRegex = new RegExp(`${settings.get().mqtt.base_topic}/bridge/config/\\w+`, 'g');
 const mqttDeviceRegex = new RegExp(`${settings.get().mqtt.base_topic}/[\\w\\s\\d]+/set`, 'g');
@@ -206,7 +207,7 @@ class Controller {
         // Zigbee message receieved, reset soft reset timeout.
         this.softResetTimeout(true);
 
-        logger.debug('Recieved zigbee message with data', message.data);
+        debug('Recieved zigbee message with data', message.data);
 
         if (message.type == 'devInterview') {
             logger.info('Connecting with device...');

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -5,7 +5,6 @@ const settings = require('./util/settings');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 const homeassistant = require('./homeassistant');
 const objectAssignDeep = require(`object-assign-deep`);
-const debug = require('debug')('zigbee2mqtt:controller');
 
 const mqttConfigRegex = new RegExp(`${settings.get().mqtt.base_topic}/bridge/config/\\w+`, 'g');
 const mqttDeviceRegex = new RegExp(`${settings.get().mqtt.base_topic}/[\\w\\s\\d]+/set`, 'g');
@@ -207,7 +206,7 @@ class Controller {
         // Zigbee message receieved, reset soft reset timeout.
         this.softResetTimeout(true);
 
-        debug('Recieved zigbee message with data', message.data);
+        logger.debug('Recieved zigbee message with data', message.data);
 
         if (message.type == 'devInterview') {
             logger.info('Connecting with device...');

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,11 +1,16 @@
 const winston = require('winston');
 const data = require('./data');
 const settings = require('./settings');
-let logLevel = settings.get().advanced && settings.get().advanced.log_level ?
-    settings.get().advanced.log_level : winston.level.info;
+
+let logLevel = '';
 if (process.env.DEBUG) {
     logLevel = 'debug';
+} else if (settings.get().advanced && settings.get().advanced.log_level) {
+    logLevel = settings.get().advanced.log_level;
+} else {
+    logLevel = winston.level.info;
 }
+
 const logger = new (winston.Logger)({
     transports: [
         new (winston.transports.File)({
@@ -26,6 +31,7 @@ const logger = new (winston.Logger)({
         }),
     ],
 });
+
 logger.transports.console.level = logLevel;
 
 module.exports = logger;

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,12 +1,13 @@
 const winston = require('winston');
 const data = require('./data');
-
+const settings = require('./settings');
+const logLevel = settings.get().advanced && settings.get().advanced.log_level ? settings.get().advanced.log_level : winston.level.info;
 const logger = new (winston.Logger)({
     transports: [
         new (winston.transports.File)({
             filename: data.joinPath('log.txt'),
             json: false,
-            level: winston.level.info,
+            level: logLevel,
             maxFiles: 3,
             maxsize: 10000000, // 10MB
         }),
@@ -21,5 +22,6 @@ const logger = new (winston.Logger)({
         }),
     ],
 });
+logger.transports.console.level = logLevel;
 
 module.exports = logger;

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,7 +1,8 @@
 const winston = require('winston');
 const data = require('./data');
 const settings = require('./settings');
-const logLevel = settings.get().advanced && settings.get().advanced.log_level ? settings.get().advanced.log_level : winston.level.info;
+const logLevel = settings.get().advanced && settings.get().advanced.log_level ?
+    settings.get().advanced.log_level : winston.level.info;
 const logger = new (winston.Logger)({
     transports: [
         new (winston.transports.File)({

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,8 +1,11 @@
 const winston = require('winston');
 const data = require('./data');
 const settings = require('./settings');
-const logLevel = settings.get().advanced && settings.get().advanced.log_level ?
+let logLevel = settings.get().advanced && settings.get().advanced.log_level ?
     settings.get().advanced.log_level : winston.level.info;
+if (process.env.DEBUG) {
+    logLevel = 'debug';
+}
 const logger = new (winston.Logger)({
     transports: [
         new (winston.transports.File)({

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -2,7 +2,6 @@ const ZShepherd = require('zigbee-shepherd');
 const logger = require('./util/logger');
 const settings = require('./util/settings');
 const data = require('./util/data');
-const debug = require('debug')('zigbee2mqtt:zigbee');
 const zclPacket = require('zcl-packet');
 
 const advancedSettings = settings.get().advanced;
@@ -139,7 +138,7 @@ class Zigbee {
 
         if (device) {
             // Note: checkOnline has the callback argument but does not call callback
-            debug(`Check online ${deviceID}`);
+            logger.debug(`Check online ${deviceID}`);
             this.shepherd.controller.checkOnline(device);
         }
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -222,16 +222,6 @@
         "serialport": "4.0.7",
         "stream-browserify": "2.0.1",
         "unpi": "1.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "chalk": {
@@ -375,9 +365,9 @@
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -559,6 +549,17 @@
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
         "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-config-google": {
@@ -1511,14 +1512,6 @@
         "object.assign": "4.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "node-pre-gyp": {
           "version": "0.6.32",
           "bundled": true,
@@ -2777,14 +2770,6 @@
         "zstack-constants": "0.2.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "zcl-id": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/zcl-id/-/zcl-id-0.3.2.tgz",
@@ -2797,9 +2782,9 @@
       }
     },
     "zigbee-shepherd-converters": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/zigbee-shepherd-converters/-/zigbee-shepherd-converters-2.0.6.tgz",
-      "integrity": "sha512-WCa6556mDOn7324yU3EQjVlO2JpiwibJMAYZkFsNkF9uOB1ViYQsx49YDJWF4ShLfnq3VRnOHJm2UfVqc/3ACA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/zigbee-shepherd-converters/-/zigbee-shepherd-converters-2.0.7.tgz",
+      "integrity": "sha512-yBLpHohmjw192Sp5rjX8pozLcjcnhy5AmVIob+CI0+AgGCHEpzGBjc9JvxLyH/N/XVOjMiyVK6wOb5B/Ua1xaw==",
       "requires": {
         "debounce": "1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/Koenkk/zigbee2mqtt/wiki",
   "dependencies": {
-    "debug": "*",
     "object-assign-deep": "*",
     "mqtt": "*",
     "winston": "2.4.2",


### PR DESCRIPTION
Added loging level through mqtt

Just logging entity (not libraries) and no documentation added in this PR. Couldn't figure out how to print nicely log level as didn't want to have it as "critical" the information that you're switching log level. 

Implements https://github.com/Koenkk/zigbee2mqtt/issues/81 parially

- [x] Allow setting log level through mqtt
- [x] Allow setting log level through configuration
- [x] Allow setting log level for dependencies (where possible, like https://github.com/Koenkk/zigbee2mqtt/issues/81#issuecomment-394113688)
- [x] Force debug on start-up for `logger` when received `DEBUG` env variable
- [x] Documentation on both mqtt and configuration for log_level
