### PR TITLE
Add Philips Hue white ambiance E14 (LTW012) HA Support

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -310,6 +310,7 @@ const mapping = {
     'AB32840': [configurations.light_brightness_colortemp],
     '8718696485880': [configurations.light_brightness_colortemp_xy],
     '8718696598283': [configurations.light_brightness_colortemp],
+    '8718696695203': [configurations.light_brightness_colortemp],
     '73693': [configurations.light_brightness_colortemp_xy],
     '324131092621': [configurations.sensor_action],
     '9290012607': [


### PR DESCRIPTION
Adds HA support for LTW012 devices - See https://github.com/Koenkk/zigbee-shepherd-converters/pull/100