### PR TITLE
Update to Serialport 6.2.2

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -13,7 +13,7 @@ const shepherdSettings = {
     },
     dbPath: data.joinPath('database.db'),
     sp: {
-        baudrate: advancedSettings && advancedSettings.baudrate ? advancedSettings.baudrate : 115200,
+        baudRate: advancedSettings && advancedSettings.baudrate ? advancedSettings.baudrate : 115200,
         rtscts: advancedSettings && (typeof(advancedSettings.rtscts) === 'boolean') ? advancedSettings.rtscts : true,
     },
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -205,11 +205,11 @@
       "dev": true
     },
     "cc-znp": {
-      "version": "git+https://github.com/Koenkk/cc-znp.git#0445c554344421498c1721b4a7fc84531b222cbf",
+      "version": "git+https://github.com/Koenkk/cc-znp.git#cf1df71dfa0b62daf1d7f21bc0071ce56bffd1f0",
       "requires": {
         "debug": "2.6.9",
         "enum": "2.5.0",
-        "serialport": "4.0.7",
+        "serialport": "6.2.2",
         "stream-browserify": "2.0.1",
         "unpi": "1.1.0"
       }
@@ -2842,7 +2842,7 @@
       "requires": {
         "areq": "0.2.0",
         "busyman": "0.3.0",
-        "cc-znp": "git+https://github.com/Koenkk/cc-znp.git#0445c554344421498c1721b4a7fc84531b222cbf",
+        "cc-znp": "git+https://github.com/Koenkk/cc-znp.git#cf1df71dfa0b62daf1d7f21bc0071ce56bffd1f0",
         "debug": "2.6.9",
         "objectbox": "0.3.0",
         "proving": "0.1.0",


### PR DESCRIPTION
This updates the serialport dependency to version 6.2.2. For this, the baudrate property had to be renamed to baudRate.
Because of the use of serialport 6.2.2, this now also works with nodejs 10.