### PR TITLE
more cache options

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -208,11 +208,13 @@ class Controller {
     }
 
     sendAllCachedStates() {
-        this.zigbee.getAllClients().forEach((device) => {
-            if (this.state.exists(device.ieeeAddr)) {
-                this.publishDeviceState(device, this.state.get(device.ieeeAddr), false);
-            }
-        });
+        if (settings.get().advanced.resend_cache_state) {
+            this.zigbee.getAllClients().forEach((device) => {
+                if (this.state.exists(device.ieeeAddr)) {
+                    this.publishDeviceState(device, this.state.get(device.ieeeAddr), false);
+                }
+            });
+        }
     }
 
     publishDeviceState(device, payload, cache) {
@@ -223,7 +225,9 @@ class Controller {
         if (appSettings.advanced.cache_state) {
             // Add cached state to payload
             if (this.state.exists(deviceID)) {
-                messagePayload = objectAssignDeep.noMutate(this.state.get(deviceID), payload);
+                if (appSettings.advanced.merge_cache_state) {
+                    messagePayload = objectAssignDeep.noMutate(this.state.get(deviceID), payload);
+                }
             }
 
             // Update state cache with new state.

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -30,6 +30,10 @@ const defaults = {
          * https://koenkk.github.io/zigbee2mqtt/configuration/configuration.html
          */
         cache_state: true,
+        /* merge cached attributes */
+        merge_cache_state: true,
+        /* send cached values when (re)connecting to the mqtt server
+        resend_cache_state: true,
 
         /**
          * https://github.com/Koenkk/zigbee2mqtt/issues/685#issuecomment-449112250


### PR DESCRIPTION
will allow to use the cache for other purposes than just merging attributes
for homeassistant or resending cache when connecting to the mqtt server