### PR TITLE
add device model to log

### DIFF
--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -52,7 +52,7 @@ class DeviceReceive {
         if (!settings.getDevice(device.ieeeAddr)) {
             logger.info(`New device '${device.modelId}' with address ${device.ieeeAddr} connected!`);
             settings.addDevice(device.ieeeAddr);
-            this.mqtt.log('device_connected', device.ieeeAddr, device.modelId);
+            this.mqtt.log('device_connected', device.ieeeAddr, {modelID: device.modelId});
         }
 
         if (!mappedDevice) {

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -50,9 +50,9 @@ class DeviceReceive {
 
         // Check if this is a new device.
         if (!settings.getDevice(device.ieeeAddr)) {
-            logger.info(`New device with address ${device.ieeeAddr} connected!`);
+            logger.info(`New device '${device.modelId}' with address ${device.ieeeAddr} connected!`);
             settings.addDevice(device.ieeeAddr);
-            this.mqtt.log('device_connected', device.ieeeAddr);
+            this.mqtt.log('device_connected', device.ieeeAddr, device.modelId);
         }
 
         if (!mappedDevice) {


### PR DESCRIPTION
It would be self explanatory if log messages for new devices not only included addresses but also the model ID