### PR TITLE
[RFC] graphviz network map, display all devices

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "env": {
+        "es6": true,
         "node": true
     },
     "extends": ["eslint:recommended", "google"],

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -23,7 +23,7 @@ class NetworkMap {
 
         if (topic === this.topic && this.supportedFormats.hasOwnProperty(message)) {
             this.zigbee.networkScan((result)=> {
-                const converted = this.supportedFormats[message](result);
+                const converted = this.supportedFormats[message](this.zigbee, result);
                 this.mqtt.publish(`bridge/networkmap/${message}`, converted, {});
             });
 
@@ -31,15 +31,34 @@ class NetworkMap {
         }
     }
 
-    raw(topology) {
+    raw(zigbee, topology) {
         return JSON.stringify(topology);
     }
 
-    graphviz(topology) {
-        let text = 'digraph G {\n';
+    graphviz(zigbee, topology) {
+        let text = 'digraph G {\nnode[shape=record];\n';
         topology.forEach((item) => {
-            const friendlyName = settings.getDevice(item.ieeeAddr).friendly_name;
-            text += `  "${item.ieeeAddr}" [label="${friendlyName} (${item.ieeeAddr} - ${item.status})"];\n`;
+            const labels = [];
+            const friendlyDevice = settings.getDevice(item.ieeeAddr);
+            const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : item.ieeeAddr;
+            labels.push(`${friendlyName} (${item.status})`);
+            const device = zigbee.getDevice(item.ieeeAddr);
+            if ( device.nwkAddr == 0 ) {
+                labels.push("Coordinator");
+            } else if ( device.type == "Router" ) {
+                labels.push(device.type);
+            }
+            const model = [];
+            if ( device.manufName ) {
+                model.push(device.manufName);
+            }
+            if ( device.modelId ) {
+                model.push(device.modelId);
+            }
+            if ( model.length > 0 ) {
+                labels.push(model.join('/'));
+            }
+            text += `  "${item.ieeeAddr}" [label="{${labels.join('|')}}"];\n`;
             text += `  "${item.ieeeAddr}" -> "${item.parent}" [label="${item.lqi}"]\n`;
         });
 

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -48,12 +48,8 @@ class NetworkMap {
             // Add friendly name
             labels.push(friendlyName);
 
-            // TODO: Add the device type
-            if ( device.nwkAddr == 0 ) {
-                labels.push('Coordinator');
-            } else if ( device.type == 'Router' ) {
-                labels.push(device.type);
-            }
+            // Add the device type
+            labels.push(device.type);
 
             // Add the device model
             const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -72,7 +72,7 @@ class NetworkMap {
 
         text += '}';
 
-        return text;
+        return text.replace(/\0/g, '');
     }
 }
 

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -1,5 +1,6 @@
 
 const settings = require('../util/settings');
+const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 
 class NetworkMap {
     constructor(zigbee, mqtt, state) {
@@ -44,26 +45,37 @@ class NetworkMap {
             const friendlyDevice = settings.getDevice(device.ieeeAddr);
             const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
 
-            labels.push(`${friendlyName} (${device.status})`);
+            // Add friendly name
+            labels.push(friendlyName);
 
+            // TODO: Add the device type
             if ( device.nwkAddr == 0 ) {
                 labels.push('Coordinator');
             } else if ( device.type == 'Router' ) {
                 labels.push(device.type);
             }
 
-            const model = [];
-            if ( device.manufName ) {
-                model.push(device.manufName);
+            // Add the device model
+            const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
+            if (mappedModel) {
+                labels.push(`${mappedModel.vendor} ${mappedModel.description} (${mappedModel.model})`);
+            } else {
+                // This model is not supported by zigbee-shepherd-converters, add zigbee model information, if available
+                const zigbeeModel = [device.manufName, device.modelId].filter((a) => a).join(' ');
+                labels.push(zigbeeModel ? zigbeeModel : 'No model information available');
             }
-            if ( device.modelId ) {
-                model.push(device.modelId);
-            }
-            if ( model.length > 0 ) {
-                labels.push(model.join('/'));
-            }
+
+            // Add the device status (online/offline)
+            labels.push(device.status);
+
+            // Add the device with its labels to the graph as a node.
             text += `  "${device.ieeeAddr}" [label="{${labels.join('|')}}"];\n`;
 
+            /**
+             * Add an edge between the device and its parent to the graph
+             * NOTE: There are situations where a device is NOT in the topology, this can be e.g.
+             * due to not responded to the lqi scan. In that case we do not add an edge for this device.
+             */
             const lqiDevice = lqiDevices.get(device.ieeeAddr);
             if (lqiDevice != undefined) {
                 text += `  "${device.ieeeAddr}" -> "${lqiDevice.parent}" [label="${lqiDevice.lqi}"]\n`;

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -32,22 +32,25 @@ class NetworkMap {
     }
 
     raw(zigbee, topology) {
-        return JSON.stringify(topology);
-    }
+        return JSON.stringify(topology); }
 
     graphviz(zigbee, topology) {
         let text = 'digraph G {\nnode[shape=record];\n';
-        topology.forEach((item) => {
+        let lqiDevices = new Map(topology.map(d => [d.ieeeAddr, d]));
+
+        zigbee.getDevices().forEach((device) => {
             const labels = [];
-            const friendlyDevice = settings.getDevice(item.ieeeAddr);
-            const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : item.ieeeAddr;
-            labels.push(`${friendlyName} (${item.status})`);
-            const device = zigbee.getDevice(item.ieeeAddr);
+            const friendlyDevice = settings.getDevice(device.ieeeAddr);
+            const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
+
+            labels.push(`${friendlyName} (${device.status})`);
+
             if ( device.nwkAddr == 0 ) {
                 labels.push("Coordinator");
             } else if ( device.type == "Router" ) {
                 labels.push(device.type);
             }
+
             const model = [];
             if ( device.manufName ) {
                 model.push(device.manufName);
@@ -58,8 +61,12 @@ class NetworkMap {
             if ( model.length > 0 ) {
                 labels.push(model.join('/'));
             }
-            text += `  "${item.ieeeAddr}" [label="{${labels.join('|')}}"];\n`;
-            text += `  "${item.ieeeAddr}" -> "${item.parent}" [label="${item.lqi}"]\n`;
+            text += `  "${device.ieeeAddr}" [label="{${labels.join('|')}}"];\n`;
+
+            const lqiDevice = lqiDevices.get(device.ieeeAddr);
+            if (lqiDevice != undefined) {
+                text += `  "${device.ieeeAddr}" -> "${lqiDevice.parent}" [label="${lqiDevice.lqi}"]\n`;
+            }
         });
 
         text += '}';

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -32,11 +32,12 @@ class NetworkMap {
     }
 
     raw(zigbee, topology) {
-        return JSON.stringify(topology); }
+        return JSON.stringify(topology);
+    }
 
     graphviz(zigbee, topology) {
         let text = 'digraph G {\nnode[shape=record];\n';
-        let lqiDevices = new Map(topology.map(d => [d.ieeeAddr, d]));
+        const lqiDevices = new Map(topology.map((d) => [d.ieeeAddr, d]));
 
         zigbee.getDevices().forEach((device) => {
             const labels = [];
@@ -46,8 +47,8 @@ class NetworkMap {
             labels.push(`${friendlyName} (${device.status})`);
 
             if ( device.nwkAddr == 0 ) {
-                labels.push("Coordinator");
-            } else if ( device.type == "Router" ) {
+                labels.push('Coordinator');
+            } else if ( device.type == 'Router' ) {
                 labels.push(device.type);
             }
 

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -173,6 +173,10 @@ class Zigbee {
         }
     }
 
+    getDevices() {
+        return this.shepherd.list();
+    }
+
     getDevice(deviceID) {
         return this.shepherd.list().find((d) => d.ieeeAddr === deviceID);
     }

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -127,7 +127,7 @@ class Zigbee {
     }
 
     getAllClients() {
-        return this.shepherd.list().filter((device) => device.type !== 'Coordinator');
+        return this.getDevices().filter((device) => device.type !== 'Coordinator');
     }
 
     removeDevice(deviceID, callback) {
@@ -178,11 +178,11 @@ class Zigbee {
     }
 
     getDevice(deviceID) {
-        return this.shepherd.list().find((d) => d.ieeeAddr === deviceID);
+        return this.getDevices().find((d) => d.ieeeAddr === deviceID);
     }
 
     getCoordinator() {
-        const device = this.shepherd.list().find((d) => d.type === 'Coordinator');
+        const device = this.getDevices().find((d) => d.type === 'Coordinator');
         return this.shepherd.find(device.ieeeAddr, 1);
     }
 


### PR DESCRIPTION
a PR for comments,

what it does:
- adds a new method to zigbee to retrieve all the devices
- doesn't display ieeeAddr if friendly name exists
- coordinator and routers marked as such
- display every devices, those that haven't responded to the lqiscan are displayed, they just don't have any parent
- display manufacturer/model id if set (doesn't clean unicode in them tho)
- also fix a bug introduced in https://github.com/Koenkk/zigbee2mqtt/commit/4180bd8933db394e126f4233f1c2689241f43048

![t](https://user-images.githubusercontent.com/10393822/46442057-c0349d80-c768-11e8-8c0a-9237f59ffbd3.png)

the graph has been generated with
```
mosquitto_sub -h $MQTT_SRV -C 1 -t zigbee2mqtt/bridge/networkmap/graphviz | sfdp -Tpng > /tmp/map.$(date +%Y%m%d%H%M%S).png
```