### PR TITLE
Add Nue Double GPO (au version) to Home Assistant

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -233,6 +233,21 @@ const switchWithPostfix = (postfix) => {
     };
 };
 
+const switchWithSuffix = (suffix) => {
+    return {
+        type: 'switch',
+        object_id: `${suffix}`,
+        discovery_payload: {
+            payload_off: 'OFF',
+            payload_on: 'ON',
+            value_template: `{{ value_json.state_${suffix} }}`,
+            command_topic: true,
+            command_topic_prefix: suffix,
+            json_attributes: [`button_${suffix}`],
+        },
+    };
+};
+
 // Map homeassitant configurations to devices.
 const mapping = {
     'WXKG01LM': [configurations.sensor_click],
@@ -358,6 +373,7 @@ const mapping = {
     '53170161': [configurations.light_brightness_colortemp],
     '4058075036147': [configurations.light_brightness_colortemp_xy],
     'KS-SM001': [configurations.switch],
+    'MG-AUWS01': [switchWithSuffix('left'), switchWithSuffix('right')],
 };
 
 // A map of all discoverd devices

--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -233,21 +233,6 @@ const switchWithPostfix = (postfix) => {
     };
 };
 
-const switchWithSuffix = (suffix) => {
-    return {
-        type: 'switch',
-        object_id: `${suffix}`,
-        discovery_payload: {
-            payload_off: 'OFF',
-            payload_on: 'ON',
-            value_template: `{{ value_json.state_${suffix} }}`,
-            command_topic: true,
-            command_topic_prefix: suffix,
-            json_attributes: [`button_${suffix}`],
-        },
-    };
-};
-
 // Map homeassitant configurations to devices.
 const mapping = {
     'WXKG01LM': [configurations.sensor_click],
@@ -373,7 +358,7 @@ const mapping = {
     '53170161': [configurations.light_brightness_colortemp],
     '4058075036147': [configurations.light_brightness_colortemp_xy],
     'KS-SM001': [configurations.switch],
-    'MG-AUWS01': [switchWithSuffix('left'), switchWithSuffix('right')],
+    'MG-AUWS01': [switchWithPostfix('left'), switchWithPostfix('right')],
 };
 
 // A map of all discoverd devices


### PR DESCRIPTION
Hi. I submitted a pull request to add the Nue Double Power Outlet to the zigbee sheppard converters and this pull request adds it to Home Assistant.  As mentioned in my other pull request, I've never done a pull request before so if I haven't done it right please let me know.  Thanks, Patrick.
