### PR TITLE
Change mqtt lights to new schema attribute

### DIFF
--- a/docs/integrating-with-homeassistant.md
+++ b/docs/integrating-with-homeassistant.md
@@ -612,95 +612,104 @@ sensor:
 ### LED1545G12
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### LED1546G12
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### LED1623G12
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### LED1537R6
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### LED1650R5
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### LED1536G5
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### LED1622G12
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### LED1624G9
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### LED1649C5
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -720,53 +729,58 @@ sensor:
 ### ICPSHC24-10EU-IL-1
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### ICPSHC24-30EU-IL-1
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### L1527
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### L1529
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### L1528
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -785,190 +799,207 @@ switch:
 ### 7299760PH
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 7146060PH
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 433714
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 9290011370
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 8718696449691
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 7299355PH
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 915005106701
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 9290012573A
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 9290002579A
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 8718696485880
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 915005733701
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 8718696695203
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 8718696598283
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 8718696548738
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 3261030P7
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 3216331P5
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 7199960PH
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -1049,10 +1080,11 @@ sensor:
 ### F7C033
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -1237,122 +1269,133 @@ switch:
 ### 4058075816718
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AA69697
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AC03645
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AC03642
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AA70155
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AA68199
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AB32840
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 4058075816794
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AC03641
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 4052899926158
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AB401130055
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -1371,58 +1414,63 @@ switch:
 ### 4052899926110
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 4058075036185
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 4058075036147
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AB35996
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### AC08562
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -1453,229 +1501,251 @@ sensor:
 ### HALIGHTDIMWWE27
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### RB 185 C
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### RB 285 C
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### RB 165
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### RB 175 W
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### RS 125
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### RS 128 T
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### RB 145
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### BY 165
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### PL 110
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### ST 110
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### UC 110
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### DL 110 N
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### DL 110 W
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### SL 110 N
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### SL 110 M
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### SL 110 W
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 73742
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 73740
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 73693
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 74283
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 74696
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -1694,106 +1764,116 @@ switch:
 ### 74282
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 22670
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 45852GE
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 45857GE
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### E11-G13
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### E11-G23/E11-G33
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### Z01-CIA19NAE26
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### Z01-A19NAE26
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### E11-N1EA
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### K2RGBW01
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -1827,10 +1907,11 @@ sensor:
 ### NL08-0800
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -1876,12 +1957,13 @@ switch:
 ### GL-C-008
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -1936,31 +2018,34 @@ sensor:
 ### ZLED-2709
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 50045
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 50049
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
@@ -2051,33 +2136,36 @@ switch:
 ### 53170161
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### 900008-WW
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 
 ### Mega23M12
 ```yaml
 light:
-  - platform: "mqtt_json"
+  - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
     brightness: true
     color_temp: true
     xy: true
+    schema: "json"
     command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
 ```
 

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -195,7 +195,7 @@ const configurations = {
             brightness: true,
             color_temp: true,
             xy: true,
-            platform: 'mqtt_json',
+            schema: 'json',
             command_topic: true,
         },
     },
@@ -205,7 +205,7 @@ const configurations = {
         discovery_payload: {
             brightness: true,
             xy: true,
-            platform: 'mqtt_json',
+            schema: 'json',
             command_topic: true,
         },
     },
@@ -215,7 +215,7 @@ const configurations = {
         discovery_payload: {
             brightness: true,
             color_temp: true,
-            platform: 'mqtt_json',
+            schema: 'json',
             command_topic: true,
         },
     },
@@ -224,7 +224,7 @@ const configurations = {
         object_id: 'light',
         discovery_payload: {
             brightness: true,
-            platform: 'mqtt_json',
+            schema: 'json',
             command_topic: true,
         },
     },


### PR DESCRIPTION
Repull of #656 

Original pull blurb:

**_This pull is in prep for Homeassistant 0.84 when light.mqtt_json will become a schema for mqtt.light._**

As noted in #646 mqtt_json lights are not showing in the mqtt config entry (configuration -> integrations). 
`light.mqtt_json` is now being incorporated in to `light.mqtt` (**This is a breaking change as mqtt_json platform now errors in 0.84**).

This pull makes the minor change to lights exposed via mqtt discovery to use the new `"schema":` attribute, allowing HA to set them up in the correct manner while also allowing the entities to be added to the entity registry. This will then in turn make them appear in the device registry once that pull is merged from dev to master in 0.84.

If used against 0.83.3 the entity will show up in the entity registry correctly but the light will be only a basic light so this has only been tested against the dev branch. Can be tested against master / merged once 0.84 is released.

- Refactored for new schema attribute added in pull [18227](https://github.com/home-assistant/home-assistant/pull/18227)