### PR TITLE
Support both DeviceID and FriendlyName in device control topic

### DIFF
--- a/lib/extension/deviceCommand.js
+++ b/lib/extension/deviceCommand.js
@@ -42,15 +42,11 @@ class DeviceCommand {
 
         // Parse topic
         const hasPrefix = topic.match(setWithPrefixTopic);
-        const friendlyName = topic.split('/').slice(hasPrefix ? -3 : -2)[0];
+        const deviceKey = topic.split('/').slice(hasPrefix ? -3 : -2)[0]; // Could be friendlyName or ieeeAddr
         const prefix = hasPrefix ? topic.split('/').slice(-2)[0] : '';
 
-        // Map friendlyName to ieeeAddr.
-        const ieeeAddr = settings.getIeeAddrByFriendlyName(friendlyName);
-        if (!ieeeAddr) {
-            logger.error(`Cannot handle '${topic}' because ieeAddr of '${friendlyName}' cannot be found`);
-            return;
-        }
+        // Map friendlyName to ieeeAddr if possible.
+        const ieeeAddr = settings.getIeeAddrByFriendlyName(deviceKey) || deviceKey;
 
         // Get device
         const device = this.zigbee.getDevice(ieeeAddr);


### PR DESCRIPTION
To make it easier for 3rd party plugins to work with devices via zigbee2mqtt add ability to control devices using both topics:
`zigbee2mqtt/{deviceId}/{command}`
`zigbee2mqtt/{deviceFriendlyName}/{command}`
as deviceFriendlyName could be changed in config while `deviceId` is always static.