### PR TITLE
Add support for TRADFRI Control Outlet

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -346,6 +346,7 @@ const mapping = {
     '433714': [configurations.light_brightness],
     '3261030P7': [configurations.light_brightness_colortemp],
     'DJT11LM': [configurations.sensor_action],
+    'E1603': [configurations.switch],
 };
 
 // A map of all discoverd devices


### PR DESCRIPTION
The control outlet is a switch, hence the switch configuration.

Dependent on https://github.com/Koenkk/zigbee-shepherd-converters/pull/86