### PR TITLE
Refactored light specific transtime to generic readAfterWriteTime value

### DIFF
--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -178,7 +178,8 @@ class DevicePublish {
             // It's possible for devices to get out of sync when writing an attribute that's not reportable.
             // So here we re-read the value after a specified timeout, this timeout could for example be the
             // transition time of a color change.
-            if (topic.type === 'set' && entity.type === 'device' && converted.hasOwnProperty('readAfterWriteTime') && converted.readAfterWriteTime !== 0) {
+            if (topic.type === 'set' && entity.type === 'device'
+                && converted.hasOwnProperty('readAfterWriteTime') && converted.readAfterWriteTime !== 0) {
                 const getConverted = converter.convert(key, json[key], json, 'get');
                 setTimeout(() => {
                     // Add job to queue

--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -175,10 +175,10 @@ class DevicePublish {
                 );
             });
 
-            // When there is a transition in the message the state of the device gets out of sync.
-            // Therefore; at the end of the transition, read the new state from the device.
-            if (topic.type === 'set' && converted.zclData.transtime && entity.type === 'device') {
-                const time = converted.zclData.transtime * 100;
+            // It's possible for devices to get out of sync when writing an attribute that's not reportable.
+            // So here we re-read the value after a specified timeout, this timeout could for example be the
+            // transition time of a color change.
+            if (topic.type === 'set' && entity.type === 'device' && converted.hasOwnProperty('readAfterWriteTime') && converted.readAfterWriteTime !== 0) {
                 const getConverted = converter.convert(key, json[key], json, 'get');
                 setTimeout(() => {
                     // Add job to queue
@@ -188,7 +188,7 @@ class DevicePublish {
                             getConverted.zclData, getConverted.cfg, endpoint, () => queueCallback()
                         );
                     });
-                }, time);
+                }, converted.readAfterWriteTime);
             }
         });
 


### PR DESCRIPTION
This fix is aimed at improving the support for the eCozy TRV, specifically when used with homeassistant.
The `system_mode` attribute is not reportable so setting the value never results in a MQTT state change message which the MQTT HVAC homeassistant expects to verify the value has changed.

I refactored the existing "re-read the attribute after x time" workaround used for light color transitions to be more generic and usable from the eCozy toZigbee converter.