### PR TITLE
Port speed for cc2530 models

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -12,7 +12,13 @@ const shepherdSettings = {
         channelList: [advancedSettings && advancedSettings.channel ? advancedSettings.channel : 11],
     },
     dbPath: data.joinPath('database.db'),
+    sp: {
+        baudrate: advancedSettings && advancedSettings.baudrate ? advancedSettings.baudrate : 115200,
+        rtscts: advancedSettings && (typeof(advancedSettings.rtscts) === 'boolean') ? advancedSettings.rtscts : true,
+    },
 };
+
+logger.debug(`Using zigbee-shepherd with settings: '${JSON.stringify(shepherdSettings)}'`);
 
 class Zigbee {
     constructor() {


### PR DESCRIPTION
Fixes #97 

- [x] Allow port `baudrate` and `rtscts` from `configuration.yaml`
- [x] Set defaults to those in zigbee-shepherd
- [x] Update documentation