### PR TITLE
Always read after write for devices that require it.

### DIFF
--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -158,9 +158,14 @@ class DevicePublish {
 
             // It's possible for devices to get out of sync when writing an attribute that's not reportable.
             // So here we re-read the value after a specified timeout, this timeout could for example be the
-            // transition time of a color change.
+            // transition time of a color change or for forcing a state read for devices that don't
+            // automatically report a new state when set.
+            // When reporting is requested for a device (report: true in device-specific settings) we won't
+            // ever issue a read here, as we assume the device will properly report changes.
+            const deviceSettings = settings.getDevice(entity.ID);
             if (topic.type === 'set' && entity.type === 'device'
-                && converted.hasOwnProperty('readAfterWriteTime') && converted.readAfterWriteTime !== 0) {
+                && converted.hasOwnProperty('readAfterWriteTime')
+                && !(deviceSettings && deviceSettings.report)) {
                 const getConverted = converter.convert(key, json[key], json, 'get');
                 setTimeout(() => {
                     this.zigbee.publish(

--- a/test/devicePublish.test.js
+++ b/test/devicePublish.test.js
@@ -406,9 +406,13 @@ describe('DevicePublish', () => {
         const msg = {'state': 'ON', 'color': {'x': 0.701, 'y': 0.299}};
         devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify(msg));
         setTimeout(() => {
-            chai.assert.isTrue(zigbee.publish.calledTwice);
+            chai.assert.equal(zigbee.publish.callCount, 3);
             chai.assert.equal(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            chai.assert.equal(zigbee.publish.getCall(0).args[3], 'on');
             chai.assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+            chai.assert.equal(zigbee.publish.getCall(1).args[3], 'moveToColor');
+            chai.assert.equal(zigbee.publish.getCall(2).args[2], 'lightingColorCtrl');
+            chai.assert.equal(zigbee.publish.getCall(2).args[3], 'read');
             done();
         }, 300);
     });


### PR DESCRIPTION
Devices with readAfterWriteTime set, even if it's 0, will get their
state read after write because those devices don't automatically
report it themselves.

Devices that are capable of reporting but don't do it by default
should have `report: true` set in the device-specific config and
we won't read after write.

As discussed.