### PR TITLE
Add styling to graphviz devices and links

### DIFF
--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -70,9 +70,9 @@ class NetworkMap {
 
             // Shape the record according to device type
             if (device.type == 'Coordinator') {
-                devStyle = 'style="square, bold"';
+                devStyle = 'style="bold"';
             } else if (device.type == 'Router') {
-                devStyle = 'style=rounded';
+                devStyle = 'style="rounded"';
             } else {
                 devStyle = 'style="rounded, dashed"';
             }
@@ -86,7 +86,7 @@ class NetworkMap {
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
             topology.filter((e) => e.ieeeAddr === device.ieeeAddr).forEach((e) => {
-                let lineStyle = (e.lqi==0) ? `style="dashed", ` : ``;
+                const lineStyle = (e.lqi==0) ? `style="dashed", ` : ``;
                 text += `  "${device.ieeeAddr}" -> "${e.parent}" [`+lineStyle+`label="${e.lqi}"]\n`;
             });
         });

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -42,6 +42,7 @@ class NetworkMap {
 
     graphviz(zigbee, topology) {
         let text = 'digraph G {\nnode[shape=record];\n';
+        let devStyle = '';
 
         zigbee.getDevices().forEach((device) => {
             const labels = [];
@@ -67,8 +68,17 @@ class NetworkMap {
             // Add the device status (online/offline)
             labels.push(device.status);
 
+            // Shape the record according to device type
+            if (device.type == 'Coordinator') {
+                devStyle = 'style="square, bold"';
+            } else if (device.type == 'Router') {
+                devStyle = 'style=rounded';
+            } else {
+                devStyle = 'style="rounded, dashed"';
+            }
+
             // Add the device with its labels to the graph as a node.
-            text += `  "${device.ieeeAddr}" [label="{${labels.join('|')}}"];\n`;
+            text += `  "${device.ieeeAddr}" [`+devStyle+`, label="{${labels.join('|')}}"];\n`;
 
             /**
              * Add an edge between the device and its parent to the graph
@@ -76,7 +86,8 @@ class NetworkMap {
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
             topology.filter((e) => e.ieeeAddr === device.ieeeAddr).forEach((e) => {
-                text += `  "${device.ieeeAddr}" -> "${e.parent}" [label="${e.lqi}"]\n`;
+                let lineStyle = (e.lqi==0) ? `style="dashed", ` : ``;
+                text += `  "${device.ieeeAddr}" -> "${e.parent}" [`+lineStyle+`label="${e.lqi}"]\n`;
             });
         });
 


### PR DESCRIPTION
Add styling to distinguish types of devices in the graphviz map. The coordinator is shown with bold outline, routers have rounded edges and end devices have a dashed outline.

I also set dashed lines for links with lqi of 0.

I find these changes make it easier to interpret the graphviz map. Let me know if you like any or all of these changes.