### PR TITLE
unique_id

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -328,11 +328,8 @@ function discover(deviceID, model, mqtt, force) {
         // Set unique names in cases this device produces multiple entities in homeassistant.
         payload.name = mapping[model].length > 1 ? `${friendlyName}_${config.object_id}` : friendlyName;
 
-        // Only set unique_id when user did not set a friendly_name yet,
-        // see https://github.com/Koenkk/zigbee2mqtt/issues/138
-        if (deviceID === friendlyName) {
-            payload.unique_id = `${deviceID}_${config.object_id}_${settings.get().mqtt.base_topic}`;
-        }
+        // Always set unique_id (independent of friendly_name)
+        payload.unique_id = `${deviceID}_${config.object_id}_${settings.get().mqtt.base_topic}`;
 
         if (payload.command_topic) {
             payload.command_topic = `${settings.get().mqtt.base_topic}/${friendlyName}/`;


### PR DESCRIPTION
Always sets a unique_id for Home Assistant that is independent of friendly_name.