### PR TITLE
Discovery fix on restart HASS + adding the timestamp of last received zigbee message visible in HASS

### DIFF
--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -84,6 +84,7 @@ class DeviceReceive {
         // - If a payload is returned publish it to the MQTT broker
         // - If NO payload is returned do nothing. This is for non-standard behaviour
         //   for e.g. click switches where we need to count number of clicks and detect long presses.
+
         converters.forEach((converter) => {
             const publish = (payload) => {
                 // Don't cache messages with following properties:
@@ -99,6 +100,9 @@ class DeviceReceive {
                     payload.linkquality = message.linkquality;
                 }
 
+                // Add last message received
+                payload.last_message = Date.now();
+
                 this.publishDeviceState(device, payload, cache);
             };
 
@@ -111,4 +115,4 @@ class DeviceReceive {
     }
 }
 
-module.exports = DeviceReceive;
+module.exports = DeviceReceive; 

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -101,7 +101,9 @@ class DeviceReceive {
                 }
 
                 // Add last message received
-                payload.last_message = Date.now();
+                if (settings.get().advanced.add_timestamp) {
+                    payload.last_message = Date.now();
+                }
 
                 this.publishDeviceState(device, payload, cache);
             };
@@ -115,4 +117,4 @@ class DeviceReceive {
     }
 }
 
-module.exports = DeviceReceive; 
+module.exports = DeviceReceive;

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -434,7 +434,7 @@ class HomeAssistant {
 
     onMQTTConnected() {
         this.mqtt.subscribe('hass/status');
-        this.discoverAllPairedDevice()
+        this.discoverAllPairedDevice();
     }
 
     discoverAllPairedDevice() {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -434,7 +434,10 @@ class HomeAssistant {
 
     onMQTTConnected() {
         this.mqtt.subscribe('hass/status');
+        this.discoverAllPairedDevice()
+    }
 
+    discoverAllPairedDevice() {
         // MQTT discovery of all paired devices on startup.
         this.zigbee.getAllClients().forEach((device) => {
             const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
@@ -455,15 +458,25 @@ class HomeAssistant {
 
         mapping[mappedModel.model].forEach((config) => {
             const topic = `${config.type}/${ieeeAddr}/${config.object_id}/config`;
+            const discovery_payload = {};
             const payload = {...config.discovery_payload};
             payload.state_topic = `${settings.get().mqtt.base_topic}/${friendlyName}`;
             payload.availability_topic = `${settings.get().mqtt.base_topic}/bridge/state`;
+
 
             // Set (unique) name
             payload.name = `${friendlyName}_${config.object_id}`;
 
             // Set unique_id
             payload.unique_id = `${ieeeAddr}_${config.object_id}_${settings.get().mqtt.base_topic}`;
+
+            // Add last_message to attributes
+            if (!payload.hasOwnProperty('json_attributes')) {
+              payload.json_attributes = [];
+            }
+            if (!payload.json_attributes.includes('last_message')) {
+              payload.json_attributes.push('last_message');
+            }
 
             // Attributes for device registry
             payload.device = {
@@ -496,6 +509,7 @@ class HomeAssistant {
         }
 
         if (message.toString().toLowerCase() === 'online') {
+            this.discoverAllPairedDevice()
             const timer = setTimeout(() => {
                 // Publish all device states.
                 this.zigbee.getAllClients().forEach((device) => {
@@ -523,4 +537,4 @@ class HomeAssistant {
     }
 }
 
-module.exports = HomeAssistant;
+module.exports = HomeAssistant; 

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -458,11 +458,9 @@ class HomeAssistant {
 
         mapping[mappedModel.model].forEach((config) => {
             const topic = `${config.type}/${ieeeAddr}/${config.object_id}/config`;
-            const discovery_payload = {};
             const payload = {...config.discovery_payload};
             payload.state_topic = `${settings.get().mqtt.base_topic}/${friendlyName}`;
             payload.availability_topic = `${settings.get().mqtt.base_topic}/bridge/state`;
-
 
             // Set (unique) name
             payload.name = `${friendlyName}_${config.object_id}`;

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -471,11 +471,13 @@ class HomeAssistant {
             payload.unique_id = `${ieeeAddr}_${config.object_id}_${settings.get().mqtt.base_topic}`;
 
             // Add last_message to attributes
-            if (!payload.hasOwnProperty('json_attributes')) {
-              payload.json_attributes = [];
-            }
-            if (!payload.json_attributes.includes('last_message')) {
-              payload.json_attributes.push('last_message');
+            if (settings.get().advanced.add_timestamp) {
+              if (!payload.hasOwnProperty('json_attributes')) {
+                payload.json_attributes = [];
+              }
+              if (!payload.json_attributes.includes('last_message')) {
+                payload.json_attributes.push('last_message');
+              }
             }
 
             // Attributes for device registry

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -470,12 +470,12 @@ class HomeAssistant {
 
             // Add last_message to attributes
             if (settings.get().advanced.add_timestamp) {
-              if (!payload.hasOwnProperty('json_attributes')) {
-                payload.json_attributes = [];
-              }
-              if (!payload.json_attributes.includes('last_message')) {
-                payload.json_attributes.push('last_message');
-              }
+                if (!payload.hasOwnProperty('json_attributes')) {
+                    payload.json_attributes = [];
+                }
+                if (!payload.json_attributes.includes('last_message')) {
+                    payload.json_attributes.push('last_message');
+                }
             }
 
             // Attributes for device registry
@@ -509,7 +509,7 @@ class HomeAssistant {
         }
 
         if (message.toString().toLowerCase() === 'online') {
-            this.discoverAllPairedDevice()
+            this.discoverAllPairedDevice();
             const timer = setTimeout(() => {
                 // Publish all device states.
                 this.zigbee.getAllClients().forEach((device) => {
@@ -537,4 +537,4 @@ class HomeAssistant {
     }
 }
 
-module.exports = HomeAssistant; 
+module.exports = HomeAssistant;

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -28,6 +28,7 @@ const defaults = {
          * https://koenkk.github.io/zigbee2mqtt/configuration/configuration.html
          */
         cache_state: true,
+        add_timestamp: false,
     },
 };
 


### PR DESCRIPTION
- On restarting Home Assistant, resending device discovery information
- Add timestamp on receiving message from Zigbee
- Add last_message into MQTT info for devices