### PR TITLE
Add support for Hue white ambiance suspension Fair

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -450,6 +450,7 @@ const mapping = {
     '4713407': [configurations.light_brightness],
     '464800': [configurations.light_brightness_colortemp],
     '3261331P7': [configurations.light_brightness_colortemp],
+    '4033930P7': [configurations.light_brightness_colortemp],
     'GL-B-008Z': [configurations.light_brightness_colortemp_colorxy],
     'AV2010/25': [configurations.switch, configurations.sensor_power],
     'E12-N14': [configurations.light_brightness],


### PR DESCRIPTION
I've succesfully added the Philips Hue white ambiance suspension Fair model 4033930P7 with these settings.