### PR TITLE
Update homeassistant for Osram E27 ID

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -315,7 +315,7 @@ const mapping = {
     'GL-C-008': [configurations.light_brightness_colortemp_xy],
     'STSS-MULT-001': [configurations.binary_sensor_contact],
     'E11-G23': [configurations.light_brightness],
-    'AC03845': [configurations.light_brightness_colortemp_xy],
+    'AC03645': [configurations.light_brightness_colortemp_xy],
     'AC03641': [configurations.light_brightness],
     'FB56+ZSW05HG1.2': [configurations.switch],
     '72922-A': [configurations.switch],


### PR DESCRIPTION
The ID for the Osram E27 bulbs was changed in
Koenkk/zigbee-shepherd-converters#91

We should update the model number here so that auto discovery still
works in Home Assistant.