### PR TITLE
Rename devices (friendly_name) ->  (#177)

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -400,42 +400,41 @@ class Controller {
             } else {
                 cleanup();
             }
-        } else if (option === 'rename') { 
-			// Convert the MQTT message to a Zigbee message.
-			let json = null;
-			try {
-				json = JSON.parse(message);
-			} catch (e) {
-				// Cannot be parsed to JSON, assume state message.
-				return;
-			}
-			if (!json.hasOwnProperty('oldname')) {
-				logger.error('Failed to renamed - oldname property is missing');
-				return;
-			}
-			if (!json.hasOwnProperty('newname')) {
-				logger.error('Failed to renamed - newname property is missing');
-				return;
-			}
-			if(json.oldname.toString() == null || json.oldname.toString() == '' || json.oldname.toString().length <= 0) {
-				logger.error('Failed to renamed - oldname value is missing or Null');
-				return;
-			}  
-			if(json.newname.toString() == null || json.newname.toString() == '' || json.newname.toString().length <= 0) {
-				logger.error('Failed to renamed - newname value is missing or Null');
-				return;
-			} 
-			if(json.newname.toString() === json.oldname.toString()) {
-				logger.error(`Failed to renamed - ${json.oldname} and ${json.newname} seem to be eqal.`);
-				return;
-			}
-			const renamed = settings.RenameFriendlyName(json.oldname,json.newname);
-			if(renamed) {
-				logger.info(`Successfully renamed - ${json.oldname} to ${json.newname} `);
-			}else {
-				logger.error(`Failed to renamed - ${json.oldname} to ${json.newname}`);
-			}			
-		} else {
+        } else if (option === 'rename') {
+            const invalid = `Invalid rename message format expected {old: 'friendly_name', new: 'new_name} ` +
+                            `got ${message.toString()}`;
+
+            let json = null;
+            try {
+                json = JSON.parse(message.toString());
+            } catch (e) {
+                logger.error(invalid);
+                return;
+            }
+
+            // Validate message
+            if (!json.new || !json.old) {
+                logger.error(invalid);
+                return;
+            }
+
+            if (settings.changeFriendlyName(json.old, json.new)) {
+                logger.info(`Successfully renamed - ${json.old} to ${json.new} `);
+            } else {
+                logger.error(`Failed to renamed - ${json.old} to ${json.new}`);
+                return;
+            }
+
+            // Homeassistant rediscover
+            if (settings.get().homeassistant) {
+                const ID = settings.getIDByFriendlyName(json.new);
+                const device = this.zigbee.getDevice(ID);
+                const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
+                if (mappedModel) {
+                    homeassistant.discover(device.ieeeAddr, mappedModel.model, this.mqtt, true);
+                }
+            }
+        } else {
             logger.warn(`Cannot handle MQTT config option '${option}' with message '${message}'`);
         }
     }

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -400,7 +400,42 @@ class Controller {
             } else {
                 cleanup();
             }
-        } else {
+        } else if (option === 'rename') { 
+			// Convert the MQTT message to a Zigbee message.
+			let json = null;
+			try {
+				json = JSON.parse(message);
+			} catch (e) {
+				// Cannot be parsed to JSON, assume state message.
+				return;
+			}
+			if (!json.hasOwnProperty('oldname')) {
+				logger.error('Failed to renamed - oldname property is missing');
+				return;
+			}
+			if (!json.hasOwnProperty('newname')) {
+				logger.error('Failed to renamed - newname property is missing');
+				return;
+			}
+			if(json.oldname.toString() == null || json.oldname.toString() == '' || json.oldname.toString().length <= 0) {
+				logger.error('Failed to renamed - oldname value is missing or Null');
+				return;
+			}  
+			if(json.newname.toString() == null || json.newname.toString() == '' || json.newname.toString().length <= 0) {
+				logger.error('Failed to renamed - newname value is missing or Null');
+				return;
+			} 
+			if(json.newname.toString() === json.oldname.toString()) {
+				logger.error(`Failed to renamed - ${json.oldname} and ${json.newname} seem to be eqal.`);
+				return;
+			}
+			const renamed = settings.RenameFriendlyName(json.oldname,json.newname);
+			if(renamed) {
+				logger.info(`Successfully renamed - ${json.oldname} to ${json.newname} `);
+			}else {
+				logger.error(`Failed to renamed - ${json.oldname} to ${json.newname}`);
+			}			
+		} else {
             logger.warn(`Cannot handle MQTT config option '${option}' with message '${message}'`);
         }
     }

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -44,6 +44,20 @@ function getIDByFriendlyName(friendlyName) {
     );
 }
 
+function RenameFriendlyName(original,replace) {
+	originalName = getIDByFriendlyName(original)
+	if(!originalName) {
+		return false;
+	}
+	removeDevice(originalName)
+	if (!settings.devices) {
+        settings.devices = {};
+    }
+	settings.devices[originalName] = {friendly_name: replace, retain: false};
+    writeRead();
+	return true;
+}
+
 module.exports = {
     get: () => settings,
     write: () => write(),
@@ -51,4 +65,5 @@ module.exports = {
     addDevice: (id) => addDevice(id),
     removeDevice: (id) => removeDevice(id),
     getIDByFriendlyName: (friendlyName) => getIDByFriendlyName(friendlyName),
+    RenameFriendlyName: (original,replace) => RenameFriendlyName(original,replace),
 };

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -44,18 +44,16 @@ function getIDByFriendlyName(friendlyName) {
     );
 }
 
-function RenameFriendlyName(original,replace) {
-	originalName = getIDByFriendlyName(original)
-	if(!originalName) {
-		return false;
-	}
-	removeDevice(originalName)
-	if (!settings.devices) {
-        settings.devices = {};
+function changeFriendlyName(old, new_) {
+    const ID = getIDByFriendlyName(old);
+
+    if (!ID) {
+        return false;
     }
-	settings.devices[originalName] = {friendly_name: replace, retain: false};
+
+    settings.devices[ID].friendly_name = new_;
     writeRead();
-	return true;
+    return true;
 }
 
 module.exports = {
@@ -65,5 +63,5 @@ module.exports = {
     addDevice: (id) => addDevice(id),
     removeDevice: (id) => removeDevice(id),
     getIDByFriendlyName: (friendlyName) => getIDByFriendlyName(friendlyName),
-    RenameFriendlyName: (original,replace) => RenameFriendlyName(original,replace),
+    changeFriendlyName: (old, new_) => changeFriendlyName(old, new_),
 };


### PR DESCRIPTION
Work on new mqtt command to rename devices #177

This implement the rename of ```friendly_name``` per DeviceID.

- Basic Implementation for MQTT Command 
via ```zigbee2mqtt/bridge/config/rename```
and JSON ```{"oldname":"XXXXXXX","newname":"XXXXX"}```
- Basic Implementation for YAML File Edit
of the ```configuration.yaml```  file.