### PR TITLE
add support for local ISO8601 timestamp format

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -76,7 +76,7 @@ class BridgeConfig {
     }
 
     lastSeen(topic, message) {
-        const allowed = ['disable', 'ISO_8601', 'epoch'];
+        const allowed = ['disable', 'ISO_8601', 'epoch', 'ISO_8601_local'];
         message = message.toString();
 
         if (!allowed.includes(message)) {

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -123,6 +123,26 @@ class DeviceReceive {
             case 'ISO_8601':
                 payload.last_seen = new Date(now).toISOString();
                 break;
+            case 'ISO_8601_Local':
+				Date.prototype.toLocalISOString = function() {
+					var tz_offset = -this.getTimezoneOffset();
+					var plusminus = tz_offset >= 0 ? '+' : '-';
+					var pad = function(num) {
+						var norm = Math.floor(Math.abs(num));
+						return (norm < 10 ? '0' : '') + norm;
+					};
+
+					return this.getFullYear() +
+						'-' + pad(this.getMonth() + 1) +
+						'-' + pad(this.getDate()) +
+						'T' + pad(this.getHours()) +
+						':' + pad(this.getMinutes()) +
+						':' + pad(this.getSeconds()) +
+						plusminus + pad(tz_offset / 60) +
+						':' + pad(tz_offset % 60);
+				}
+                payload.last_seen = new Date(now).toLocalISOString();
+                break;
             case 'epoch':
                 payload.last_seen = now;
                 break;

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -98,6 +98,28 @@ class DeviceReceive {
             return;
         }
 
+        // construct a local ISO8601 string (instead of UTC-based)
+        // Example:
+        //  - ISO8601 (UTC) = 2019-03-01T15:32:45.941+0000
+        //  - ISO8601 (local) = 2019-03-01T16:32:45.941+0100 (for timezone GMT+1)
+        const toLocalISOString = function(dDate) {
+            const tzOffset = -dDate.getTimezoneOffset();
+            const plusOrMinus = tzOffset >= 0 ? '+' : '-';
+            const pad = function(num) {
+                const norm = Math.floor(Math.abs(num));
+                return (norm < 10 ? '0' : '') + norm;
+            };
+
+            return dDate.getFullYear() +
+                '-' + pad(dDate.getMonth() + 1) +
+                '-' + pad(dDate.getDate()) +
+                'T' + pad(dDate.getHours()) +
+                ':' + pad(dDate.getMinutes()) +
+                ':' + pad(dDate.getSeconds()) +
+                plusOrMinus + pad(tzOffset / 60) +
+                ':' + pad(tzOffset % 60);
+        };
+        
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
         // - If a payload is returned publish it to the MQTT broker
@@ -124,23 +146,6 @@ class DeviceReceive {
                 payload.last_seen = new Date(now).toISOString();
                 break;
             case 'ISO_8601_Local':
-                let toLocalISOString = function(dDate) {
-                    let tzOffset = -dDate.getTimezoneOffset();
-                    let plusOrMinus = tzOffset >= 0 ? '+' : '-';
-                    let pad = function(num) {
-                        let norm = Math.floor(Math.abs(num));
-                        return (norm < 10 ? '0' : '') + norm;
-                    };
-
-                    return dDate.getFullYear() +
-                        '-' + pad(dDate.getMonth() + 1) +
-                        '-' + pad(dDate.getDate()) +
-                        'T' + pad(dDate.getHours()) +
-                        ':' + pad(dDate.getMinutes()) +
-                        ':' + pad(dDate.getSeconds()) +
-                        plusOrMinus + pad(tzOffset / 60) +
-                        ':' + pad(tzOffset % 60);
-                };
                 payload.last_seen = toLocalISOString(new Date(now));
                 break;
             case 'epoch':

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -119,7 +119,7 @@ class DeviceReceive {
                 plusOrMinus + pad(tzOffset / 60) +
                 ':' + pad(tzOffset % 60);
         };
-        
+
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
         // - If a payload is returned publish it to the MQTT broker

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -124,23 +124,23 @@ class DeviceReceive {
                 payload.last_seen = new Date(now).toISOString();
                 break;
             case 'ISO_8601_Local':
-		Date.prototype.toLocalISOString = function() {
-			var tz_offset = -this.getTimezoneOffset();
-			var plusminus = tz_offset >= 0 ? '+' : '-';
-			var pad = function(num) {
-				var norm = Math.floor(Math.abs(num));
-				return (norm < 10 ? '0' : '') + norm;
-			};
+                Date.prototype.toLocalISOString = function() {
+                    var tz_offset = -this.getTimezoneOffset();
+                    var plusminus = tz_offset >= 0 ? '+' : '-';
+                    var pad = function(num) {
+                        var norm = Math.floor(Math.abs(num));
+                        return (norm < 10 ? '0' : '') + norm;
+                    };
 
-			return this.getFullYear() +
-				'-' + pad(this.getMonth() + 1) +
-				'-' + pad(this.getDate()) +
-				'T' + pad(this.getHours()) +
-				':' + pad(this.getMinutes()) +
-				':' + pad(this.getSeconds()) +
-				plusminus + pad(tz_offset / 60) +
-				':' + pad(tz_offset % 60);
-		}
+                    return this.getFullYear() +
+                        '-' + pad(this.getMonth() + 1) +
+                        '-' + pad(this.getDate()) +
+                        'T' + pad(this.getHours()) +
+                        ':' + pad(this.getMinutes()) +
+                        ':' + pad(this.getSeconds()) +
+                        plusminus + pad(tz_offset / 60) +
+                        ':' + pad(tz_offset % 60);
+                }
                 payload.last_seen = new Date(now).toLocalISOString();
                 break;
             case 'epoch':

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -1,5 +1,6 @@
 const settings = require('../util/settings');
 const logger = require('../util/logger');
+const utils = require('../util/utils');
 
 const dontCacheProperties = [
     'action', 'button', 'button_left', 'button_right', 'click', 'forgotten', 'keyerror',
@@ -98,28 +99,6 @@ class DeviceReceive {
             return;
         }
 
-        // construct a local ISO8601 string (instead of UTC-based)
-        // Example:
-        //  - ISO8601 (UTC) = 2019-03-01T15:32:45.941+0000
-        //  - ISO8601 (local) = 2019-03-01T16:32:45.941+0100 (for timezone GMT+1)
-        const toLocalISOString = function(dDate) {
-            const tzOffset = -dDate.getTimezoneOffset();
-            const plusOrMinus = tzOffset >= 0 ? '+' : '-';
-            const pad = function(num) {
-                const norm = Math.floor(Math.abs(num));
-                return (norm < 10 ? '0' : '') + norm;
-            };
-
-            return dDate.getFullYear() +
-                '-' + pad(dDate.getMonth() + 1) +
-                '-' + pad(dDate.getDate()) +
-                'T' + pad(dDate.getHours()) +
-                ':' + pad(dDate.getMinutes()) +
-                ':' + pad(dDate.getSeconds()) +
-                plusOrMinus + pad(tzOffset / 60) +
-                ':' + pad(tzOffset % 60);
-        };
-
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
         // - If a payload is returned publish it to the MQTT broker
@@ -145,8 +124,8 @@ class DeviceReceive {
             case 'ISO_8601':
                 payload.last_seen = new Date(now).toISOString();
                 break;
-            case 'ISO_8601_Local':
-                payload.last_seen = toLocalISOString(new Date(now));
+            case 'ISO_8601_local':
+                payload.last_seen = utils.toLocalISOString(new Date(now));
                 break;
             case 'epoch':
                 payload.last_seen = now;

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -124,23 +124,23 @@ class DeviceReceive {
                 payload.last_seen = new Date(now).toISOString();
                 break;
             case 'ISO_8601_Local':
-				Date.prototype.toLocalISOString = function() {
-					var tz_offset = -this.getTimezoneOffset();
-					var plusminus = tz_offset >= 0 ? '+' : '-';
-					var pad = function(num) {
-						var norm = Math.floor(Math.abs(num));
-						return (norm < 10 ? '0' : '') + norm;
-					};
+		Date.prototype.toLocalISOString = function() {
+			var tz_offset = -this.getTimezoneOffset();
+			var plusminus = tz_offset >= 0 ? '+' : '-';
+			var pad = function(num) {
+				var norm = Math.floor(Math.abs(num));
+				return (norm < 10 ? '0' : '') + norm;
+			};
 
-					return this.getFullYear() +
-						'-' + pad(this.getMonth() + 1) +
-						'-' + pad(this.getDate()) +
-						'T' + pad(this.getHours()) +
-						':' + pad(this.getMinutes()) +
-						':' + pad(this.getSeconds()) +
-						plusminus + pad(tz_offset / 60) +
-						':' + pad(tz_offset % 60);
-				}
+			return this.getFullYear() +
+				'-' + pad(this.getMonth() + 1) +
+				'-' + pad(this.getDate()) +
+				'T' + pad(this.getHours()) +
+				':' + pad(this.getMinutes()) +
+				':' + pad(this.getSeconds()) +
+				plusminus + pad(tz_offset / 60) +
+				':' + pad(tz_offset % 60);
+		}
                 payload.last_seen = new Date(now).toLocalISOString();
                 break;
             case 'epoch':

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -124,24 +124,24 @@ class DeviceReceive {
                 payload.last_seen = new Date(now).toISOString();
                 break;
             case 'ISO_8601_Local':
-                Date.prototype.toLocalISOString = function() {
-                    var tz_offset = -this.getTimezoneOffset();
-                    var plusminus = tz_offset >= 0 ? '+' : '-';
-                    var pad = function(num) {
-                        var norm = Math.floor(Math.abs(num));
+                let toLocalISOString = function(dDate) {
+                    let tzOffset = -dDate.getTimezoneOffset();
+                    let plusOrMinus = tzOffset >= 0 ? '+' : '-';
+                    let pad = function(num) {
+                        let norm = Math.floor(Math.abs(num));
                         return (norm < 10 ? '0' : '') + norm;
                     };
 
-                    return this.getFullYear() +
-                        '-' + pad(this.getMonth() + 1) +
-                        '-' + pad(this.getDate()) +
-                        'T' + pad(this.getHours()) +
-                        ':' + pad(this.getMinutes()) +
-                        ':' + pad(this.getSeconds()) +
-                        plusminus + pad(tz_offset / 60) +
-                        ':' + pad(tz_offset % 60);
-                }
-                payload.last_seen = new Date(now).toLocalISOString();
+                    return dDate.getFullYear() +
+                        '-' + pad(dDate.getMonth() + 1) +
+                        '-' + pad(dDate.getDate()) +
+                        'T' + pad(dDate.getHours()) +
+                        ':' + pad(dDate.getMinutes()) +
+                        ':' + pad(dDate.getSeconds()) +
+                        plusOrMinus + pad(tzOffset / 60) +
+                        ':' + pad(tzOffset % 60);
+                };
+                payload.last_seen = toLocalISOString(new Date(now));
                 break;
             case 'epoch':
                 payload.last_seen = now;

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -44,6 +44,7 @@ const defaults = {
         /**
          * Add a last_seen attribute to mqtt messages, contains date/time of zigbee message arrival
          * "ISO_8601": ISO 8601 format
+         * "ISO_8601_local": Local ISO 8601 format (instead of UTC-based)
          * "epoch": milliseconds elapsed since the UNIX epoch
          * "disable": no last_seen attribute (default)
          */

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -33,6 +33,28 @@ function resolveEntity(ID) {
     return {ID: ID, type: type, friendlyName: friendlyName};
 }
 
+// construct a local ISO8601 string (instead of UTC-based)
+// Example:
+//  - ISO8601 (UTC) = 2019-03-01T15:32:45.941+0000
+//  - ISO8601 (local) = 2019-03-01T16:32:45.941+0100 (for timezone GMT+1)
+function toLocalISOString(dDate) {
+    const tzOffset = -dDate.getTimezoneOffset();
+    const plusOrMinus = tzOffset >= 0 ? '+' : '-';
+    const pad = function(num) {
+        const norm = Math.floor(Math.abs(num));
+        return (norm < 10 ? '0' : '') + norm;
+    };
+
+    return dDate.getFullYear() +
+        '-' + pad(dDate.getMonth() + 1) +
+        '-' + pad(dDate.getDate()) +
+        'T' + pad(dDate.getHours()) +
+        ':' + pad(dDate.getMinutes()) +
+        ':' + pad(dDate.getSeconds()) +
+        plusOrMinus + pad(tzOffset / 60) +
+        ':' + pad(tzOffset % 60);
+}
+
 module.exports = {
     millisecondsToSeconds: (milliseconds) => milliseconds / 1000,
     secondsToMilliseconds: (seconds) => seconds * 1000,
@@ -40,4 +62,5 @@ module.exports = {
     isIkeaTradfriDevice: (device) => ikeaTradfriManufacturerID.includes(device.manufId),
     isNumeric: (string) => /^\d+$/.test(string),
     resolveEntity: (ID) => resolveEntity(ID),
+    toLocalISOString: (dDate) => toLocalISOString(dDate),
 };

--- a/test/deviceReceive.test.js
+++ b/test/deviceReceive.test.js
@@ -225,5 +225,20 @@ describe('DeviceReceive', () => {
             chai.assert.isTrue(publishEntityState.calledOnce);
             chai.assert.equal(typeof publishEntityState.getCall(0).args[1].last_seen, 'string');
         });
+
+        it('Should publish last_seen ISO_8601_local', () => {
+            const device = {ieeeAddr: '0x12345678'};
+            const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
+            sandbox.stub(settings, 'get').callsFake(() => {
+                return {
+                    advanced: {
+                        last_seen: 'ISO_8601_local',
+                    },
+                };
+            });
+            deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
+            chai.assert.isTrue(publishEntityState.calledOnce);
+            chai.assert.equal(typeof publishEntityState.getCall(0).args[1].last_seen, 'string');
+        });
     });
 });


### PR DESCRIPTION
added local ISO8601 timestamp format for local rather than UTC-based timestamps

ISO8601 = 2019-03-01T15:32:45.941+0000
ISO8601_Local = 2019-03-01T16:32:45.941+0100 (for TZ GMT+1)