### PR TITLE
Added the extPanId option

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -9,6 +9,7 @@ const advancedSettings = settings.get().advanced;
 const shepherdSettings = {
     net: {
         panId: advancedSettings.pan_id,
+        extPanId: advancedSettings.ext_pan_id,        
         channelList: [advancedSettings.channel],
         precfgkey: settings.get().advanced.network_key,
     },


### PR DESCRIPTION
Added the extPanId option, because Livolo switch does not work properly with the default extPanId.

https://github.com/Koenkk/zigbee2mqtt/issues/592#issuecomment-457867404