### PR TITLE
allow a default retain value to be set globally

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -566,8 +566,9 @@ class Controller {
 
         const deviceSettings = settings.getDevice(deviceID);
         const friendlyName = deviceSettings ? deviceSettings.friendly_name : deviceID;
+        const defaultRetainValue = appSettings.mqtt.retain ? appSettings.mqtt.retain : false;
         const options = {
-            retain: deviceSettings ? deviceSettings.retain : false,
+            retain: deviceSettings ? deviceSettings.retain : defaultRetainValue,
             qos: deviceSettings && deviceSettings.qos ? deviceSettings.qos : 0,
         };
 


### PR DESCRIPTION
Makes it possible to specify retain for MQTT device messages by default without having to specify a device specific configuration for all devices. Defaults to false, which is current behavior.