### PR TITLE
Create default and system MQTT postfixes

### DIFF
--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -5,7 +5,8 @@ const logger = require('../util/logger');
 const utils = require('../util/utils');
 
 const topicRegex = new RegExp(`^${settings.get().mqtt.base_topic}/.+/(set|get)$`);
-const postfixes = ['left', 'right', 'center', 'bottom_left', 'bottom_right', 'top_left', 'top_right', 'white', 'rgb'];
+const postfixes = ['left', 'right', 'center', 'bottom_left', 'bottom_right',
+    'top_left', 'top_right', 'white', 'rgb', 'system'];
 const maxDepth = 20;
 
 const groupConverters = [
@@ -160,6 +161,9 @@ class DevicePublish {
             if (model.hasOwnProperty('ep')) {
                 const eps = model.ep(device);
                 endpoint = eps.hasOwnProperty(topic.postfix) ? eps[topic.postfix] : null;
+                if (endpoint === null && eps.hasOwnProperty('default')) {
+                    endpoint = eps['default'];
+                }
             }
 
             converters = model.toZigbee;


### PR DESCRIPTION
Allows to choose default endpoint.
Also adds `system` postfix.

Required for https://github.com/Koenkk/zigbee-shepherd-converters/pull/287