### PR TITLE
Support Foundation Command for use in zigbee-shepherd converter

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -541,7 +541,7 @@ class Controller {
                 }
             };
 
-            this.zigbee.publish(deviceID, message.cid, message.cmd, message.zclData, ep, callback);
+            this.zigbee.publish(deviceID, message.cid, message.cmd, message.zclData, ep, message.type, callback);
 
             published.push({message: message, converter: converter});
         });

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -183,7 +183,7 @@ class Zigbee {
         return this.shepherd.find(device.ieeeAddr, 1);
     }
 
-    publish(deviceID, cid, cmd, zclData, ep, callback) {
+    publish(deviceID, cid, cmd, zclData, ep, type, callback) {
         const device = this._findDevice(deviceID, ep);
         if (!device) {
             logger.error(`Zigbee cannot publish message to device because '${deviceID}' not known by zigbee-shepherd`);
@@ -191,27 +191,16 @@ class Zigbee {
         }
 
         logger.info(`Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep}`);
-        if (zclData['foudation']!==true) {
-            device.functional(cid, cmd, zclData, (error) => {
-                if (error) {
-                    logger.error(
-                        `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
-                        `failed with error ${error}`);
-                }
 
-                callback(error);
-            });
-        } else { // use foundation command
-            device.foundation(cid, cmd, [{attrId: zclData['attrId'], dataType: zclData['dataType'],
-                attrData: zclData['attrData']}], function(error, rsp) {
-                if (error) {
-                    logger.error(
-                        `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
-                        `failed with error ${error}, respond ${rsp}`);
-                }
-                callback(error);
-            });
-        }
+        device[type](cid, cmd, zclData, (error) => {
+            if (error) {
+                logger.error(
+                    `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
+                    `failed with error ${error}`);
+            }
+
+            callback(error);
+        });
     }
 
     read(deviceID, cid, attr, ep, callback) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -191,15 +191,27 @@ class Zigbee {
         }
 
         logger.info(`Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep}`);
-        device.functional(cid, cmd, zclData, (error) => {
+        if(zclData['foudation']!==true){
+          device.functional(cid, cmd, zclData, (error) => {
             if (error) {
+              logger.error(
+                `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
+                `failed with error ${error}`);
+              }
+
+              callback(error);
+            });
+          }else{ // use foundation command
+            device.foundation(cid, cmd, [{ attrId: zclData['attrId'], dataType:zclData['dataType'], attrData:zclData['attrData'] }, ], function (error, rsp) {
+              if (error){
                 logger.error(
-                    `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
-                    `failed with error ${error}`);
+                  `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
+                  `failed with error ${error}, respond ${rsp}`);
+                }
+                callback(error);
+              });
             }
 
-            callback(error);
-        });
     }
 
     read(deviceID, cid, attr, ep, callback) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -191,27 +191,27 @@ class Zigbee {
         }
 
         logger.info(`Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep}`);
-        if(zclData['foudation']!==true){
-          device.functional(cid, cmd, zclData, (error) => {
-            if (error) {
-              logger.error(
-                `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
-                `failed with error ${error}`);
-              }
+        if (zclData['foudation']!==true) {
+            device.functional(cid, cmd, zclData, (error) => {
+                if (error) {
+                    logger.error(
+                        `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
+                        `failed with error ${error}`);
+                }
 
-              callback(error);
+                callback(error);
             });
-          }else{ // use foundation command
-            device.foundation(cid, cmd, [{ attrId: zclData['attrId'], dataType:zclData['dataType'], attrData:zclData['attrData'] }, ], function (error, rsp) {
-              if (error){
-                logger.error(
-                  `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
-                  `failed with error ${error}, respond ${rsp}`);
+        } else { // use foundation command
+            device.foundation(cid, cmd, [{attrId: zclData['attrId'], dataType: zclData['dataType'],
+                attrData: zclData['attrData']}], function(error, rsp) {
+                if (error) {
+                    logger.error(
+                        `Zigbee publish to '${deviceID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} - ${ep} ` +
+                        `failed with error ${error}, respond ${rsp}`);
                 }
                 callback(error);
-              });
-            }
-
+            });
+        }
     }
 
     read(deviceID, cid, attr, ep, callback) {


### PR DESCRIPTION
Many Xiaomi device does not use standard Zigbee command, they use their private command which use "genAnalogOuput", "genMultistateOutput" write command for change the setting on the device  and control them like Aqara Curtain https://github.com/Koenkk/zigbee2mqtt/issues/294#issuecomment-419636303,
Aqara Vibration sensor: https://github.com/Koenkk/zigbee2mqtt/issues/295 
http://faire-ca-soi-meme.fr/domotique/2018/09/03/test-xiaomi-aqara-vibration-sensor/

So I add the code for use Foudation Command https://github.com/zigbeer/zcl-packet/wiki/6.-Appendix#FoundCmdTbl with option:
```
foudation: true
```
in zclData like this:
```
    curtain_dim_test: {
        key: 'dim',
        attr: ['presentValue'],
        convert: (value, message) => {
            return {
                cid: 'genMultistateOutput',//genMultistateOutput //genAnalogOutput
                cmd: 'write',
                zclData: {
                    attrId: 0x0055,     // presentValue
                    dataType: 0x39, // dataType
                    attrData: value,
                    foudation: true,	// enable foudation write					
                },
            };
        },
    },
```