### PR TITLE
Fix Docker images having the wrong platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ services:
 node_js:
   - "10"
 
++before_install:
+  - "echo '{\"experimental\": true}' | sudo tee /etc/docker/daemon.json"
+  - sudo apt update -y
+  - sudo apt install --only-upgrade docker-ce -y
+  - sudo service docker restart
+
 install:
   - npm install
 

--- a/.travis/docker.sh
+++ b/.travis/docker.sh
@@ -10,9 +10,7 @@ tag_push() {
 }
 
 build_and_push() {
-  platform=${3:-amd64}
-
-  docker build --platform=$platform --build-arg COMMIT=$(git rev-parse --short HEAD) -t $DOCKER_USERNAME/zigbee2mqtt:$1 -f $2 .
+  docker build --platform=$3 --build-arg COMMIT=$(git rev-parse --short HEAD) -t $DOCKER_USERNAME/zigbee2mqtt:$1 -f $2 .
   docker push $DOCKER_USERNAME/zigbee2mqtt:$1
 }
 
@@ -25,7 +23,7 @@ then
   login
 
   # Push versioned images
-  build_and_push "$TRAVIS_TAG" docker/Dockerfile.amd64
+  build_and_push "$TRAVIS_TAG" docker/Dockerfile.amd64 amd64
   build_and_push "$TRAVIS_TAG-arm32v6" docker/Dockerfile.arm32v6 arm
   build_and_push "$TRAVIS_TAG-arm64v8" docker/Dockerfile.arm64v8 arm64
 
@@ -37,7 +35,7 @@ elif [ "$TRAVIS_BRANCH" = "dev" -a "$TRAVIS_PULL_REQUEST" = "false" ]
 then
   echo "Updating docker images for dev branch!"
   login
-  build_and_push latest-dev docker/Dockerfile.amd64
+  build_and_push latest-dev docker/Dockerfile.amd64 amd64
   build_and_push arm32v6-dev docker/Dockerfile.arm32v6 arm
   build_and_push arm64v8-dev docker/Dockerfile.arm64v8 arm64
 else

--- a/.travis/docker.sh
+++ b/.travis/docker.sh
@@ -10,7 +10,9 @@ tag_push() {
 }
 
 build_and_push() {
-  docker build --build-arg COMMIT=$(git rev-parse --short HEAD) -t $DOCKER_USERNAME/zigbee2mqtt:$1 -f $2 .
+  platform=${3:-amd64}
+
+  docker build --platform=$platform --build-arg COMMIT=$(git rev-parse --short HEAD) -t $DOCKER_USERNAME/zigbee2mqtt:$1 -f $2 .
   docker push $DOCKER_USERNAME/zigbee2mqtt:$1
 }
 
@@ -24,8 +26,8 @@ then
 
   # Push versioned images
   build_and_push "$TRAVIS_TAG" docker/Dockerfile.amd64
-  build_and_push "$TRAVIS_TAG-arm32v6" docker/Dockerfile.arm32v6
-  build_and_push "$TRAVIS_TAG-arm64v8" docker/Dockerfile.arm64v8
+  build_and_push "$TRAVIS_TAG-arm32v6" docker/Dockerfile.arm32v6 arm
+  build_and_push "$TRAVIS_TAG-arm64v8" docker/Dockerfile.arm64v8 arm64
 
   # Push latest images.
   tag_push "$TRAVIS_TAG-arm32v6" "arm32v6"
@@ -36,8 +38,8 @@ then
   echo "Updating docker images for dev branch!"
   login
   build_and_push latest-dev docker/Dockerfile.amd64
-  build_and_push arm32v6-dev docker/Dockerfile.arm32v6
-  build_and_push arm64v8-dev docker/Dockerfile.arm64v8
+  build_and_push arm32v6-dev docker/Dockerfile.arm32v6 arm
+  build_and_push arm64v8-dev docker/Dockerfile.arm64v8 arm64
 else
   echo "Not updating docker images, triggered by pull request or not on master/dev branch"
 fi


### PR DESCRIPTION
This PR should fix the tagging issue as discussed in #907.

It makes travis update to the most recent version of docker, enables experimental support and then builds with `--platform={arm,arm64,amd64}`