### PR TITLE
Add device information to MQTT message payload

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     },
     "extends": ["eslint:recommended", "google"],
     "parserOptions": {
-        "ecmaVersion": 6,
+        "ecmaVersion": 2018,
         "sourceType": "module"
     },
     "rules": {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -6,7 +6,7 @@ const settings = require('./util/settings');
 const ExtensionNetworkMap = require('./extension/networkMap');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 const homeassistant = require('./homeassistant');
-const objectAssignDeep = require(`object-assign-deep`);
+const objectAssignDeep = require('object-assign-deep');
 
 const mqttConfigRegex = new RegExp(`${settings.get().mqtt.base_topic}/bridge/config/\\w+`, 'g');
 const mqttDeviceRegex = new RegExp(`${settings.get().mqtt.base_topic}/[\\w\\s\\d.-]+/set`, 'g');
@@ -108,7 +108,7 @@ class Controller {
     sendAllCachedStates() {
         this.zigbee.getAllClients().forEach((device) => {
             if (this.state.exists(device.ieeeAddr)) {
-                this.mqttPublishDeviceState(device.ieeeAddr, this.state.get(device.ieeeAddr), false);
+                this.mqttPublishDeviceState(device, this.state.get(device.ieeeAddr), false);
             }
         });
     }
@@ -215,6 +215,23 @@ class Controller {
 
         return `${friendlyName} (${device.ieeeAddr}): ${friendlyDevice.model} - ` +
             `${friendlyDevice.vendor} ${friendlyDevice.description} (${type})`;
+    }
+
+    getDeviceInfoForMqtt(device) {
+        const {type, ieeeAddr, nwkAddr, manufId, manufName, powerSource, modelId, status} = device;
+        const deviceSettings = settings.getDevice(device.ieeeAddr);
+
+        return {
+            ieeeAddr,
+            friendlyName: deviceSettings.friendly_name || '',
+            type,
+            nwkAddr,
+            manufId,
+            manufName,
+            powerSource,
+            modelId,
+            status,
+        };
     }
 
     handleZigbeeMessage(message) {
@@ -338,7 +355,7 @@ class Controller {
                     payload.linkquality = message.linkquality;
                 }
 
-                this.mqttPublishDeviceState(device.ieeeAddr, payload, cache);
+                this.mqttPublishDeviceState(device, payload, cache);
             };
 
             const payload = converter.convert(mappedModel, message, publish, settings.getDevice(device.ieeeAddr));
@@ -537,7 +554,7 @@ class Controller {
                     const msg = {};
                     const _key = topicPrefix ? `${key}_${topicPrefix}` : key;
                     msg[_key] = json[key];
-                    this.mqttPublishDeviceState(deviceID, msg, true);
+                    this.mqttPublishDeviceState(device, msg, true);
                 }
             };
 
@@ -576,11 +593,15 @@ class Controller {
         });
     }
 
-    mqttPublishDeviceState(deviceID, payload, cache) {
+    mqttPublishDeviceState(device, payload, cache) {
+        const deviceID = device.ieeeAddr;
+        const appSettings = settings.get();
+        let messagePayload = {...payload};
+
         if (cacheState) {
             // Add cached state to payload
             if (this.state.exists(deviceID)) {
-                payload = objectAssignDeep.noMutate(this.state.get(deviceID), payload);
+                messagePayload = objectAssignDeep.noMutate(this.state.get(deviceID), payload);
             }
 
             // Update state cache with new state.
@@ -595,7 +616,11 @@ class Controller {
             qos: deviceSettings.qos ? deviceSettings.qos : 0,
         };
 
-        this.mqtt.publish(deviceSettings.friendly_name, JSON.stringify(payload), options);
+        if (appSettings.mqtt.include_device_information) {
+            messagePayload.device = this.getDeviceInfoForMqtt(device);
+        }
+
+        this.mqtt.publish(deviceSettings.friendly_name, JSON.stringify(messagePayload), options);
     }
 
     startupLogVersion(callback) {


### PR DESCRIPTION
Add basic device information to each MQTT message to make it possible to somehow recognize devices (type, manufactor, model, etc.) for 3rd party plugins 