### PR TITLE
Add the timestamp of last received zigbee message visible in HASS

### DIFF
--- a/docs/integration/home_assistant.md
+++ b/docs/integration/home_assistant.md
@@ -225,6 +225,7 @@ sensor:
       - "voltage"
       - "action"
       - "duration"
+      - "last_seen"
     force_update: true
 ```
 {% endraw %}
@@ -244,6 +245,7 @@ sensor:
       - "voltage"
       - "action"
       - "duration"
+      - "last_seen"
     force_update: true
 ```
 {% endraw %}
@@ -263,6 +265,7 @@ sensor:
       - "voltage"
       - "action"
       - "duration"
+      - "last_seen"
     force_update: true
 ```
 {% endraw %}
@@ -282,6 +285,7 @@ sensor:
       - "voltage"
       - "action"
       - "duration"
+      - "last_seen"
     force_update: true
 ```
 {% endraw %}
@@ -301,6 +305,7 @@ sensor:
       - "voltage"
       - "action"
       - "duration"
+      - "last_seen"
     force_update: true
 ```
 {% endraw %}
@@ -345,6 +350,7 @@ sensor:
       - "consumption"
       - "current"
       - "power_factor"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -418,6 +424,7 @@ sensor:
       - "consumption"
       - "current"
       - "power_factor"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -435,6 +442,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 
 sensor:
   - platform: "mqtt"
@@ -447,6 +455,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -464,6 +473,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 
 sensor:
   - platform: "mqtt"
@@ -476,6 +486,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 
 sensor:
   - platform: "mqtt"
@@ -488,6 +499,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -514,6 +526,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -540,6 +553,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 
 sensor:
   - platform: "mqtt"
@@ -552,6 +566,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -578,6 +593,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -604,6 +620,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -630,6 +647,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -657,6 +675,7 @@ sensor:
       - "angle_y"
       - "angle_x"
       - "unknown_data"
+      - "last_seen"
     force_update: true
 ```
 {% endraw %}
@@ -687,6 +706,7 @@ sensor:
       - "consumption"
       - "current"
       - "power_factor"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -716,6 +736,7 @@ sensor:
       - "consumption"
       - "current"
       - "power_factor"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -742,6 +763,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -768,6 +790,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -784,6 +807,7 @@ sensor:
       - "linkquality"
       - "forgotten"
       - "keyerror"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -811,6 +835,7 @@ sensor:
       - "angle_y"
       - "angle_x"
       - "unknown_data"
+      - "last_seen"
     force_update: true
 ```
 {% endraw %}
@@ -949,6 +974,7 @@ sensor:
     value_template: "{{ value_json.brightness }}"
     json_attributes: 
       - "linkquality"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -1299,6 +1325,7 @@ sensor:
       - "angle_y"
       - "angle_x"
       - "unknown_data"
+      - "last_seen"
     force_update: true
 ```
 {% endraw %}
@@ -1326,6 +1353,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 
 sensor:
   - platform: "mqtt"
@@ -1338,6 +1366,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 
 sensor:
   - platform: "mqtt"
@@ -1350,6 +1379,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -1392,6 +1422,7 @@ sensor:
       - "consumption"
       - "current"
       - "power_factor"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -1416,6 +1447,7 @@ sensor:
       - "description"
       - "type"
       - "rssi"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -1821,6 +1853,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -2105,6 +2138,7 @@ sensor:
       - "consumption"
       - "current"
       - "power_factor"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -2353,6 +2387,7 @@ sensor:
       - "consumption"
       - "current"
       - "power_factor"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -2450,6 +2485,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -2476,6 +2512,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -2542,6 +2579,7 @@ sensor:
       - "voltage"
       - "action"
       - "sensitivity"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -2582,6 +2620,7 @@ sensor:
       - "linkquality"
       - "battery"
       - "voltage"
+      - "last_seen"
 ```
 {% endraw %}
 
@@ -2681,6 +2720,7 @@ sensor:
       - "consumption"
       - "current"
       - "power_factor"
+      - "last_seen"
 ```
 {% endraw %}
 

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -84,7 +84,6 @@ class DeviceReceive {
         // - If a payload is returned publish it to the MQTT broker
         // - If NO payload is returned do nothing. This is for non-standard behaviour
         //   for e.g. click switches where we need to count number of clicks and detect long presses.
-
         converters.forEach((converter) => {
             const publish = (payload) => {
                 // Don't cache messages with following properties:

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -79,6 +79,9 @@ class DeviceReceive {
             return;
         }
 
+        // Save device last seen timestamp
+        device.last_seen = Date.now();
+        
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
         // - If a payload is returned publish it to the MQTT broker
@@ -100,7 +103,7 @@ class DeviceReceive {
                 }
 
                 // Add last seen timestamp
-                payload.last_seen = Date.now();
+                payload.last_seen = new Date(device.last_seen).toISOString();
 
                 this.publishDeviceState(device, payload, cache);
             };

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -84,6 +84,7 @@ class DeviceReceive {
         // - If a payload is returned publish it to the MQTT broker
         // - If NO payload is returned do nothing. This is for non-standard behaviour
         //   for e.g. click switches where we need to count number of clicks and detect long presses.
+
         converters.forEach((converter) => {
             const publish = (payload) => {
                 // Don't cache messages with following properties:
@@ -99,6 +100,9 @@ class DeviceReceive {
                     payload.linkquality = message.linkquality;
                 }
 
+                // Add last message received
+                payload.last_message = Date.now();
+
                 this.publishDeviceState(device, payload, cache);
             };
 
@@ -111,4 +115,4 @@ class DeviceReceive {
     }
 }
 
-module.exports = DeviceReceive;
+module.exports = DeviceReceive; 

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -78,7 +78,7 @@ class DeviceReceive {
             logger.warn(`Please see: https://koenkk.github.io/zigbee2mqtt/how_tos/how_to_support_new_devices.html.`);
             return;
         }
-        
+ 
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
         // - If a payload is returned publish it to the MQTT broker

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -78,7 +78,7 @@ class DeviceReceive {
             logger.warn(`Please see: https://koenkk.github.io/zigbee2mqtt/how_tos/how_to_support_new_devices.html.`);
             return;
         }
- 
+
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
         // - If a payload is returned publish it to the MQTT broker

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -78,9 +78,6 @@ class DeviceReceive {
             logger.warn(`Please see: https://koenkk.github.io/zigbee2mqtt/how_tos/how_to_support_new_devices.html.`);
             return;
         }
-
-        // Save device last seen timestamp
-        device.last_seen = Date.now();
         
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
@@ -103,7 +100,8 @@ class DeviceReceive {
                 }
 
                 // Add last seen timestamp
-                payload.last_seen = new Date(device.last_seen).toISOString();
+                const now = new Date();
+                payload.last_seen = now.toISOString();
 
                 this.publishDeviceState(device, payload, cache);
             };

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -99,10 +99,8 @@ class DeviceReceive {
                     payload.linkquality = message.linkquality;
                 }
 
-                // Add last message received
-                if (settings.get().advanced.add_timestamp) {
-                    payload.last_message = Date.now();
-                }
+                // Add last seen timestamp
+                payload.last_seen = Date.now();
 
                 this.publishDeviceState(device, payload, cache);
             };

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -101,7 +101,9 @@ class DeviceReceive {
                 }
 
                 // Add last message received
-                payload.last_message = Date.now();
+                if (settings.get().advanced.add_timestamp) {
+                    payload.last_message = Date.now();
+                }
 
                 this.publishDeviceState(device, payload, cache);
             };
@@ -115,4 +117,4 @@ class DeviceReceive {
     }
 }
 
-module.exports = DeviceReceive; 
+module.exports = DeviceReceive;

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -434,7 +434,7 @@ class HomeAssistant {
 
     onMQTTConnected() {
         this.mqtt.subscribe('hass/status');
-        this.discoverAllPairedDevice()
+        this.discoverAllPairedDevice();
     }
 
     discoverAllPairedDevice() {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -434,7 +434,10 @@ class HomeAssistant {
 
     onMQTTConnected() {
         this.mqtt.subscribe('hass/status');
+        this.discoverAllPairedDevice()
+    }
 
+    discoverAllPairedDevice() {
         // MQTT discovery of all paired devices on startup.
         this.zigbee.getAllClients().forEach((device) => {
             const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
@@ -455,15 +458,25 @@ class HomeAssistant {
 
         mapping[mappedModel.model].forEach((config) => {
             const topic = `${config.type}/${ieeeAddr}/${config.object_id}/config`;
+            const discovery_payload = {};
             const payload = {...config.discovery_payload};
             payload.state_topic = `${settings.get().mqtt.base_topic}/${friendlyName}`;
             payload.availability_topic = `${settings.get().mqtt.base_topic}/bridge/state`;
+
 
             // Set (unique) name
             payload.name = `${friendlyName}_${config.object_id}`;
 
             // Set unique_id
             payload.unique_id = `${ieeeAddr}_${config.object_id}_${settings.get().mqtt.base_topic}`;
+
+            // Add last_message to attributes
+            if (!payload.hasOwnProperty('json_attributes')) {
+              payload.json_attributes = [];
+            }
+            if (!payload.json_attributes.includes('last_message')) {
+              payload.json_attributes.push('last_message');
+            }
 
             // Attributes for device registry
             payload.device = {
@@ -496,6 +509,7 @@ class HomeAssistant {
         }
 
         if (message.toString().toLowerCase() === 'online') {
+            this.discoverAllPairedDevice()
             const timer = setTimeout(() => {
                 // Publish all device states.
                 this.zigbee.getAllClients().forEach((device) => {
@@ -523,4 +537,4 @@ class HomeAssistant {
     }
 }
 
-module.exports = HomeAssistant;
+module.exports = HomeAssistant; 

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -434,10 +434,7 @@ class HomeAssistant {
 
     onMQTTConnected() {
         this.mqtt.subscribe('hass/status');
-        this.discoverAllPairedDevice();
-    }
 
-    discoverAllPairedDevice() {
         // MQTT discovery of all paired devices on startup.
         this.zigbee.getAllClients().forEach((device) => {
             const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
@@ -509,7 +506,6 @@ class HomeAssistant {
         }
 
         if (message.toString().toLowerCase() === 'online') {
-            this.discoverAllPairedDevice();
             const timer = setTimeout(() => {
                 // Publish all device states.
                 this.zigbee.getAllClients().forEach((device) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -458,11 +458,9 @@ class HomeAssistant {
 
         mapping[mappedModel.model].forEach((config) => {
             const topic = `${config.type}/${ieeeAddr}/${config.object_id}/config`;
-            const discovery_payload = {};
             const payload = {...config.discovery_payload};
             payload.state_topic = `${settings.get().mqtt.base_topic}/${friendlyName}`;
             payload.availability_topic = `${settings.get().mqtt.base_topic}/bridge/state`;
-
 
             // Set (unique) name
             payload.name = `${friendlyName}_${config.object_id}`;

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -471,11 +471,13 @@ class HomeAssistant {
             payload.unique_id = `${ieeeAddr}_${config.object_id}_${settings.get().mqtt.base_topic}`;
 
             // Add last_message to attributes
-            if (!payload.hasOwnProperty('json_attributes')) {
-              payload.json_attributes = [];
-            }
-            if (!payload.json_attributes.includes('last_message')) {
-              payload.json_attributes.push('last_message');
+            if (settings.get().advanced.add_timestamp) {
+              if (!payload.hasOwnProperty('json_attributes')) {
+                payload.json_attributes = [];
+              }
+              if (!payload.json_attributes.includes('last_message')) {
+                payload.json_attributes.push('last_message');
+              }
             }
 
             // Attributes for device registry

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -84,7 +84,7 @@ const configurations = {
             unit_of_measurement: 'lx',
             device_class: 'illuminance',
             value_template: '{{ value_json.illuminance }}',
-            json_attributes: ['linkquality', 'battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage', 'last_seen'],
         },
     },
     'sensor_humidity': {
@@ -94,7 +94,7 @@ const configurations = {
             unit_of_measurement: '%',
             device_class: 'humidity',
             value_template: '{{ value_json.humidity }}',
-            json_attributes: ['linkquality', 'battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage', 'last_seen'],
         },
     },
     'sensor_temperature': {
@@ -104,7 +104,7 @@ const configurations = {
             unit_of_measurement: '°C',
             device_class: 'temperature',
             value_template: '{{ value_json.temperature }}',
-            json_attributes: ['linkquality', 'battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage', 'last_seen'],
         },
     },
     'sensor_pressure': {
@@ -114,7 +114,7 @@ const configurations = {
             unit_of_measurement: 'hPa',
             device_class: 'pressure',
             value_template: '{{ value_json.pressure }}',
-            json_attributes: ['linkquality', 'battery', 'voltage'],
+            json_attributes: ['linkquality', 'battery', 'voltage', 'last_seen'],
         },
     },
     'sensor_click': {
@@ -123,7 +123,7 @@ const configurations = {
         discovery_payload: {
             icon: 'mdi:toggle-switch',
             value_template: '{{ value_json.click }}',
-            json_attributes: ['linkquality', 'battery', 'voltage', 'action', 'duration'],
+            json_attributes: ['linkquality', 'battery', 'voltage', 'action', 'duration', 'last_seen'],
             force_update: true,
         },
     },
@@ -134,7 +134,7 @@ const configurations = {
             unit_of_measurement: 'Watt',
             icon: 'mdi:flash',
             value_template: '{{ value_json.power }}',
-            json_attributes: ['linkquality', 'voltage', 'temperature', 'consumption', 'current', 'power_factor'],
+            json_attributes: ['linkquality', 'voltage', 'temperature', 'consumption', 'current', 'power_factor', 'last_seen'],
         },
     },
     'sensor_action': {
@@ -146,6 +146,7 @@ const configurations = {
             json_attributes: [
                 'linkquality', 'battery', 'voltage', 'angle', 'side', 'from_side', 'to_side', 'brightness',
                 'angle_x_absolute', 'angle_y_absolute', 'angle_z', 'angle_y', 'angle_x', 'unknown_data',
+                'last_seen'
             ],
             force_update: true,
         },
@@ -157,7 +158,7 @@ const configurations = {
             unit_of_measurement: 'brightness',
             icon: 'mdi:brightness-5',
             value_template: '{{ value_json.brightness }}',
-            json_attributes: ['linkquality'],
+            json_attributes: ['linkquality', 'last_seen'],
         },
     },
     'sensor_lock': {
@@ -166,7 +167,7 @@ const configurations = {
         discovery_payload: {
             icon: 'mdi:lock',
             value_template: '{{ value_json.inserted }}',
-            json_attributes: ['linkquality', 'forgotten', 'keyerror'],
+            json_attributes: ['linkquality', 'forgotten', 'keyerror', 'last_seen'],
         },
     },
     'sensor_battery': {
@@ -175,7 +176,7 @@ const configurations = {
         discovery_payload: {
             device_class: 'battery',
             value_template: '{{ value_json.battery }}',
-            json_attributes: ['linkquality', 'voltage', 'action', 'sensitivity'],
+            json_attributes: ['linkquality', 'voltage', 'action', 'sensitivity', 'last_seen'],
         },
     },
     'sensor_linkquality': {
@@ -183,7 +184,7 @@ const configurations = {
         object_id: 'linkquality',
         discovery_payload: {
             value_template: '{{ value_json.linkquality }}',
-            json_attributes: ['description', 'type', 'rssi'],
+            json_attributes: ['description', 'type', 'rssi', 'last_seen'],
         },
     },
 
@@ -464,16 +465,6 @@ class HomeAssistant {
 
             // Set unique_id
             payload.unique_id = `${ieeeAddr}_${config.object_id}_${settings.get().mqtt.base_topic}`;
-
-            // Add last_message to attributes
-            if (settings.get().advanced.add_timestamp) {
-                if (!payload.hasOwnProperty('json_attributes')) {
-                    payload.json_attributes = [];
-                }
-                if (!payload.json_attributes.includes('last_message')) {
-                    payload.json_attributes.push('last_message');
-                }
-            }
 
             // Attributes for device registry
             payload.device = {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -470,12 +470,12 @@ class HomeAssistant {
 
             // Add last_message to attributes
             if (settings.get().advanced.add_timestamp) {
-              if (!payload.hasOwnProperty('json_attributes')) {
-                payload.json_attributes = [];
-              }
-              if (!payload.json_attributes.includes('last_message')) {
-                payload.json_attributes.push('last_message');
-              }
+                if (!payload.hasOwnProperty('json_attributes')) {
+                    payload.json_attributes = [];
+                }
+                if (!payload.json_attributes.includes('last_message')) {
+                    payload.json_attributes.push('last_message');
+                }
             }
 
             // Attributes for device registry
@@ -509,7 +509,7 @@ class HomeAssistant {
         }
 
         if (message.toString().toLowerCase() === 'online') {
-            this.discoverAllPairedDevice()
+            this.discoverAllPairedDevice();
             const timer = setTimeout(() => {
                 // Publish all device states.
                 this.zigbee.getAllClients().forEach((device) => {
@@ -537,4 +537,4 @@ class HomeAssistant {
     }
 }
 
-module.exports = HomeAssistant; 
+module.exports = HomeAssistant;

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -134,7 +134,9 @@ const configurations = {
             unit_of_measurement: 'Watt',
             icon: 'mdi:flash',
             value_template: '{{ value_json.power }}',
-            json_attributes: ['linkquality', 'voltage', 'temperature', 'consumption', 'current', 'power_factor', 'last_seen'],
+            json_attributes: [
+                'linkquality', 'voltage', 'temperature', 'consumption', 'current', 'power_factor', 'last_seen',
+            ],
         },
     },
     'sensor_action': {
@@ -146,7 +148,7 @@ const configurations = {
             json_attributes: [
                 'linkquality', 'battery', 'voltage', 'angle', 'side', 'from_side', 'to_side', 'brightness',
                 'angle_x_absolute', 'angle_y_absolute', 'angle_z', 'angle_y', 'angle_x', 'unknown_data',
-                'last_seen'
+                'last_seen',
             ],
             force_update: true,
         },

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -28,6 +28,7 @@ const defaults = {
          * https://koenkk.github.io/zigbee2mqtt/configuration/configuration.html
          */
         cache_state: true,
+        add_timestamp: false,
     },
 };
 

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -28,7 +28,6 @@ const defaults = {
          * https://koenkk.github.io/zigbee2mqtt/configuration/configuration.html
          */
         cache_state: true,
-        add_timestamp: false,
     },
 };
 

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -51,7 +51,6 @@ describe('Controller', () => {
             const message = utils.zigbeeMessage(device, 'genOnOff', 'devChange', {onOff: 1}, 1);
             controller.onZigbeeMessage(message);
             chai.assert.isTrue(mqttPublish.calledOnce);
-            console.log(utils.withoutLastSeen(mqttPublish.getCall(0).args[1]));
             chai.assert.strictEqual(
                 utils.withoutLastSeen(mqttPublish.getCall(0).args[1]),
                 `{"state":"ON","device":{"ieeeAddr":"0x12345678","friendlyName":"test",` +

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -29,7 +29,10 @@ describe('Controller', () => {
             const message = utils.zigbeeMessage(device, 'genOnOff', 'devChange', {onOff: 1}, 1);
             controller.onZigbeeMessage(message);
             chai.assert.isTrue(mqttPublish.calledOnce);
-            chai.assert.strictEqual(mqttPublish.getCall(0).args[1], JSON.stringify({state: 'ON'}));
+            chai.assert.strictEqual(
+                utils.withoutLastSeen(mqttPublish.getCall(0).args[1]),
+                JSON.stringify({state: 'ON'})
+            );
         });
 
         it('Should handle a zigbee message when include_device_information is set', () => {
@@ -48,8 +51,9 @@ describe('Controller', () => {
             const message = utils.zigbeeMessage(device, 'genOnOff', 'devChange', {onOff: 1}, 1);
             controller.onZigbeeMessage(message);
             chai.assert.isTrue(mqttPublish.calledOnce);
+            console.log(utils.withoutLastSeen(mqttPublish.getCall(0).args[1]));
             chai.assert.strictEqual(
-                mqttPublish.getCall(0).args[1],
+                utils.withoutLastSeen(mqttPublish.getCall(0).args[1]),
                 `{"state":"ON","device":{"ieeeAddr":"0x12345678","friendlyName":"test",` +
                 `"modelId":"TRADFRI bulb E27 CWS opal 600lm"}}`
             );

--- a/test/deviceReceive.test.js
+++ b/test/deviceReceive.test.js
@@ -35,7 +35,7 @@ describe('DeviceReceive', () => {
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG11LM);
             chai.assert.isTrue(publishDeviceState.calledOnce);
-            chai.assert.deepEqual(publishDeviceState.getCall(0).args[1], {click: 'single'});
+            chai.assert.deepEqual(utils.withoutLastSeen(publishDeviceState.getCall(0).args[1]), {click: 'single'});
         });
 
         it('Should handle a zigbee message which uses ep (left)', () => {
@@ -43,7 +43,7 @@ describe('DeviceReceive', () => {
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
             chai.assert.isTrue(publishDeviceState.calledOnce);
-            chai.assert.deepEqual(publishDeviceState.getCall(0).args[1], {click: 'left'});
+            chai.assert.deepEqual(utils.withoutLastSeen(publishDeviceState.getCall(0).args[1]), {click: 'left'});
         });
 
         it('Should handle a zigbee message which uses ep (right)', () => {
@@ -51,7 +51,7 @@ describe('DeviceReceive', () => {
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 2);
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
             chai.assert.isTrue(publishDeviceState.calledOnce);
-            chai.assert.deepEqual(publishDeviceState.getCall(0).args[1], {click: 'right'});
+            chai.assert.deepEqual(utils.withoutLastSeen(publishDeviceState.getCall(0).args[1]), {click: 'right'});
         });
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,4 +10,19 @@ module.exports = {
     zigbeeMessage: (device, cid, type, data, epId) => {
         return {data: {cid: cid, data: data}, type: type, endpoints: [{device: device, epId: epId}]};
     },
+    withoutLastSeen: (obj) => {
+        const isString = typeof obj === 'string';
+
+        if (isString) {
+            obj = JSON.parse(obj);
+        }
+
+        delete obj.last_seen;
+
+        if (isString) {
+            obj = JSON.stringify(obj);
+        }
+
+        return obj;
+    },
 };


### PR DESCRIPTION
- can be enabled in settings / advanced / add_timestamp: true
- on enabled add last_message json attribute to mqtt payload