### PR TITLE
Add mapping for Gledopto RGB+CCT controller for Home Assistant

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -288,6 +288,7 @@ const mapping = {
     'NL08-0800': [configurations.light_brightness],
     '915005106701': [configurations.light_brightness_colortemp_xy],
     'AB32840': [configurations.light_brightness_colortemp],
+    'GL-C-008': [configurations.light_brightness_colortemp_xy],
 };
 
 // A map of all discoverd devices


### PR DESCRIPTION
This adds the HA mapping for the Gledopto RGB+CCT controller added in this PR: https://github.com/Koenkk/zigbee-shepherd-converters/pull/31 