### PR TITLE
[devicePublish.js] Increase timeout

### DIFF
--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -172,7 +172,7 @@ class DevicePublish {
                     }
                 );
 
-                setTimeout(() => queueCallback(), 100);
+                setTimeout(() => queueCallback(), 170);
             });
 
             // It's possible for devices to get out of sync when writing an attribute that's not reportable.


### PR DESCRIPTION
This should avoid a non-function state of the app when too many
requests arrive at a specific time frame (e. g. turning a lot of lights
out in the same time).
See discussion in #362