### PR TITLE
Allow to override Home Assistant discovery configuration. 

### DIFF
--- a/docs/configuration/device_specific_configuration.md
+++ b/docs/configuration/device_specific_configuration.md
@@ -6,6 +6,7 @@ The `configuration.yaml` allows to set device specific configuration. The follow
 * `retain`: Retain MQTT messages of this device.
 * `qos`: QoS level for MQTT messages of this device. [What is QoS?](https://www.npmjs.com/package/mqtt#about-qos)
 * `report`: The device will be setup to report it's changed state when not directly controlled by zigbee2mqtt (e.g. via a remote control).
+* `homeassistant`: Allows to override values of the Home Assistant discovery payload. See example below.
 
 ### Device type specific
 * `occupancy_timeout`: Timeout (in seconds) after the `occupancy: false` message is sent, only available for occupany sensors. If not set, the timeout is `90` seconds. When set to `0` no `occupancy: false` is send.
@@ -22,6 +23,12 @@ devices:
     occupancy_timeout: 20
     qos: 1
     report: true
+    homeassistant:
+      # Applied to all discovered entities.
+      expire_after: 30
+      # Only applied to discovered temperature sensor.
+      temperature:
+        icon: mdi:oil-temperature
 ```
 
 ### Changing device type specific defaults

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -567,6 +567,12 @@ class HomeAssistant {
                 payload.availability_topic = `${settings.get().mqtt.base_topic}/bridge/state`;
             }
 
+
+            // set expire after
+            if (settings.getDevice(ieeeAddr).expire_after) {
+                payload.expire_after = `${settings.getDevice(ieeeAddr).expire_after}`
+            }
+
             // Add precision to value_template
             if (settings.getDevice(ieeeAddr).hasOwnProperty(`${config.object_id}_precision`)) {
                 const precision = settings.getDevice(ieeeAddr)[`${config.object_id}_precision`];

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -567,15 +567,10 @@ class HomeAssistant {
                 payload.availability_topic = `${settings.get().mqtt.base_topic}/bridge/state`;
             }
 
-
-            // set expire after
-            if (settings.getDevice(ieeeAddr).homeassistant.expire_after) {
-                payload.expire_after = `${settings.getDevice(ieeeAddr).homeassistant.expire_after}`
-            }
-
             // Add precision to value_template
-            if (settings.getDevice(ieeeAddr).hasOwnProperty(`${config.object_id}_precision`)) {
-                const precision = settings.getDevice(ieeeAddr)[`${config.object_id}_precision`];
+            const device = settings.getDevice(ieeeAddr);
+            if (device.hasOwnProperty(`${config.object_id}_precision`)) {
+                const precision = device[`${config.object_id}_precision`];
                 let template = payload.value_template;
                 template = template.replace('{{ ', '').replace(' }}', '');
                 template = `{{ (${template} | float) | round(${precision}) }}`;
@@ -591,6 +586,23 @@ class HomeAssistant {
                 }
 
                 payload.command_topic += 'set';
+            }
+
+            // Override configuration with user settings.
+            if (device.hasOwnProperty('homeassistant')) {
+                const add = (obj) => {
+                    Object.keys(obj).forEach((key) => {
+                        if (['number', 'string'].includes(typeof obj[key])) {
+                            payload[key] = obj[key];
+                        }
+                    });
+                };
+
+                add(device.homeassistant);
+
+                if (device.homeassistant.hasOwnProperty(config.object_id)) {
+                    add(device.homeassistant[config.object_id]);
+                }
             }
 
             this.mqtt.publish(topic, JSON.stringify(payload), {retain: true, qos: 0}, null, 'homeassistant');

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -569,8 +569,8 @@ class HomeAssistant {
 
 
             // set expire after
-            if (settings.getDevice(ieeeAddr).expire_after) {
-                payload.expire_after = `${settings.getDevice(ieeeAddr).expire_after}`
+            if (settings.getDevice(ieeeAddr).homeassistant.expire_after) {
+                payload.expire_after = `${settings.getDevice(ieeeAddr).homeassistant.expire_after}`
             }
 
             // Add precision to value_template

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -252,4 +252,127 @@ describe('HomeAssistant extension', () => {
         chai.assert.equal(mqtt.publish.getCall(3).args[3], null);
         chai.assert.equal(mqtt.publish.getCall(3).args[4], 'homeassistant');
     });
+
+    it('Should discover devices with overriden user configuration', () => {
+        let payload = null;
+        sandbox.stub(settings, 'getDevice').callsFake(() => {
+            return {
+                friendly_name: 'my_device',
+                homeassistant: {
+                    expire_after: 30,
+                    icon: 'mdi:test',
+                    temperature: {
+                        expire_after: 90,
+                    },
+                },
+            };
+        });
+
+        homeassistant.discover('0x12345678', WSDCGQ11LM, false);
+        chai.assert.equal(mqtt.publish.callCount, 4);
+
+        // 1
+        payload = {
+            'unit_of_measurement': '°C',
+            'device_class': 'temperature',
+            'value_template': '{{ value_json.temperature }}',
+            'json_attributes_topic': 'zigbee2mqtt/my_device',
+            'state_topic': 'zigbee2mqtt/my_device',
+            'name': 'my_device_temperature',
+            'unique_id': '0x12345678_temperature_zigbee2mqtt',
+            'expire_after': 90,
+            'icon': 'mdi:test',
+            'device': {
+                'identifiers': 'zigbee2mqtt_0x12345678',
+                'name': 'my_device',
+                'sw_version': 'Zigbee2mqtt test',
+                'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
+                'manufacturer': 'Xiaomi',
+            },
+            'availability_topic': 'zigbee2mqtt/bridge/state',
+        };
+
+        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
+        chai.assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
+        chai.assert.equal(mqtt.publish.getCall(0).args[3], null);
+        chai.assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
+
+        // 2
+        payload = {
+            'unit_of_measurement': '%',
+            'device_class': 'humidity',
+            'value_template': '{{ value_json.humidity }}',
+            'json_attributes_topic': 'zigbee2mqtt/my_device',
+            'state_topic': 'zigbee2mqtt/my_device',
+            'name': 'my_device_humidity',
+            'unique_id': '0x12345678_humidity_zigbee2mqtt',
+            'expire_after': 30,
+            'icon': 'mdi:test',
+            'device': {
+                'identifiers': 'zigbee2mqtt_0x12345678',
+                'name': 'my_device',
+                'sw_version': 'Zigbee2mqtt test',
+                'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
+                'manufacturer': 'Xiaomi',
+            },
+            'availability_topic': 'zigbee2mqtt/bridge/state',
+        };
+
+        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(1).args[1]), payload);
+        chai.assert.deepEqual(mqtt.publish.getCall(1).args[2], {retain: true, qos: 0});
+        chai.assert.equal(mqtt.publish.getCall(1).args[3], null);
+        chai.assert.equal(mqtt.publish.getCall(1).args[4], 'homeassistant');
+
+        // 3
+        payload = {
+            'unit_of_measurement': 'hPa',
+            'device_class': 'pressure',
+            'value_template': '{{ value_json.pressure }}',
+            'json_attributes_topic': 'zigbee2mqtt/my_device',
+            'state_topic': 'zigbee2mqtt/my_device',
+            'name': 'my_device_pressure',
+            'unique_id': '0x12345678_pressure_zigbee2mqtt',
+            'expire_after': 30,
+            'icon': 'mdi:test',
+            'device': {
+                'identifiers': 'zigbee2mqtt_0x12345678',
+                'name': 'my_device',
+                'sw_version': 'Zigbee2mqtt test',
+                'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
+                'manufacturer': 'Xiaomi',
+            },
+            'availability_topic': 'zigbee2mqtt/bridge/state',
+        };
+
+        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(2).args[1]), payload);
+        chai.assert.deepEqual(mqtt.publish.getCall(2).args[2], {retain: true, qos: 0});
+        chai.assert.equal(mqtt.publish.getCall(2).args[3], null);
+        chai.assert.equal(mqtt.publish.getCall(2).args[4], 'homeassistant');
+
+        // 4
+        payload = {
+            'unit_of_measurement': '%',
+            'device_class': 'battery',
+            'value_template': '{{ value_json.battery }}',
+            'json_attributes_topic': 'zigbee2mqtt/my_device',
+            'state_topic': 'zigbee2mqtt/my_device',
+            'name': 'my_device_battery',
+            'unique_id': '0x12345678_battery_zigbee2mqtt',
+            'expire_after': 30,
+            'icon': 'mdi:test',
+            'device': {
+                'identifiers': 'zigbee2mqtt_0x12345678',
+                'name': 'my_device',
+                'sw_version': 'Zigbee2mqtt test',
+                'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
+                'manufacturer': 'Xiaomi',
+            },
+            'availability_topic': 'zigbee2mqtt/bridge/state',
+        };
+
+        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(3).args[1]), payload);
+        chai.assert.deepEqual(mqtt.publish.getCall(3).args[2], {retain: true, qos: 0});
+        chai.assert.equal(mqtt.publish.getCall(3).args[3], null);
+        chai.assert.equal(mqtt.publish.getCall(3).args[4], 'homeassistant');
+    });
 });


### PR DESCRIPTION
Allow per device configuration of home assistant expire_after option. This allows home assistant to consider a device unavailable if a value is not received within X seconds.

Work around for issue #1020 and #775 