### PR TITLE
Mt api set time

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -104,6 +104,22 @@ class Zigbee {
         if (settings.get().serial.disable_led) {
             this.shepherd.controller.request('UTIL', 'ledControl', {ledid: 3, mode: 0});
         }
+        
+        // Set SystemTime for TI-STACK-Stick(Coordinator)
+        var date = new Date();
+        var dhour = date.getHours();
+        var dminutes = date.getMinutes();
+        var dseconds = date.getSeconds();
+        var dmonth = date.getMonth() + 1;
+        var dday = date.getDate();
+        var dyear = date.getFullYear();
+        this.shepherd.controller.request('SYS', 'setTime', {utc:0,hour:dhour,minute:dminutes,second:dseconds,month:dmonth,day:dday,year:dyear}, function (err, result) {
+            if (err) {
+                logger.error(`Error setTime - ${err} - ${JSON.stringify(result)}`);
+            }else{
+                logger.debug(`Return setTime - ${JSON.stringify(result)}`);
+            }
+        });
 
         logger.info('zigbee-shepherd ready');
     }


### PR DESCRIPTION
This implements the SYS_SET_TIME (setTime) Functionality for the Coordinator Stick via Z Stack MT API.
It allows the right time in TI-Stack and maybe we could use it for another stuff in future.
Attention: This is for the first only on hardware side effect.