### PR TITLE
add linkquality to json_attributes for HA discovery

### DIFF
--- a/lib/homeassistant.js
+++ b/lib/homeassistant.js
@@ -10,7 +10,7 @@ const configurations = {
             payload_off: false,
             value_template: '{{ value_json.occupancy }}',
             device_class: 'motion',
-            json_attributes: ['battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage'],
         },
     },
     'binary_sensor_contact': {
@@ -21,7 +21,7 @@ const configurations = {
             payload_off: true,
             value_template: '{{ value_json.contact }}',
             device_class: 'door',
-            json_attributes: ['battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage'],
         },
     },
     'binary_sensor_water_leak': {
@@ -32,7 +32,7 @@ const configurations = {
             payload_off: false,
             value_template: '{{ value_json.water_leak }}',
             device_class: 'moisture',
-            json_attributes: ['battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage'],
         },
     },
     'binary_sensor_smoke': {
@@ -43,7 +43,7 @@ const configurations = {
             payload_off: false,
             value_template: '{{ value_json.smoke }}',
             device_class: 'smoke',
-            json_attributes: ['battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage'],
         },
     },
     'binary_sensor_gas': {
@@ -54,7 +54,7 @@ const configurations = {
             payload_off: false,
             value_template: '{{ value_json.gas }}',
             device_class: 'gas',
-            json_attributes: ['sensitivity'],
+            json_attributes: ['linkquality', 'sensitivity'],
         },
     },
     'binary_sensor_router': {
@@ -65,7 +65,7 @@ const configurations = {
             payload_off: false,
             value_template: '{{ value_json.state }}',
             device_class: 'connectivity',
-            json_attributes: ['description', 'type', 'rssi'],
+            json_attributes: ['linkquality', 'description', 'type', 'rssi'],
         },
     },
 
@@ -77,7 +77,7 @@ const configurations = {
             unit_of_measurement: 'lx',
             icon: 'mdi:theme-light-dark',
             value_template: '{{ value_json.illuminance }}',
-            json_attributes: ['battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage'],
         },
     },
     'sensor_humidity': {
@@ -87,7 +87,7 @@ const configurations = {
             unit_of_measurement: '%',
             icon: 'mdi:water-percent',
             value_template: '{{ value_json.humidity }}',
-            json_attributes: ['battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage'],
         },
     },
     'sensor_temperature': {
@@ -97,7 +97,7 @@ const configurations = {
             unit_of_measurement: '°C',
             icon: 'mdi:temperature-celsius',
             value_template: '{{ value_json.temperature }}',
-            json_attributes: ['battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage'],
         },
     },
     'sensor_pressure': {
@@ -107,7 +107,7 @@ const configurations = {
             unit_of_measurement: 'Pa',
             icon: 'mdi:speedometer',
             value_template: '{{ value_json.pressure }}',
-            json_attributes: ['battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage'],
         },
     },
     'sensor_click': {
@@ -116,7 +116,7 @@ const configurations = {
         discovery_payload: {
             icon: 'mdi:toggle-switch',
             value_template: '{{ value_json.click }}',
-            json_attributes: ['battery', 'voltage', 'action', 'duration'],
+            json_attributes: ['linkquality', 'battery', 'voltage', 'action', 'duration'],
             force_update: true,
         },
     },
@@ -127,7 +127,7 @@ const configurations = {
             unit_of_measurement: 'Watt',
             icon: 'mdi:flash',
             value_template: '{{ value_json.power }}',
-            json_attributes: ['voltage', 'temperature', 'consumption', 'current', 'power_factor'],
+            json_attributes: ['linkquality', 'voltage', 'temperature', 'consumption', 'current', 'power_factor'],
         },
     },
     'sensor_action': {
@@ -137,7 +137,7 @@ const configurations = {
             icon: 'mdi:gesture-double-tap',
             value_template: '{{ value_json.action }}',
             json_attributes: [
-                'battery', 'voltage', 'angle', 'side', 'from_side', 'to_side', 'brightness',
+                'linkquality', 'battery', 'voltage', 'angle', 'side', 'from_side', 'to_side', 'brightness',
                 'angle_x_absolute', 'angle_y_absolute', 'angle_z', 'angle_y', 'angle_x', 'unknown_data',
             ],
             force_update: true,
@@ -150,7 +150,7 @@ const configurations = {
             unit_of_measurement: 'brightness',
             icon: 'mdi:brightness-5',
             value_template: '{{ value_json.brightness }}',
-            json_attributes: [],
+            json_attributes: ['linkquality'],
         },
     },
     'sensor_lock': {
@@ -159,7 +159,7 @@ const configurations = {
         discovery_payload: {
             icon: 'mdi:lock',
             value_template: '{{ value_json.inserted }}',
-            json_attributes: ['forgotten', 'keyerror'],
+            json_attributes: ['linkquality', 'forgotten', 'keyerror'],
         },
     },
 
@@ -228,7 +228,7 @@ const switchWithPostfix = (postfix) => {
             value_template: `{{ value_json.state_${postfix} }}`,
             command_topic: true,
             command_topic_prefix: postfix,
-            json_attributes: [`button_${postfix}`],
+            json_attributes: ['linkquality', `button_${postfix}`],
         },
     };
 };


### PR DESCRIPTION
As discussed in #563, linkquality should be exposed to MQTT discovery for HA.