### PR TITLE
Stop caching `forgotten` and `keyerror` properties

### DIFF
--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -1,7 +1,7 @@
 const settings = require('../util/settings');
 const logger = require('../util/logger');
 
-const dontCacheProperties = ['click', 'action', 'button', 'button_left', 'button_right', 'forgotten', 'keyerror'];
+const dontCacheProperties = ['action', 'button', 'button_left', 'button_right', 'click', 'forgotten', 'keyerror'];
 
 /**
  * This extensions handles messages received from devices.

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -1,7 +1,7 @@
 const settings = require('../util/settings');
 const logger = require('../util/logger');
 
-const dontCacheProperties = ['click', 'action', 'button', 'button_left', 'button_right'];
+const dontCacheProperties = ['click', 'action', 'button', 'button_left', 'button_right', 'forgotten', 'keyerror'];
 
 /**
  * This extensions handles messages received from devices.


### PR DESCRIPTION
After this change, the `forgotten` and `keyerror` properties as emitted by the Xiaomi Vima Smart Lock will stop being cached. Previously they were mostly useless, because after they were set to `true`, they were never being unset or set back to `false` upon a successful unlock.

I took this chance to also order the list of the uncached properties. This will make life easier to any developer looking for a particular property in the list, and in overall makes things look tidier.

Close #666