### PR TITLE
Add group membership command

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -14,6 +14,7 @@ const ExtensionXiaomi = require('./extension/xiaomi');
 const ExtensionDevicePublish = require('./extension/devicePublish');
 const ExtensionHomeAssistant = require('./extension/homeassistant');
 const ExtensionDeviceConfigure = require('./extension/deviceConfigure');
+const ExtensionDeviceGroupMembership = require('./extension/deviceGroupMembership');
 const ExtensionDeviceReceive = require('./extension/deviceReceive');
 const ExtensionBridgeConfig = require('./extension/bridgeConfig');
 const ExtensionGroups = require('./extension/groups');
@@ -38,6 +39,7 @@ class Controller {
         // Initialize extensions.
         this.extensions = [
             new ExtensionDeviceReceive(this.zigbee, this.mqtt, this.state, this.publishEntityState),
+            new ExtensionDeviceGroupMembership(this.zigbee, this.mqtt, this.publishEntityState),
             new ExtensionDeviceConfigure(this.zigbee, this.mqtt, this.state, this.publishEntityState),
             new ExtensionDevicePublish(this.zigbee, this.mqtt, this.state, this.publishEntityState),
             new ExtensionNetworkMap(this.zigbee, this.mqtt, this.state, this.publishEntityState),

--- a/lib/extension/deviceGroupMembership.js
+++ b/lib/extension/deviceGroupMembership.js
@@ -47,7 +47,7 @@ class DeviceGroupMembership {
             if (error) {
                 logger.error(`Failed to get membership of ${ieeeAddr}`);
             } else {
-                const { grouplist, capacity } = rsp;
+                const {grouplist, capacity} = rsp;
                 const msgGroupList = `${ieeeAddr} is in groups [${grouplist}]`;
                 let msgCapacity;
                 if (capacity === 254) {
@@ -60,7 +60,7 @@ class DeviceGroupMembership {
                 // never cache
                 this.publishEntityState(ieeeAddr, {
                     groupList: grouplist,
-                    groupCapacity: capacity
+                    groupCapacity: capacity,
                 }, false);
             }
         };

--- a/lib/extension/deviceGroupMembership.js
+++ b/lib/extension/deviceGroupMembership.js
@@ -59,8 +59,8 @@ class DeviceGroupMembership {
 
                 // never cache
                 this.publishEntityState(ieeeAddr, {
-                    groupList: grouplist,
-                    groupCapacity: capacity,
+                    group_list: grouplist,
+                    group_capacity: capacity,
                 }, false);
             }
         };

--- a/lib/extension/deviceGroupMembership.js
+++ b/lib/extension/deviceGroupMembership.js
@@ -1,0 +1,77 @@
+const settings = require('../util/settings');
+const logger = require('../util/logger');
+
+const topicRegex = new RegExp(`^${settings.get().mqtt.base_topic}/bridge/.+/get_group_membership$`);
+
+class DeviceGroupMembership {
+    constructor(zigbee, mqtt, publishEntityState) {
+        this.zigbee = zigbee;
+        this.mqtt = mqtt;
+        this.publishEntityState = publishEntityState;
+    }
+
+    onMQTTConnected() {
+        this.mqtt.subscribe(`${settings.get().mqtt.base_topic}/bridge/device/+/get_group_membership`);
+    }
+
+    parseTopic(topic) {
+        if (!topic.match(topicRegex)) {
+            return null;
+        }
+
+        // Remove base from topic
+        topic = topic.replace(`${settings.get().mqtt.base_topic}/bridge/device/`, '');
+
+        // Remove command from topic
+        topic = topic.replace(`/get_group_membership`, '');
+
+        return {friendlyName: topic};
+    }
+
+    onMQTTMessage(topic, message) {
+        topic = this.parseTopic(topic);
+
+        if (!topic) {
+            return false;
+        }
+
+        // Map message to ieeeAddr and check if device exist.
+        const friendlyName = topic.friendlyName;
+        const ieeeAddr = settings.getIeeeAddrByFriendlyName(friendlyName) || friendlyName;
+        if (!this.zigbee.getDevice(ieeeAddr)) {
+            logger.error(`Failed to find device '${friendlyName}'`);
+            return;
+        }
+
+        const callback = (error, rsp) => {
+            if (error) {
+                logger.error(`Failed to get membership of ${ieeeAddr}`);
+            } else {
+                const { grouplist, capacity } = rsp;
+                const msgGroupList = `${ieeeAddr} is in groups [${grouplist}]`;
+                let msgCapacity;
+                if (capacity === 254) {
+                    msgCapacity = 'it can be a part of at least 1 more group';
+                } else {
+                    msgCapacity = `its remaining group capacity is ${capacity === 255 ? 'unknown' : capacity}`;
+                }
+                logger.info(`${msgGroupList} and ${msgCapacity}`);
+
+                // never cache
+                this.publishEntityState(ieeeAddr, {
+                    groupList: grouplist,
+                    groupCapacity: capacity
+                }, false);
+            }
+        };
+
+        this.zigbee.publish(
+            ieeeAddr, 'device', 'genGroups', 'getMembership', 'functional',
+            {groupcount: 0, grouplist: []}, null, null, callback,
+        );
+
+        return true;
+    }
+}
+
+module.exports = DeviceGroupMembership;

--- a/lib/extension/deviceGroupMembership.js
+++ b/lib/extension/deviceGroupMembership.js
@@ -1,7 +1,7 @@
 const settings = require('../util/settings');
 const logger = require('../util/logger');
 
-const topicRegex = new RegExp(`^${settings.get().mqtt.base_topic}/bridge/.+/get_group_membership$`);
+const topicRegex = new RegExp(`^${settings.get().mqtt.base_topic}/bridge/device/.+/get_group_membership$`);
 
 class DeviceGroupMembership {
     constructor(zigbee, mqtt, publishEntityState) {


### PR DESCRIPTION
From docs at http://www.zigbee.org/wp-content/uploads/2014/11/docs-07-5123-04-zigbee-cluster-library-specification.pdf section 3.6.2.3.3.2, sending the `getMembership` command with `groupcount` = `0` and `grouplist` = `[]` returns all the groups a device is a part of.

This worked against the Sengled element classic E11-G13 lights I had in my network, but I don't have any other devices to test against.

Example of using the command:

```
zigbee2mqtt:info 2019-2-10 04:43:26 Zigbee publish to device '0xb0ce18140316d859', genGroups - getMembership - {"groupcount":0,"grouplist":[]} - null - null
zigbee2mqtt:info 2019-2-10 04:43:27 0xb0ce18140316d859 is in groups [1] and its remaining group capacity is unknown
zigbee2mqtt:info 2019-2-10 04:43:37 Zigbee publish to device '0xb0ce18140316d859', genGroups - add - {"groupid":"2","groupname":""} - null - null
zigbee2mqtt:info 2019-2-10 04:43:37 Successfully add 0xb0ce18140316d859 to office_lights
zigbee2mqtt:info 2019-2-10 04:43:45 Zigbee publish to device '0xb0ce18140316d859', genGroups - getMembership - {"groupcount":0,"grouplist":[]} - null - null
zigbee2mqtt:info 2019-2-10 04:43:45 0xb0ce18140316d859 is in groups [1,2] and its remaining group capacity is unknown
zigbee2mqtt:info 2019-2-10 04:43:54 Zigbee publish to device '0xb0ce18140316d859', genGroups - remove - {"groupid":"2"} - null - null
zigbee2mqtt:info 2019-2-10 04:43:54 Successfully remove 0xb0ce18140316d859 to office_lights
zigbee2mqtt:info 2019-2-10 04:43:57 Zigbee publish to device '0xb0ce18140316d859', genGroups - getMembership - {"groupcount":0,"grouplist":[]} - null - null
zigbee2mqtt:info 2019-2-10 04:43:57 0xb0ce18140316d859 is in groups [1] and its remaining group capacity is unknown
```

n.b. reading https://www.nxp.com/docs/en/user-guide/JN-UG-3077.pdf says that 255 means group capacity is unknown, 254 means that there is space for at least 1 more group but how many more is unknown.
> u8Capacity is the capacity of the device’s Group table to receive more groups -
that is, the number of groups that may be added (special values: 0xFE means
at least one more group may be added, a higher value means that the table’s
remaining capacity is unknown) 