### PR TITLE
Add support for Sengled E12-N14 (BR30) Light

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -460,6 +460,7 @@ const mapping = {
     '3261331P7': [configurations.light_brightness_colortemp],
     'GL-B-008Z': [configurations.light_brightness_colortemp_colorxy],
     'AV2010/25': [configurations.switch, configurations.sensor_power],
+    'E12-N14': [configurations.light_brightness],
 };
 
 /**


### PR DESCRIPTION
Added support for Element Classic BR30 Soft White 2700K (E12-N14) from [Sengled](https://us.sengled.com/products/element-classic-bulb-br30).

And relevant pull request for device convertors [#189](https://github.com/Koenkk/zigbee-shepherd-converters/pull/189)