### PR TITLE
Add autodiscovery support for Sylvania MR16

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -351,6 +351,7 @@ const mapping = {
     '74696': [configurations.light_brightness],
     'AB35996': [configurations.light_brightness_colortemp_xy],
     'AB401130055': [configurations.light_brightness_colortemp],
+    '74282': [configurations.light_brightness_colortemp],
 };
 
 // A map of all discoverd devices


### PR DESCRIPTION
Adds auto discovery support for the MR16 smart bulbs from
Osram/Sylvania.