### PR TITLE
For devices with 'queryState' set, we read state after write.

### DIFF
--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -89,6 +89,7 @@ class DevicePublish {
         let endpoint = null;
         let converters = null;
         let device = null;
+        let model = null;
 
         if (entity.type === 'device') {
             device = this.zigbee.getDevice(entity.ID);
@@ -98,7 +99,7 @@ class DevicePublish {
             }
 
             // Map device to a model
-            const model = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
+            model = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
             if (!model) {
                 logger.warn(`Device with modelID '${device.modelId}' is not supported.`);
                 logger.warn(`Please see: https://koenkk.github.io/zigbee2mqtt/how_tos/how_to_support_new_devices.html`);
@@ -178,18 +179,36 @@ class DevicePublish {
             // It's possible for devices to get out of sync when writing an attribute that's not reportable.
             // So here we re-read the value after a specified timeout, this timeout could for example be the
             // transition time of a color change.
-            if (topic.type === 'set' && entity.type === 'device'
-                && converted.hasOwnProperty('readAfterWriteTime') && converted.readAfterWriteTime !== 0) {
-                const getConverted = converter.convert(key, json[key], json, 'get');
-                setTimeout(() => {
-                    // Add job to queue
-                    this.queue.push((queueCallback) => {
-                        this.zigbee.publish(
-                            entity.ID, entity.type, getConverted.cid, getConverted.cmd, getConverted.cmdType,
-                            getConverted.zclData, getConverted.cfg, endpoint, () => queueCallback()
-                        );
-                    });
-                }, converted.readAfterWriteTime);
+            // If the device definition has "queryState" set to true, we always query the state after
+            // setting it
+            if (topic.type === 'set' && entity.type === 'device') {
+                let readAfterWriteTime = 0;
+
+                // First let's see if we want to re-read because of a transition or something set
+                // in the toZigbee converter
+                if (converted.hasOwnProperty('readAfterWriteTime')) {
+                    readAfterWriteTime = converted.readAfterWriteTime;
+                }
+
+                // If not, check if we always want to read state for this device
+                if (model && readAfterWriteTime == 0
+                    && model.hasOwnProperty('queryState') && model.queryState == true) {
+                    readAfterWriteTime = 100;
+                }
+
+                // We want to read the current state after determined interval
+                if (readAfterWriteTime != 0) {
+                    const getConverted = converter.convert(key, json[key], json, 'get');
+                    setTimeout(() => {
+                        // Add job to queue
+                        this.queue.push((queueCallback) => {
+                            this.zigbee.publish(
+                                entity.ID, entity.type, getConverted.cid, getConverted.cmd, getConverted.cmdType,
+                                getConverted.zclData, getConverted.cfg, endpoint, () => queueCallback()
+                            );
+                        });
+                    }, readAfterWriteTime);
+                }
             }
         });
 


### PR DESCRIPTION
As per the discussion in https://github.com/Koenkk/zigbee2mqtt/issues/939 some devices (like my AduroSmart lights) don't send device updates. To properly know the state of the device after we set it, we can issue a get command. This change will always do that for devices that have `queryState` set to true.

I decided to implement it like this, in a more generic way. This works fine for me. If you approve this PR, I'll submit one to actually include `querystate` for the device. The other option is to just make a few converters for this device and set `readAfterWriteTime` for those - I've tried that and that also works fine. Let me know if you prefer that and I'll make a PR accordingly,