### PR TITLE
Allow no timestamp in log directory

### DIFF
--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -22,7 +22,8 @@ if (settings.get().advanced && settings.get().advanced.log_directory) {
 }
 
 // Add start time to directory.
-const directory = path.join(rootDirectory, moment(Date.now()).format('YYYY-MM-DD.HH:mm:ss'));
+const directory = (settings.get().advanced && settings.get().advanced.log_directory_no_timestamp === true) ?
+    rootDirectory : path.join(rootDirectory, moment(Date.now()).format('YYYY-MM-DD.HH:mm:ss'));
 
 // Make sure that log directoy exsists
 fx.mkdirSync(directory);

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -22,8 +22,11 @@ if (settings.get().advanced && settings.get().advanced.log_directory) {
 }
 
 // Add start time to directory.
-const directory = (settings.get().advanced && settings.get().advanced.log_directory_no_timestamp === true) ?
-    rootDirectory : path.join(rootDirectory, moment(Date.now()).format('YYYY-MM-DD.HH:mm:ss'));
+let directory = path.join(rootDirectory, moment(Date.now()).format('YYYY-MM-DD.HH:mm:ss'));
+if (settings.get().advanced && settings.get().advanced.hasOwnProperty('log_directory_timestamp') &&
+ settings.get().advanced.log_directory_timestamp === false) {
+    directory = rootDirectory;
+}
 
 // Make sure that log directoy exsists
 fx.mkdirSync(directory);


### PR DESCRIPTION
I'd like to use logrotate to manage(rotate, compress) the log, add option to allow no timestamp in log directory.