### PR TITLE
Use Home Assistant's device_class

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -75,7 +75,7 @@ const configurations = {
         object_id: 'illuminance',
         discovery_payload: {
             unit_of_measurement: 'lx',
-            icon: 'mdi:theme-light-dark',
+            device_class: 'illuminance',
             value_template: '{{ value_json.illuminance }}',
             json_attributes: ['battery', 'voltage'],
         },
@@ -85,7 +85,7 @@ const configurations = {
         object_id: 'humidity',
         discovery_payload: {
             unit_of_measurement: '%',
-            icon: 'mdi:water-percent',
+            device_class: 'humidity',
             value_template: '{{ value_json.humidity }}',
             json_attributes: ['battery', 'voltage'],
         },
@@ -95,7 +95,7 @@ const configurations = {
         object_id: 'temperature',
         discovery_payload: {
             unit_of_measurement: '°C',
-            icon: 'mdi:temperature-celsius',
+            device_class: 'temperature',
             value_template: '{{ value_json.temperature }}',
             json_attributes: ['battery', 'voltage'],
         },
@@ -105,7 +105,7 @@ const configurations = {
         object_id: 'pressure',
         discovery_payload: {
             unit_of_measurement: 'Pa',
-            icon: 'mdi:speedometer',
+            device_class: 'pressure',
             value_template: '{{ value_json.pressure }}',
             json_attributes: ['battery', 'voltage'],
         },
@@ -157,7 +157,7 @@ const configurations = {
         type: 'sensor',
         object_id: 'lock',
         discovery_payload: {
-            icon: 'mdi:lock',
+            device_class: 'lock',
             value_template: '{{ value_json.inserted }}',
             json_attributes: ['forgotten', 'keyerror'],
         },

--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -157,7 +157,7 @@ const configurations = {
         type: 'sensor',
         object_id: 'lock',
         discovery_payload: {
-            device_class: 'lock',
+            icon: 'mdi:lock',
             value_template: '{{ value_json.inserted }}',
             json_attributes: ['forgotten', 'keyerror'],
         },

--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -104,7 +104,7 @@ const configurations = {
         type: 'sensor',
         object_id: 'pressure',
         discovery_payload: {
-            unit_of_measurement: 'Pa',
+            unit_of_measurement: 'hPa',
             device_class: 'pressure',
             value_template: '{{ value_json.pressure }}',
             json_attributes: ['battery', 'voltage'],


### PR DESCRIPTION
As @RodBr wrote in https://github.com/Koenkk/zigbee2mqtt/issues/522 we should use `device_class` to have the default appearance in Home Assistant.

I am not sure about `sensor_click`, `sensor_power`, `sensor_action` and `sensor_brightness`.

Available device classes can be found [here](https://www.home-assistant.io/components/binary_sensor/) and [here](https://www.home-assistant.io/components/sensor/).

