### PR TITLE
Fix events propagation to Home Assistant

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -28,11 +28,19 @@ if (settings.get().homeassistant && !cacheState) {
     logger.warn('In order for Home Assistant integration to work properly set `cache_state: true');
 }
 
+const payloadSequence = settings.get().advanced && settings.get().advanced.payload_sequence;
+if (settings.get().homeassistant && !payloadSequence) {
+    logger.info(
+        'In order for Home Assistant to detect sensor state change on the same consecutive events ' +
+        '(e.g. single button presses), set `payload_sequence: true');
+}
+
 class Controller {
     constructor() {
         this.zigbee = new Zigbee();
         this.mqtt = new MQTT();
         this.stateCache = {};
+        this.payloadSequence = {};
         this.configured = [];
         this.handleZigbeeMessage = this.handleZigbeeMessage.bind(this);
         this.handleMQTTMessage = this.handleMQTTMessage.bind(this);
@@ -552,6 +560,17 @@ class Controller {
             if (cache) {
                 this.stateCache[deviceID] = payload;
             }
+        }
+
+        if (payloadSequence) {
+            const payloadStr = JSON.stringify(payload);
+            if (!this.payloadSequence[deviceID] || this.payloadSequence[deviceID]['payload'] != payloadStr) {
+                this.payloadSequence[deviceID] = {'payload': payloadStr, 'sequence': 1};
+            } else {
+                this.payloadSequence[deviceID]['sequence']++;
+            }
+
+            payload['sequence'] = this.payloadSequence[deviceID]['sequence'];
         }
 
         const deviceSettings = settings.getDevice(deviceID);

--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -310,11 +310,15 @@ function discover(deviceID, model, mqtt, force) {
         return;
     }
 
+    const payloadSequence = settings.get().advanced && settings.get().advanced.payload_sequence;
     const friendlyName = settings.getDevice(deviceID).friendly_name;
 
     mapping[model].forEach((config) => {
         const topic = `${config.type}/${deviceID}/${config.object_id}/config`;
         const payload = config.discovery_payload;
+        if (payloadSequence && payload.hasOwnProperty('json_attributes')) {
+            payload['json_attributes'].push('sequence');
+        }
         payload.state_topic = `${settings.get().mqtt.base_topic}/${friendlyName}`;
         payload.availability_topic = `${settings.get().mqtt.base_topic}/bridge/state`;
 


### PR DESCRIPTION
Fix events propagation to Home Assistant
    
`payload_sequence` (an advanced boolean option) controls whether zigbee2mqtt
should add an additional `sequence` integer attribute to payload. It starts
with 1 and increases for identical payloads allowing Home Assistant to
distinguish consecutive same events. Otherwise, all events with the same
payload (except the 1st) are ignored and don't trigger state change. Because of
that a workaround (use of mqtt trigger in automations) is required, e.g.
```
      trigger:
        platform: mqtt
        topic: 'zigbee2mqtt/bedroom_switch'
      condition:
        condition: template
        value_template: {{ 'single' == trigger.payload_json.click }}
```
After this change (and setting `payload_sequence = true` in the configuration
file, advanced section), the above example trigger could be converted to:
```
      trigger:
        platform: state
        entity_id: sensor.bedroom_switch
      condition:
      - condition: template
        value_template: >
          {{ trigger.to_state.state == 'single' and
             trigger.from_state.state != 'unavailable' }}
```
(Checking from_state is needed to ignore state change after Home Assistant or
zigbee2mqtt restarts.)
    
Additionally, it should be possible to react only on selected events in
sequence (e.g. every third press of the button).