### PR TITLE
Test improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "eslint-plugin-mocha": "*",
     "mocha": "*",
     "nyc": "*",
-    "proxyquire": "*",
     "sinon": "*",
     "tmp": "*"
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "rimraf": "*",
     "semver": "*",
     "winston": "2.4.2",
+    "zcl-id": "git+https://github.com/Koenkk/zcl-id.git#77ba3058c6c4b09a9958761ae5e3046765c12872",
     "ziee": "*",
     "zigbee-shepherd": "git+https://github.com/Koenkk/zigbee-shepherd.git#ce12cdd9c7aa11ac9f7464839db6215d05926207",
     "zigbee-shepherd-converters": "7.2.5",

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -4,18 +4,17 @@ const Controller = require('../lib/controller');
 const settings = require('../lib/util/settings');
 const mqtt = require('../lib/mqtt');
 const utils = require('./utils');
-const sandbox = sinon.createSandbox();
 
 describe('Controller', () => {
     let controller;
     let mqttPublish;
 
     beforeEach(() => {
-        utils.stubLogger(sandbox);
-        sandbox.stub(settings, 'getDevice').callsFake((ieeeAddr) => {
+        utils.stubLogger(sinon);
+        sinon.stub(settings, 'getDevice').callsFake((ieeeAddr) => {
             return {friendly_name: 'test'};
         });
-        mqttPublish = sandbox.stub(mqtt.prototype, 'publish').callsFake(() => {});
+        mqttPublish = sinon.stub(mqtt.prototype, 'publish').callsFake(() => {});
         controller = new Controller();
         controller.zigbee = {
             getDevice: () => {
@@ -28,7 +27,7 @@ describe('Controller', () => {
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Handling zigbee messages', () => {
@@ -44,7 +43,7 @@ describe('Controller', () => {
         });
 
         it('Should handle a zigbee message when include_device_information is set', () => {
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     mqtt: {
                         include_device_information: true,
@@ -80,7 +79,7 @@ describe('Controller', () => {
         });
 
         it('Should output to attribute', () => {
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     mqtt: {
                         include_device_information: false,

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const assert = require('chai').assert;
 const sinon = require('sinon');
 const Controller = require('../lib/controller');
 const settings = require('../lib/util/settings');
@@ -35,8 +35,8 @@ describe('Controller', () => {
             const device = {ieeeAddr: '0x12345678', modelId: 'TRADFRI bulb E27 CWS opal 600lm'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'devChange', {onOff: 1}, 1);
             controller.onZigbeeMessage(message);
-            chai.assert.isTrue(mqttPublish.calledOnce);
-            chai.assert.strictEqual(
+            assert.isTrue(mqttPublish.calledOnce);
+            assert.strictEqual(
                 mqttPublish.getCall(0).args[1],
                 JSON.stringify({state: 'ON'})
             );
@@ -60,8 +60,8 @@ describe('Controller', () => {
             const device = {ieeeAddr: '0x12345678', modelId: 'TRADFRI bulb E27 CWS opal 600lm'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'devChange', {onOff: 1}, 1);
             controller.onZigbeeMessage(message);
-            chai.assert.isTrue(mqttPublish.calledOnce);
-            chai.assert.strictEqual(
+            assert.isTrue(mqttPublish.calledOnce);
+            assert.strictEqual(
                 mqttPublish.getCall(0).args[1],
                 `{"state":"ON","device":{"ieeeAddr":"0x12345678","friendlyName":"test",` +
                 `"manufName":"IKEA","modelId":"TRADFRI bulb E27 CWS opal 600lm"}}`
@@ -71,8 +71,8 @@ describe('Controller', () => {
         it('Should output to json by default', () => {
             const payload = {temperature: 1, humidity: 2};
             controller.publishEntityState('0x12345678', payload);
-            chai.assert.isTrue(mqttPublish.calledOnce);
-            chai.assert.deepEqual(
+            assert.isTrue(mqttPublish.calledOnce);
+            assert.deepEqual(
                 JSON.parse(mqttPublish.getCall(0).args[1]),
                 payload
             );
@@ -95,11 +95,11 @@ describe('Controller', () => {
 
             const payload = {temperature: 1, humidity: 2};
             controller.publishEntityState('0x12345678', payload);
-            chai.assert.isTrue(mqttPublish.calledTwice);
-            chai.assert.deepEqual(mqttPublish.getCall(0).args[0], 'test/temperature');
-            chai.assert.deepEqual(mqttPublish.getCall(0).args[1], '1');
-            chai.assert.deepEqual(mqttPublish.getCall(1).args[0], 'test/humidity');
-            chai.assert.deepEqual(mqttPublish.getCall(1).args[1], '2');
+            assert.isTrue(mqttPublish.calledTwice);
+            assert.deepEqual(mqttPublish.getCall(0).args[0], 'test/temperature');
+            assert.deepEqual(mqttPublish.getCall(0).args[1], '1');
+            assert.deepEqual(mqttPublish.getCall(1).args[0], 'test/humidity');
+            assert.deepEqual(mqttPublish.getCall(1).args[1], '2');
         });
     });
 });

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const assert = require('chai').assert;
 const data = require('../lib/util/data.js');
 const path = require('path');
 
@@ -7,7 +7,7 @@ describe('Data', () => {
         it('Should return correct path', () => {
             const expected = path.normalize(path.join(__dirname, '..', 'data'));
             const actual = data.getPath();
-            chai.assert.strictEqual(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it('Should return correct path when ZIGBEE2MQTT_DATA set', () => {
@@ -15,7 +15,7 @@ describe('Data', () => {
             process.env.ZIGBEE2MQTT_DATA = expected;
             data._reload();
             const actual = data.getPath();
-            chai.assert.strictEqual(actual, expected);
+            assert.strictEqual(actual, expected);
             delete process.env.ZIGBEE2MQTT_DATA;
             data._reload();
         });

--- a/test/deviceAvailability.test.js
+++ b/test/deviceAvailability.test.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const assert = require('chai').assert;
 const sinon = require('sinon');
 const Availability = require('../lib/extension/deviceAvailability');
 const utils = require('./utils');
@@ -22,7 +22,7 @@ describe('Availability', () => {
                 type: 'Router',
             };
 
-            chai.assert.isTrue(availability.isPingable(device));
+            assert.isTrue(availability.isPingable(device));
         });
 
         it('Battery device should not be a pingable device', () => {
@@ -31,7 +31,7 @@ describe('Availability', () => {
                 type: 'EndDevice',
             };
 
-            chai.assert.isFalse(availability.isPingable(device));
+            assert.isFalse(availability.isPingable(device));
         });
 
         it('E11-G13 should be a pingable device', () => {
@@ -42,7 +42,7 @@ describe('Availability', () => {
                 manufId: 4448,
             };
 
-            chai.assert.isTrue(availability.isPingable(device));
+            assert.isTrue(availability.isPingable(device));
         });
     });
 });

--- a/test/deviceAvailability.test.js
+++ b/test/deviceAvailability.test.js
@@ -2,18 +2,17 @@ const chai = require('chai');
 const sinon = require('sinon');
 const Availability = require('../lib/extension/deviceAvailability');
 const utils = require('./utils');
-const sandbox = sinon.createSandbox();
 
 describe('Availability', () => {
     let availability;
 
     beforeEach(() => {
-        utils.stubLogger(sandbox);
+        utils.stubLogger(sinon);
         availability = new Availability(null, null, null, () => {});
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Determine pingable devices', () => {

--- a/test/devicePublish.test.js
+++ b/test/devicePublish.test.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const assert = require('chai').assert;
 const sinon = require('sinon');
 const DevicePublish = require('../lib/extension/devicePublish');
 const settings = require('../lib/util/settings');
@@ -45,21 +45,21 @@ describe('DevicePublish', () => {
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000001/set', JSON.stringify({brightness: '200'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000001');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 200, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000001');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 200});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000001');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 200, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000001');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 200});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish messages to zigbee devices', async () => {
@@ -68,21 +68,21 @@ describe('DevicePublish', () => {
             sinon.stub(settings, 'getIeeeAddrByFriendlyName').callsFake(() => '0x00000002');
             zigbee.getDevice = sinon.fake.returns({modelId: 'LCT003'});
             devicePublish.onMQTTMessage('zigbee2mqtt/wohnzimmer.light.wall.right/set', JSON.stringify({state: 'ON'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000002');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'on');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000002');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000002');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'on');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000002');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
         it('Should publish messages to zigbee devices when brightness is in %', async () => {
@@ -90,21 +90,21 @@ describe('DevicePublish', () => {
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000003/set', JSON.stringify({brightness_percent: '92'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000003');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 235, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000003');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 235});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000003');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 235, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000003');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 235});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish messages to zigbee devices when brightness is in number', async () => {
@@ -112,38 +112,38 @@ describe('DevicePublish', () => {
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000004/set', JSON.stringify({brightness: 230}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000004');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 230, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000004');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 230});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000004');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 230, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000004');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 230});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish messages to zigbee devices with color_temp', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 WS opal 980lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000005/set', JSON.stringify({color_temp: '222'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000005');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColorTemp');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colortemp: '222', transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000005');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColorTemp');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {colortemp: '222', transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish messages to zigbee devices with color_temp in %', async () => {
@@ -151,35 +151,35 @@ describe('DevicePublish', () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 WS opal 980lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000006/set', JSON.stringify({color_temp_percent: '100'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000006');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColorTemp');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colortemp: '500', transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.notCalled);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000006');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColorTemp');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {colortemp: '500', transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.isTrue(publishEntityState.notCalled);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish messages to zigbee devices with non-default ep', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'lumi.ctrl_neutral1'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000007/set', JSON.stringify({state: 'OFF'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000007');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], 2);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000007');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.strictEqual(zigbee.publish.getCall(0).args[7], 2);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
         it('Should publish messages to zigbee devices with non-default ep and postfix', async () => {
@@ -187,21 +187,21 @@ describe('DevicePublish', () => {
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'lumi.ctrl_neutral2'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000008/right/set', JSON.stringify({state: 'OFF'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000008');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], 3);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000008');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state_right: 'OFF'});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000008');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.strictEqual(zigbee.publish.getCall(0).args[7], 3);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000008');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state_right: 'OFF'});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
         it('Should publish messages to zigbee gledopto with [11,13]', async () => {
@@ -209,21 +209,21 @@ describe('DevicePublish', () => {
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'GLEDOPTO', epList: [11, 13]});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000009/set', JSON.stringify({state: 'OFF'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000009');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], 11);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000009');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000009');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.strictEqual(zigbee.publish.getCall(0).args[7], 11);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000009');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
         it('Should publish messages to zigbee gledopto with [11,12,13]', async () => {
@@ -231,38 +231,38 @@ describe('DevicePublish', () => {
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'GLEDOPTO', epList: [11, 12, 13]});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000010/set', JSON.stringify({state: 'OFF', brightness: 50}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000010');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], 12);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000010');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000010');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.strictEqual(zigbee.publish.getCall(0).args[7], 12);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000010');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
         it('Should publish messages to zigbee devices with color xy', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000011/set', JSON.stringify({color: {x: 100, y: 50}}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000011');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000011');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish messages to zigbee devices with color xy and state', async () => {
@@ -271,29 +271,29 @@ describe('DevicePublish', () => {
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             const payload = {color: {x: 100, y: 50}, state: 'ON'};
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000012/set', JSON.stringify(payload));
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000012');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'on');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000012');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000012');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000012');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'on');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000012');
+            assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
+            assert.strictEqual(zigbee.publish.getCall(1).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000012');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 3);
+            assert.strictEqual(zigbee.publish.callCount, 3);
         });
 
         it('Should publish messages to zigbee devices with color xy and brightness', async () => {
@@ -302,29 +302,29 @@ describe('DevicePublish', () => {
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             const payload = {color: {x: 100, y: 50}, brightness: 20};
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000013/set', JSON.stringify(payload));
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000013');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 20, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000013');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000013');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 20});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000013');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 20, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000013');
+            assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
+            assert.strictEqual(zigbee.publish.getCall(1).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000013');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 20});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 4);
+            assert.strictEqual(zigbee.publish.callCount, 4);
         });
 
         it('Should publish messages to zigbee devices with color xy, brightness and state on', async () => {
@@ -333,29 +333,29 @@ describe('DevicePublish', () => {
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             const payload = {color: {x: 100, y: 50}, brightness: 20, state: 'oN'};
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000014/set', JSON.stringify(payload));
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000014');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 20, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000014');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000014');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 20});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000014');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 20, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000014');
+            assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
+            assert.strictEqual(zigbee.publish.getCall(1).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000014');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 20});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 4);
+            assert.strictEqual(zigbee.publish.callCount, 4);
         });
 
         it('Should publish messages to zigbee devices with color xy, brightness and state off', async () => {
@@ -364,63 +364,63 @@ describe('DevicePublish', () => {
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             const payload = {color: {x: 100, y: 50}, brightness: 20, state: 'oFF'};
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000015/set', JSON.stringify(payload));
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000015');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000015');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000015');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000015');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000015');
+            assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
+            assert.strictEqual(zigbee.publish.getCall(1).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000015');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 3);
+            assert.strictEqual(zigbee.publish.callCount, 3);
         });
 
         it('Should publish messages to zigbee devices with color rgb', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000016/set', JSON.stringify({color: {r: 100, g: 200, b: 10}}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000016');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 17085, colory: 44000, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000016');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 17085, colory: 44000, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish messages to zigbee devices with color rgb string', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000017/set', JSON.stringify({color: {rgb: '100,200,10'}}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000017');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 17085, colory: 44000, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000017');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 17085, colory: 44000, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish 1 message when brightness with state is send', async () => {
@@ -428,21 +428,21 @@ describe('DevicePublish', () => {
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             devicePublish.onMQTTMessage('zigbee2mqtt/0x00000018/set', JSON.stringify({state: 'ON', brightness: '50'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000018');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 50, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000018');
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 50});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000018');
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 50, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000018');
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 50});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
         it('Should publish messages to groups', async () => {
@@ -450,21 +450,21 @@ describe('DevicePublish', () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'ON'}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'on');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'on');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
         it('Should publish messages to groups with brightness_percent', async () => {
@@ -472,21 +472,21 @@ describe('DevicePublish', () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({brightness_percent: 50}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 127, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 127});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 127, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 127});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
         it('Should publish messages to groups with on and brightness', async () => {
@@ -494,21 +494,21 @@ describe('DevicePublish', () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'ON', brightness: 50}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 50, transtime: 0});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 50});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 50, transtime: 0});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 50});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
         it('Should publish messages to groups with off and brightness', async () => {
@@ -516,21 +516,21 @@ describe('DevicePublish', () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'OFF', brightness: 5}));
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
-            chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(publishEntityState.callCount, 1);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
+            assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
+            assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
+            assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
+            assert.strictEqual(zigbee.publish.getCall(0).args[4], 'functional');
+            assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
+            assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
+            assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            assert.strictEqual(publishEntityState.callCount, 1);
+            assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
+            assert.strictEqual(publishEntityState.getCall(0).args[2], true);
             await wait(10);
-            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            assert.strictEqual(zigbee.publish.callCount, 1);
         });
     });
 
@@ -538,47 +538,47 @@ describe('DevicePublish', () => {
         it('Should handle non-valid topics', () => {
             const topic = 'zigbee2mqtt1/my_device_id/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed, null);
+            assert.strictEqual(parsed, null);
         });
 
         it('Should handle non-valid topics', () => {
             const topic = 'zigbee2mqtt1/my_device_id/sett';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed, null);
+            assert.strictEqual(parsed, null);
         });
 
         it('Should handle non-valid topics', () => {
             const topic = 'zigbee2mqtt/my_device_id/write';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed, null);
+            assert.strictEqual(parsed, null);
         });
 
         it('Should handle non-valid topics', () => {
             const topic = 'zigbee2mqtt/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed, null);
+            assert.strictEqual(parsed, null);
         });
 
         it('Should handle non-valid topics', () => {
             const topic = 'set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed, null);
+            assert.strictEqual(parsed, null);
         });
 
         it('Should parse set topic', () => {
             const topic = 'zigbee2mqtt/my_device_id/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, 'my_device_id');
-            chai.assert.strictEqual(parsed.postfix, '');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, 'my_device_id');
+            assert.strictEqual(parsed.postfix, '');
         });
 
         it('Should parse get topic', () => {
             const topic = 'zigbee2mqtt/my_device_id2/get';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'get');
-            chai.assert.strictEqual(parsed.ID, 'my_device_id2');
-            chai.assert.strictEqual(parsed.postfix, '');
+            assert.strictEqual(parsed.type, 'get');
+            assert.strictEqual(parsed.ID, 'my_device_id2');
+            assert.strictEqual(parsed.postfix, '');
         });
 
         it('Should parse topic with when base topic has multiple slashes', () => {
@@ -592,17 +592,17 @@ describe('DevicePublish', () => {
 
             const topic = 'zigbee2mqtt/at/my/home/my_device_id2/get';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'get');
-            chai.assert.strictEqual(parsed.ID, 'my_device_id2');
-            chai.assert.strictEqual(parsed.postfix, '');
+            assert.strictEqual(parsed.type, 'get');
+            assert.strictEqual(parsed.ID, 'my_device_id2');
+            assert.strictEqual(parsed.postfix, '');
         });
 
         it('Should parse topic with when deviceID has multiple slashes', () => {
             const topic = 'zigbee2mqtt/floor0/basement/my_device_id2/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, 'floor0/basement/my_device_id2');
-            chai.assert.strictEqual(parsed.postfix, '');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, 'floor0/basement/my_device_id2');
+            assert.strictEqual(parsed.postfix, '');
         });
 
         it('Should parse topic with when base and deviceID have multiple slashes', () => {
@@ -616,57 +616,57 @@ describe('DevicePublish', () => {
 
             const topic = 'zigbee2mqtt/at/my/basement/floor0/basement/my_device_id2/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, 'floor0/basement/my_device_id2');
-            chai.assert.strictEqual(parsed.postfix, '');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, 'floor0/basement/my_device_id2');
+            assert.strictEqual(parsed.postfix, '');
         });
 
         it('Should parse set with ieeAddr topic', () => {
             const topic = 'zigbee2mqtt/0x12345689/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, '0x12345689');
-            chai.assert.strictEqual(parsed.postfix, '');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, '0x12345689');
+            assert.strictEqual(parsed.postfix, '');
         });
 
         it('Should parse set with postfix topic', () => {
             const topic = 'zigbee2mqtt/0x12345689/left/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, '0x12345689');
-            chai.assert.strictEqual(parsed.postfix, 'left');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, '0x12345689');
+            assert.strictEqual(parsed.postfix, 'left');
         });
 
         it('Should parse set with almost postfix topic', () => {
             const topic = 'zigbee2mqtt/wohnzimmer.light.wall.right/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, 'wohnzimmer.light.wall.right');
-            chai.assert.strictEqual(parsed.postfix, '');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, 'wohnzimmer.light.wall.right');
+            assert.strictEqual(parsed.postfix, '');
         });
 
         it('Should parse set with postfix topic', () => {
             const topic = 'zigbee2mqtt/0x12345689/right/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, '0x12345689');
-            chai.assert.strictEqual(parsed.postfix, 'right');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, '0x12345689');
+            assert.strictEqual(parsed.postfix, 'right');
         });
 
         it('Should parse set with postfix topic', () => {
             const topic = 'zigbee2mqtt/0x12345689/bottom_left/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, '0x12345689');
-            chai.assert.strictEqual(parsed.postfix, 'bottom_left');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, '0x12345689');
+            assert.strictEqual(parsed.postfix, 'bottom_left');
         });
 
         it('Shouldnt parse set with invalid postfix topic', () => {
             const topic = 'zigbee2mqtt/0x12345689/invalid/set';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'set');
-            chai.assert.strictEqual(parsed.ID, '0x12345689/invalid');
-            chai.assert.strictEqual(parsed.postfix, '');
+            assert.strictEqual(parsed.type, 'set');
+            assert.strictEqual(parsed.ID, '0x12345689/invalid');
+            assert.strictEqual(parsed.postfix, '');
         });
 
         it('Should parse set with and slashes in base and deviceID postfix topic', () => {
@@ -680,9 +680,9 @@ describe('DevicePublish', () => {
 
             const topic = 'zigbee2mqtt/at/my/home/my/device/in/basement/sensor/bottom_left/get';
             const parsed = devicePublish.parseTopic(topic);
-            chai.assert.strictEqual(parsed.type, 'get');
-            chai.assert.strictEqual(parsed.ID, 'my/device/in/basement/sensor');
-            chai.assert.strictEqual(parsed.postfix, 'bottom_left');
+            assert.strictEqual(parsed.type, 'get');
+            assert.strictEqual(parsed.ID, 'my/device/in/basement/sensor');
+            assert.strictEqual(parsed.postfix, 'bottom_left');
         });
     });
 
@@ -691,10 +691,10 @@ describe('DevicePublish', () => {
         zigbee.getDevice = sinon.fake.returns({modelId: 'lumi.ctrl_neutral1'});
         devicePublish.onMQTTMessage('zigbee2mqtt/0x00000019/set', JSON.stringify({state: true}));
         await wait(10);
-        chai.assert.isTrue(zigbee.publish.notCalled);
+        assert.isTrue(zigbee.publish.notCalled);
         devicePublish.onMQTTMessage('zigbee2mqtt/0x00000019/set', JSON.stringify({state: 1}));
         await wait(10);
-        chai.assert.isTrue(zigbee.publish.notCalled);
+        assert.isTrue(zigbee.publish.notCalled);
     });
 
     it('Should set state before color', async () => {
@@ -702,15 +702,15 @@ describe('DevicePublish', () => {
         zigbee.getDevice = sinon.fake.returns({modelId: 'LCT001'});
         const msg = {'state': 'ON', 'color': {'x': 0.701, 'y': 0.299}};
         devicePublish.onMQTTMessage('zigbee2mqtt/0x00000020/set', JSON.stringify(msg));
-        chai.assert.equal(zigbee.publish.callCount, 2);
-        chai.assert.equal(zigbee.publish.getCall(0).args[2], 'genOnOff');
-        chai.assert.equal(zigbee.publish.getCall(0).args[3], 'on');
-        chai.assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
-        chai.assert.equal(zigbee.publish.getCall(1).args[3], 'moveToColor');
+        assert.equal(zigbee.publish.callCount, 2);
+        assert.equal(zigbee.publish.getCall(0).args[2], 'genOnOff');
+        assert.equal(zigbee.publish.getCall(0).args[3], 'on');
+        assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+        assert.equal(zigbee.publish.getCall(1).args[3], 'moveToColor');
         await wait(10);
-        chai.assert.equal(zigbee.publish.callCount, 3);
-        chai.assert.equal(zigbee.publish.getCall(2).args[2], 'lightingColorCtrl');
-        chai.assert.equal(zigbee.publish.getCall(2).args[3], 'read');
+        assert.equal(zigbee.publish.callCount, 3);
+        assert.equal(zigbee.publish.getCall(2).args[2], 'lightingColorCtrl');
+        assert.equal(zigbee.publish.getCall(2).args[3], 'read');
     });
 
     it('Should set state with brightness before color', async () => {
@@ -718,10 +718,10 @@ describe('DevicePublish', () => {
         zigbee.getDevice = sinon.fake.returns({modelId: 'LCT001'});
         const msg = {'state': 'ON', 'color': {'x': 0.701, 'y': 0.299}, 'transition': 3, 'brightness': 100};
         devicePublish.onMQTTMessage('zigbee2mqtt/0x00000021/set', JSON.stringify(msg));
-        chai.assert.strictEqual(zigbee.publish.callCount, 2);
-        chai.assert.equal(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-        chai.assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+        assert.strictEqual(zigbee.publish.callCount, 2);
+        assert.equal(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+        assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
         await wait(10);
-        chai.assert.strictEqual(zigbee.publish.callCount, 2);
+        assert.strictEqual(zigbee.publish.callCount, 2);
     });
 });

--- a/test/devicePublish.test.js
+++ b/test/devicePublish.test.js
@@ -3,7 +3,6 @@ const sinon = require('sinon');
 const DevicePublish = require('../lib/extension/devicePublish');
 const settings = require('../lib/util/settings');
 const utils = require('./utils');
-const sandbox = sinon.createSandbox();
 
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -13,12 +12,12 @@ const mqtt = {
 
 const zigbee = {
     getDevice: null,
-    publish: sandbox.stub().callsFake((entityID, entityType, cid, cmd, cmdType, zclData, cfg, ep, callback) => {
+    publish: sinon.stub().callsFake((entityID, entityType, cid, cmd, cmdType, zclData, cfg, ep, callback) => {
         callback(false, null);
     }),
 };
 
-const publishEntityState = sandbox.stub().callsFake((entityID, payload, cache) => {
+const publishEntityState = sinon.stub().callsFake((entityID, payload, cache) => {
 });
 
 const cfg = {
@@ -32,12 +31,12 @@ describe('DevicePublish', () => {
     let devicePublish;
 
     beforeEach(() => {
-        utils.stubLogger(sandbox);
+        utils.stubLogger(sinon);
         devicePublish = new DevicePublish(zigbee, mqtt, null, publishEntityState);
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Parse topic', () => {
@@ -66,7 +65,7 @@ describe('DevicePublish', () => {
         it('Should publish messages to zigbee devices', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
-            sandbox.stub(settings, 'getIeeeAddrByFriendlyName').callsFake(() => '0x00000002');
+            sinon.stub(settings, 'getIeeeAddrByFriendlyName').callsFake(() => '0x00000002');
             zigbee.getDevice = sinon.fake.returns({modelId: 'LCT003'});
             devicePublish.onMQTTMessage('zigbee2mqtt/wohnzimmer.light.wall.right/set', JSON.stringify({state: 'ON'}));
             chai.assert.strictEqual(zigbee.publish.callCount, 1);
@@ -447,7 +446,7 @@ describe('DevicePublish', () => {
         });
 
         it('Should publish messages to groups', async () => {
-            sandbox.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
+            sinon.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'ON'}));
@@ -469,7 +468,7 @@ describe('DevicePublish', () => {
         });
 
         it('Should publish messages to groups with brightness_percent', async () => {
-            sandbox.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
+            sinon.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({brightness_percent: 50}));
@@ -491,7 +490,7 @@ describe('DevicePublish', () => {
         });
 
         it('Should publish messages to groups with on and brightness', async () => {
-            sandbox.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
+            sinon.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'ON', brightness: 50}));
@@ -513,7 +512,7 @@ describe('DevicePublish', () => {
         });
 
         it('Should publish messages to groups with off and brightness', async () => {
-            sandbox.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
+            sinon.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'OFF', brightness: 5}));
@@ -583,7 +582,7 @@ describe('DevicePublish', () => {
         });
 
         it('Should parse topic with when base topic has multiple slashes', () => {
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     mqtt: {
                         base_topic: 'zigbee2mqtt/at/my/home',
@@ -607,7 +606,7 @@ describe('DevicePublish', () => {
         });
 
         it('Should parse topic with when base and deviceID have multiple slashes', () => {
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     mqtt: {
                         base_topic: 'zigbee2mqtt/at/my/basement',
@@ -671,7 +670,7 @@ describe('DevicePublish', () => {
         });
 
         it('Should parse set with and slashes in base and deviceID postfix topic', () => {
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     mqtt: {
                         base_topic: 'zigbee2mqtt/at/my/home',

--- a/test/devicePublish.test.js
+++ b/test/devicePublish.test.js
@@ -5,6 +5,8 @@ const settings = require('../lib/util/settings');
 const utils = require('./utils');
 const sandbox = sinon.createSandbox();
 
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 const mqtt = {
     subscribe: (topic) => {},
 };
@@ -39,13 +41,13 @@ describe('DevicePublish', () => {
     });
 
     describe('Parse topic', () => {
-        it('Should publish messages to zigbee devices', () => {
+        it('Should publish messages to zigbee devices', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({brightness: '200'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000001/set', JSON.stringify({brightness: '200'}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000001');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
@@ -53,20 +55,22 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 200, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000001');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 200});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish messages to zigbee devices', () => {
+        it('Should publish messages to zigbee devices', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
-            sandbox.stub(settings, 'getIeeeAddrByFriendlyName').callsFake(() => '0x12345666');
+            sandbox.stub(settings, 'getIeeeAddrByFriendlyName').callsFake(() => '0x00000002');
             zigbee.getDevice = sinon.fake.returns({modelId: 'LCT003'});
             devicePublish.onMQTTMessage('zigbee2mqtt/wohnzimmer.light.wall.right/set', JSON.stringify({state: 'ON'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345666');
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000002');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'on');
@@ -74,19 +78,21 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345666');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000002');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
-        it('Should publish messages to zigbee devices when brightness is in %', () => {
+        it('Should publish messages to zigbee devices when brightness is in %', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({brightness_percent: '92'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000003/set', JSON.stringify({brightness_percent: '92'}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000003');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
@@ -94,19 +100,21 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 235, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000003');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 235});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish messages to zigbee devices when brightness is in number', () => {
+        it('Should publish messages to zigbee devices when brightness is in number', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({brightness: 230}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000004/set', JSON.stringify({brightness: 230}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000004');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
@@ -114,18 +122,20 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 230, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000004');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 230});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish messages to zigbee devices with color_temp', () => {
+        it('Should publish messages to zigbee devices with color_temp', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 WS opal 980lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({color_temp: '222'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000005/set', JSON.stringify({color_temp: '222'}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000005');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColorTemp');
@@ -133,15 +143,17 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colortemp: '222', transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish messages to zigbee devices with color_temp in %', () => {
+        it('Should publish messages to zigbee devices with color_temp in %', async () => {
             publishEntityState.resetHistory();
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 WS opal 980lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({color_temp_percent: '100'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000006/set', JSON.stringify({color_temp_percent: '100'}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000006');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColorTemp');
@@ -150,14 +162,16 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
             chai.assert.isTrue(publishEntityState.notCalled);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish messages to zigbee devices with non-default ep', () => {
+        it('Should publish messages to zigbee devices with non-default ep', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'lumi.ctrl_neutral1'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({state: 'OFF'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000007/set', JSON.stringify({state: 'OFF'}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000007');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
@@ -165,15 +179,17 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], 2);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
-        it('Should publish messages to zigbee devices with non-default ep and postfix', () => {
+        it('Should publish messages to zigbee devices with non-default ep and postfix', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'lumi.ctrl_neutral2'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/right/set', JSON.stringify({state: 'OFF'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000008/right/set', JSON.stringify({state: 'OFF'}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000008');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
@@ -181,19 +197,21 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], 3);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000008');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state_right: 'OFF'});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
-        it('Should publish messages to zigbee gledopto with [11,13]', () => {
+        it('Should publish messages to zigbee gledopto with [11,13]', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'GLEDOPTO', epList: [11, 13]});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({state: 'OFF'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000009/set', JSON.stringify({state: 'OFF'}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000009');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
@@ -201,19 +219,21 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], 11);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000009');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
-        it('Should publish messages to zigbee gledopto with [11,12,13]', () => {
+        it('Should publish messages to zigbee gledopto with [11,12,13]', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'GLEDOPTO', epList: [11, 12, 13]});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({state: 'OFF', brightness: 50}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000010/set', JSON.stringify({state: 'OFF', brightness: 50}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000010');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
@@ -221,18 +241,20 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], 12);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000010');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
-        it('Should publish messages to zigbee devices with color xy', () => {
+        it('Should publish messages to zigbee devices with color xy', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({color: {x: 100, y: 50}}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000011/set', JSON.stringify({color: {x: 100, y: 50}}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000011');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
@@ -240,16 +262,18 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish messages to zigbee devices with color xy and state', () => {
+        it('Should publish messages to zigbee devices with color xy and state', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             const payload = {color: {x: 100, y: 50}, state: 'ON'};
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify(payload));
-            chai.assert.isTrue(zigbee.publish.calledTwice);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000012/set', JSON.stringify(payload));
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000012');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'on');
@@ -257,7 +281,7 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x12345678');
+            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000012');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
@@ -265,20 +289,22 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000012');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 3);
         });
 
-        it('Should publish messages to zigbee devices with color xy and brightness', () => {
+        it('Should publish messages to zigbee devices with color xy and brightness', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             const payload = {color: {x: 100, y: 50}, brightness: 20};
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify(payload));
-            chai.assert.isTrue(zigbee.publish.calledTwice);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000013/set', JSON.stringify(payload));
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000013');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
@@ -286,7 +312,7 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 20, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x12345678');
+            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000013');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
@@ -294,20 +320,22 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000013');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 20});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 4);
         });
 
-        it('Should publish messages to zigbee devices with color xy, brightness and state on', () => {
+        it('Should publish messages to zigbee devices with color xy, brightness and state on', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             const payload = {color: {x: 100, y: 50}, brightness: 20, state: 'oN'};
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify(payload));
-            chai.assert.isTrue(zigbee.publish.calledTwice);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000014/set', JSON.stringify(payload));
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000014');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
@@ -315,7 +343,7 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 20, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x12345678');
+            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000014');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
@@ -323,20 +351,22 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000014');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 20});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 4);
         });
 
-        it('Should publish messages to zigbee devices with color xy, brightness and state off', () => {
+        it('Should publish messages to zigbee devices with color xy, brightness and state off', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
             const payload = {color: {x: 100, y: 50}, brightness: 20, state: 'oFF'};
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify(payload));
-            chai.assert.isTrue(zigbee.publish.calledTwice);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000015/set', JSON.stringify(payload));
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000015');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'off');
@@ -344,7 +374,7 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x12345678');
+            chai.assert.strictEqual(zigbee.publish.getCall(1).args[0], '0x00000015');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(1).args[3], 'moveToColor');
@@ -352,18 +382,20 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[5], {colorx: 6553500, colory: 3276750, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(1).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000015');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 3);
         });
 
-        it('Should publish messages to zigbee devices with color rgb', () => {
+        it('Should publish messages to zigbee devices with color rgb', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({color: {r: 100, g: 200, b: 10}}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000016/set', JSON.stringify({color: {r: 100, g: 200, b: 10}}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000016');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
@@ -371,14 +403,16 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 17085, colory: 44000, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish messages to zigbee devices with color rgb string', () => {
+        it('Should publish messages to zigbee devices with color rgb string', async () => {
             zigbee.publish.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({color: {rgb: '100,200,10'}}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000017/set', JSON.stringify({color: {rgb: '100,200,10'}}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000017');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'lightingColorCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToColor');
@@ -386,15 +420,17 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {colorx: 17085, colory: 44000, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish 1 message when brightness with state is send', () => {
+        it('Should publish 1 message when brightness with state is send', async () => {
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             zigbee.getDevice = sinon.fake.returns({modelId: 'TRADFRI bulb E27 CWS opal 600lm'});
-            devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({state: 'ON', brightness: '50'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
-            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x12345678');
+            devicePublish.onMQTTMessage('zigbee2mqtt/0x00000018/set', JSON.stringify({state: 'ON', brightness: '50'}));
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
+            chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], '0x00000018');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'device');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[3], 'moveToLevelWithOnOff');
@@ -402,18 +438,20 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 50, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x12345678');
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
+            chai.assert.strictEqual(publishEntityState.getCall(0).args[0], '0x00000018');
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 50});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 2);
         });
 
-        it('Should publish messages to groups', () => {
+        it('Should publish messages to groups', async () => {
             sandbox.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'ON'}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
@@ -422,18 +460,20 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
             chai.assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON'});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
-        it('Should publish messages to groups with brightness_percent', () => {
+        it('Should publish messages to groups with brightness_percent', async () => {
             sandbox.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({brightness_percent: 50}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
@@ -442,18 +482,20 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 127, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
             chai.assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 127});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
-        it('Should publish messages to groups with on and brightness', () => {
+        it('Should publish messages to groups with on and brightness', async () => {
             sandbox.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'ON', brightness: 50}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
@@ -462,18 +504,20 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {level: 50, transtime: 0});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
             chai.assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'ON', brightness: 50});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
 
-        it('Should publish messages to groups with off and brightness', () => {
+        it('Should publish messages to groups with off and brightness', async () => {
             sandbox.stub(settings, 'getGroupIDByFriendlyName').callsFake(() => '1');
             zigbee.publish.resetHistory();
             publishEntityState.resetHistory();
             devicePublish.onMQTTMessage('zigbee2mqtt/group/group_1/set', JSON.stringify({state: 'OFF', brightness: 5}));
-            chai.assert.isTrue(zigbee.publish.calledOnce);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[0], 1);
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[1], 'group');
             chai.assert.strictEqual(zigbee.publish.getCall(0).args[2], 'genOnOff');
@@ -482,10 +526,12 @@ describe('DevicePublish', () => {
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[5], {});
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[6], cfg.default);
             chai.assert.deepEqual(zigbee.publish.getCall(0).args[7], null);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            chai.assert.strictEqual(publishEntityState.callCount, 1);
             chai.assert.strictEqual(publishEntityState.getCall(0).args[0], 1);
             chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {state: 'OFF'});
             chai.assert.strictEqual(publishEntityState.getCall(0).args[2], true);
+            await wait(10);
+            chai.assert.strictEqual(zigbee.publish.callCount, 1);
         });
     });
 
@@ -641,42 +687,42 @@ describe('DevicePublish', () => {
         });
     });
 
-    it('Should not publish messages to zigbee devices when payload is invalid', () => {
+    it('Should not publish messages to zigbee devices when payload is invalid', async () => {
         zigbee.publish.resetHistory();
         zigbee.getDevice = sinon.fake.returns({modelId: 'lumi.ctrl_neutral1'});
-        devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({state: true}));
+        devicePublish.onMQTTMessage('zigbee2mqtt/0x00000019/set', JSON.stringify({state: true}));
+        await wait(10);
         chai.assert.isTrue(zigbee.publish.notCalled);
-        devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify({state: 1}));
+        devicePublish.onMQTTMessage('zigbee2mqtt/0x00000019/set', JSON.stringify({state: 1}));
+        await wait(10);
         chai.assert.isTrue(zigbee.publish.notCalled);
     });
 
-    it('Should set state before color', (done) => {
+    it('Should set state before color', async () => {
         zigbee.publish.resetHistory();
         zigbee.getDevice = sinon.fake.returns({modelId: 'LCT001'});
         const msg = {'state': 'ON', 'color': {'x': 0.701, 'y': 0.299}};
-        devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify(msg));
-        setTimeout(() => {
-            chai.assert.equal(zigbee.publish.callCount, 3);
-            chai.assert.equal(zigbee.publish.getCall(0).args[2], 'genOnOff');
-            chai.assert.equal(zigbee.publish.getCall(0).args[3], 'on');
-            chai.assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
-            chai.assert.equal(zigbee.publish.getCall(1).args[3], 'moveToColor');
-            chai.assert.equal(zigbee.publish.getCall(2).args[2], 'lightingColorCtrl');
-            chai.assert.equal(zigbee.publish.getCall(2).args[3], 'read');
-            done();
-        }, 300);
+        devicePublish.onMQTTMessage('zigbee2mqtt/0x00000020/set', JSON.stringify(msg));
+        chai.assert.equal(zigbee.publish.callCount, 2);
+        chai.assert.equal(zigbee.publish.getCall(0).args[2], 'genOnOff');
+        chai.assert.equal(zigbee.publish.getCall(0).args[3], 'on');
+        chai.assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+        chai.assert.equal(zigbee.publish.getCall(1).args[3], 'moveToColor');
+        await wait(10);
+        chai.assert.equal(zigbee.publish.callCount, 3);
+        chai.assert.equal(zigbee.publish.getCall(2).args[2], 'lightingColorCtrl');
+        chai.assert.equal(zigbee.publish.getCall(2).args[3], 'read');
     });
 
-    it('Should set state with brightness before color', (done) => {
+    it('Should set state with brightness before color', async () => {
         zigbee.publish.resetHistory();
         zigbee.getDevice = sinon.fake.returns({modelId: 'LCT001'});
         const msg = {'state': 'ON', 'color': {'x': 0.701, 'y': 0.299}, 'transition': 3, 'brightness': 100};
-        devicePublish.onMQTTMessage('zigbee2mqtt/0x12345678/set', JSON.stringify(msg));
-        setTimeout(() => {
-            chai.assert.isTrue(zigbee.publish.calledTwice);
-            chai.assert.equal(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
-            chai.assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
-            done();
-        }, 300);
+        devicePublish.onMQTTMessage('zigbee2mqtt/0x00000021/set', JSON.stringify(msg));
+        chai.assert.strictEqual(zigbee.publish.callCount, 2);
+        chai.assert.equal(zigbee.publish.getCall(0).args[2], 'genLevelCtrl');
+        chai.assert.equal(zigbee.publish.getCall(1).args[2], 'lightingColorCtrl');
+        await wait(10);
+        chai.assert.strictEqual(zigbee.publish.callCount, 2);
     });
 });

--- a/test/deviceReceive.test.js
+++ b/test/deviceReceive.test.js
@@ -4,7 +4,6 @@ const DeviceReceive = require('../lib/extension/deviceReceive');
 const settings = require('../lib/util/settings');
 const devices = require('zigbee-shepherd-converters').devices;
 const utils = require('./utils');
-const sandbox = sinon.createSandbox();
 
 // Devices
 const WXKG11LM = devices.find((d) => d.model === 'WXKG11LM');
@@ -21,14 +20,14 @@ describe('DeviceReceive', () => {
     let publishEntityState;
 
     beforeEach(() => {
-        utils.stubLogger(sandbox);
-        sandbox.stub(settings, 'addDevice').callsFake(() => {});
+        utils.stubLogger(sinon);
+        sinon.stub(settings, 'addDevice').callsFake(() => {});
         publishEntityState = sinon.spy();
         deviceReceive = new DeviceReceive(null, mqtt, null, publishEntityState);
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Handling zigbee messages', () => {
@@ -68,7 +67,7 @@ describe('DeviceReceive', () => {
 
         it('Should handle a zigbee message with 1 precision', () => {
             const device = {ieeeAddr: '0x12345678'};
-            sandbox.stub(settings, 'getDevice').callsFake(() => {
+            sinon.stub(settings, 'getDevice').callsFake(() => {
                 return {temperature_precision: 1};
             });
             const message = utils.zigbeeMessage(
@@ -81,7 +80,7 @@ describe('DeviceReceive', () => {
 
         it('Should handle a zigbee message with 0 precision', () => {
             const device = {ieeeAddr: '0x12345678'};
-            sandbox.stub(settings, 'getDevice').callsFake(() => {
+            sinon.stub(settings, 'getDevice').callsFake(() => {
                 return {temperature_precision: 0};
             });
             const message = utils.zigbeeMessage(
@@ -94,7 +93,7 @@ describe('DeviceReceive', () => {
 
         it('Should handle a zigbee message with 1 precision when set via device_options', () => {
             const device = {ieeeAddr: '0x12345678'};
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     device_options: {
                         temperature_precision: 1,
@@ -104,7 +103,7 @@ describe('DeviceReceive', () => {
                     },
                 };
             });
-            sandbox.stub(settings, 'getDevice').callsFake(() => {
+            sinon.stub(settings, 'getDevice').callsFake(() => {
                 return {};
             });
             const message = utils.zigbeeMessage(
@@ -117,7 +116,7 @@ describe('DeviceReceive', () => {
 
         it('Should handle a zigbee message with 2 precision when overrides device_options', () => {
             const device = {ieeeAddr: '0x12345678'};
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     device_options: {
                         temperature_precision: 1,
@@ -127,7 +126,7 @@ describe('DeviceReceive', () => {
                     },
                 };
             });
-            sandbox.stub(settings, 'getDevice').callsFake(() => {
+            sinon.stub(settings, 'getDevice').callsFake(() => {
                 return {
                     temperature_precision: 2,
                 };
@@ -199,7 +198,7 @@ describe('DeviceReceive', () => {
         it('Should publish last_seen epoch', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     advanced: {
                         last_seen: 'epoch',
@@ -214,7 +213,7 @@ describe('DeviceReceive', () => {
         it('Should publish last_seen ISO_8601', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     advanced: {
                         last_seen: 'ISO_8601',
@@ -229,7 +228,7 @@ describe('DeviceReceive', () => {
         it('Should publish last_seen ISO_8601_local', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
-            sandbox.stub(settings, 'get').callsFake(() => {
+            sinon.stub(settings, 'get').callsFake(() => {
                 return {
                     advanced: {
                         last_seen: 'ISO_8601_local',

--- a/test/deviceReceive.test.js
+++ b/test/deviceReceive.test.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const assert = require('chai').assert;
 const sinon = require('sinon');
 const DeviceReceive = require('../lib/extension/deviceReceive');
 const settings = require('../lib/util/settings');
@@ -35,24 +35,24 @@ describe('DeviceReceive', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG11LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {click: 'single'});
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {click: 'single'});
         });
 
         it('Should handle a zigbee message which uses ep (left)', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {click: 'left'});
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {click: 'left'});
         });
 
         it('Should handle a zigbee message which uses ep (right)', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 2);
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {click: 'right'});
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {click: 'right'});
         });
 
         it('Should handle a zigbee message with default precision', () => {
@@ -61,8 +61,8 @@ describe('DeviceReceive', () => {
                 device, 'msTemperatureMeasurement', 'attReport', {measuredValue: -85}, 1
             );
             deviceReceive.onZigbeeMessage(message, device, WSDCGQ11LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -0.85});
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -0.85});
         });
 
         it('Should handle a zigbee message with 1 precision', () => {
@@ -74,8 +74,8 @@ describe('DeviceReceive', () => {
                 device, 'msTemperatureMeasurement', 'attReport', {measuredValue: -85}, 1
             );
             deviceReceive.onZigbeeMessage(message, device, WSDCGQ11LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -0.8});
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -0.8});
         });
 
         it('Should handle a zigbee message with 0 precision', () => {
@@ -87,8 +87,8 @@ describe('DeviceReceive', () => {
                 device, 'msTemperatureMeasurement', 'attReport', {measuredValue: -85}, 1
             );
             deviceReceive.onZigbeeMessage(message, device, WSDCGQ11LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -1});
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -1});
         });
 
         it('Should handle a zigbee message with 1 precision when set via device_options', () => {
@@ -110,8 +110,8 @@ describe('DeviceReceive', () => {
                 device, 'msTemperatureMeasurement', 'attReport', {measuredValue: -85}, 1
             );
             deviceReceive.onZigbeeMessage(message, device, WSDCGQ11LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -0.8});
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -0.8});
         });
 
         it('Should handle a zigbee message with 2 precision when overrides device_options', () => {
@@ -135,44 +135,44 @@ describe('DeviceReceive', () => {
                 device, 'msTemperatureMeasurement', 'attReport', {measuredValue: -85}, 1
             );
             deviceReceive.onZigbeeMessage(message, device, WSDCGQ11LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -0.85});
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], {temperature: -0.85});
         });
 
         it('Should handle a zigbee message with voltage 3010', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genBasic', 'attReport', {'65281': {'1': 3010}}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            assert.isTrue(publishEntityState.calledOnce);
             const expected = {battery: 100, voltage: 3010};
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
         });
 
         it('Should handle a zigbee message with voltage 2850', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genBasic', 'attReport', {'65281': {'1': 2850}}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            assert.isTrue(publishEntityState.calledOnce);
             const expected = {battery: 35, voltage: 2850};
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
         });
 
         it('Should handle a zigbee message with voltage 2650', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genBasic', 'attReport', {'65281': {'1': 2650}}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            assert.isTrue(publishEntityState.calledOnce);
             const expected = {battery: 14, voltage: 2650};
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
         });
 
         it('Should handle a zigbee message with voltage 2000', () => {
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genBasic', 'attReport', {'65281': {'1': 2000}}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            assert.isTrue(publishEntityState.calledOnce);
             const expected = {battery: 0, voltage: 2000};
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
         });
 
         it('Should publish 1 message when converted twice', () => {
@@ -182,9 +182,9 @@ describe('DeviceReceive', () => {
             };
             const message = utils.zigbeeMessage(device, 'genBasic', 'attReport', payload, 1);
             deviceReceive.onZigbeeMessage(message, device, RTCGQ11LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
+            assert.isTrue(publishEntityState.calledOnce);
             const expected = {'battery': 100, 'illuminance': 381, 'voltage': 3045};
-            chai.assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
+            assert.deepEqual(publishEntityState.getCall(0).args[1], expected);
         });
 
         it('Should publish no message when converted without result', () => {
@@ -192,7 +192,7 @@ describe('DeviceReceive', () => {
             const payload = {'9999': {'1': 3045}};
             const message = utils.zigbeeMessage(device, 'genBasic', 'attReport', payload, 1);
             deviceReceive.onZigbeeMessage(message, device, RTCGQ11LM);
-            chai.assert.isTrue(publishEntityState.notCalled);
+            assert.isTrue(publishEntityState.notCalled);
         });
 
         it('Should publish last_seen epoch', () => {
@@ -206,8 +206,8 @@ describe('DeviceReceive', () => {
                 };
             });
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.equal(typeof publishEntityState.getCall(0).args[1].last_seen, 'number');
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.equal(typeof publishEntityState.getCall(0).args[1].last_seen, 'number');
         });
 
         it('Should publish last_seen ISO_8601', () => {
@@ -221,8 +221,8 @@ describe('DeviceReceive', () => {
                 };
             });
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.equal(typeof publishEntityState.getCall(0).args[1].last_seen, 'string');
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.equal(typeof publishEntityState.getCall(0).args[1].last_seen, 'string');
         });
 
         it('Should publish last_seen ISO_8601_local', () => {
@@ -236,8 +236,8 @@ describe('DeviceReceive', () => {
                 };
             });
             deviceReceive.onZigbeeMessage(message, device, WXKG02LM);
-            chai.assert.isTrue(publishEntityState.calledOnce);
-            chai.assert.equal(typeof publishEntityState.getCall(0).args[1].last_seen, 'string');
+            assert.isTrue(publishEntityState.calledOnce);
+            assert.equal(typeof publishEntityState.getCall(0).args[1].last_seen, 'string');
         });
     });
 });

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -1,6 +1,6 @@
 const devices = require('zigbee-shepherd-converters').devices;
 const HomeassistantExtension = require('../lib/extension/homeassistant');
-const chai = require('chai');
+const assert = require('chai').assert;
 const sinon = require('sinon');
 const settings = require('../lib/util/settings');
 
@@ -33,7 +33,7 @@ describe('HomeAssistant extension', () => {
             }
         });
 
-        chai.assert.strictEqual(missing.length, 0, `Missing HomeAssistant mapping for: ${missing.join(', ')}`);
+        assert.strictEqual(missing.length, 0, `Missing HomeAssistant mapping for: ${missing.join(', ')}`);
     });
 
     it('Should discover devices', () => {
@@ -43,7 +43,7 @@ describe('HomeAssistant extension', () => {
         });
 
         homeassistant.discover('0x12345678', WSDCGQ11LM, false);
-        chai.assert.equal(mqtt.publish.callCount, 5);
+        assert.equal(mqtt.publish.callCount, 5);
 
         // 1
         payload = {
@@ -64,10 +64,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(0).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(0).args[3], null);
+        assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
 
         // 2
         payload = {
@@ -88,10 +88,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(1).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(1).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(1).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(1).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(1).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(1).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(1).args[3], null);
+        assert.equal(mqtt.publish.getCall(1).args[4], 'homeassistant');
 
         // 3
         payload = {
@@ -112,10 +112,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(2).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(2).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(2).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(2).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(2).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(2).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(2).args[3], null);
+        assert.equal(mqtt.publish.getCall(2).args[4], 'homeassistant');
 
         // 4
         payload = {
@@ -136,10 +136,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(3).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(3).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(3).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(3).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(3).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(3).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(3).args[3], null);
+        assert.equal(mqtt.publish.getCall(3).args[4], 'homeassistant');
 
         // 5
         payload = {
@@ -159,10 +159,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(4).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(4).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(4).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(4).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(4).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(4).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(4).args[3], null);
+        assert.equal(mqtt.publish.getCall(4).args[4], 'homeassistant');
     });
 
     it('Should discover devices with precision', () => {
@@ -177,7 +177,7 @@ describe('HomeAssistant extension', () => {
         });
 
         homeassistant.discover('0x12345678', WSDCGQ11LM, false);
-        chai.assert.equal(mqtt.publish.callCount, 5);
+        assert.equal(mqtt.publish.callCount, 5);
 
         // 1
         payload = {
@@ -198,10 +198,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(0).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(0).args[3], null);
+        assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
 
         // 2
         payload = {
@@ -222,10 +222,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(1).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(1).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(1).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(1).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(1).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(1).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(1).args[3], null);
+        assert.equal(mqtt.publish.getCall(1).args[4], 'homeassistant');
 
         // 3
         payload = {
@@ -246,10 +246,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(2).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(2).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(2).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(2).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(2).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(2).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(2).args[3], null);
+        assert.equal(mqtt.publish.getCall(2).args[4], 'homeassistant');
 
         // 4
         payload = {
@@ -270,10 +270,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(3).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(3).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(3).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(3).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(3).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(3).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(3).args[3], null);
+        assert.equal(mqtt.publish.getCall(3).args[4], 'homeassistant');
 
         // 5
         payload = {
@@ -293,10 +293,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(4).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(4).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(4).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(4).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(4).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(4).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(4).args[3], null);
+        assert.equal(mqtt.publish.getCall(4).args[4], 'homeassistant');
     });
 
     it('Should discover devices with overriden user configuration', () => {
@@ -315,7 +315,7 @@ describe('HomeAssistant extension', () => {
         });
 
         homeassistant.discover('0x12345678', WSDCGQ11LM, false);
-        chai.assert.equal(mqtt.publish.callCount, 5);
+        assert.equal(mqtt.publish.callCount, 5);
 
         // 1
         payload = {
@@ -338,10 +338,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(0).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(0).args[3], null);
+        assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
 
         // 2
         payload = {
@@ -364,10 +364,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(1).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(1).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(1).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(1).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(1).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(1).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(1).args[3], null);
+        assert.equal(mqtt.publish.getCall(1).args[4], 'homeassistant');
 
         // 3
         payload = {
@@ -390,10 +390,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(2).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(2).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(2).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(2).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(2).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(2).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(2).args[3], null);
+        assert.equal(mqtt.publish.getCall(2).args[4], 'homeassistant');
 
         // 4
         payload = {
@@ -416,10 +416,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(3).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(3).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(3).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(3).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(3).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(3).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(3).args[3], null);
+        assert.equal(mqtt.publish.getCall(3).args[4], 'homeassistant');
 
         // 5
         payload = {
@@ -441,10 +441,10 @@ describe('HomeAssistant extension', () => {
             'availability_topic': 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(4).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(4).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(4).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(4).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(4).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(4).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(4).args[3], null);
+        assert.equal(mqtt.publish.getCall(4).args[4], 'homeassistant');
     });
 
     it('Should discover devices with cover_position', () => {
@@ -454,7 +454,7 @@ describe('HomeAssistant extension', () => {
         });
 
         homeassistant.discover('0x12345678', SV01, false);
-        chai.assert.equal(mqtt.publish.callCount, 5);
+        assert.equal(mqtt.publish.callCount, 5);
 
         // 1
         payload = {
@@ -475,9 +475,9 @@ describe('HomeAssistant extension', () => {
             availability_topic: 'zigbee2mqtt/bridge/state',
         };
 
-        chai.assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
-        chai.assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
-        chai.assert.equal(mqtt.publish.getCall(0).args[3], null);
-        chai.assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
+        assert.deepEqual(JSON.parse(mqtt.publish.getCall(0).args[1]), payload);
+        assert.deepEqual(mqtt.publish.getCall(0).args[2], {retain: true, qos: 0});
+        assert.equal(mqtt.publish.getCall(0).args[3], null);
+        assert.equal(mqtt.publish.getCall(0).args[4], 'homeassistant');
     });
 });

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -2,7 +2,6 @@ const devices = require('zigbee-shepherd-converters').devices;
 const HomeassistantExtension = require('../lib/extension/homeassistant');
 const chai = require('chai');
 const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
 const settings = require('../lib/util/settings');
 
 const WSDCGQ11LM = devices.find((d) => d.model === 'WSDCGQ11LM');
@@ -22,7 +21,7 @@ describe('HomeAssistant extension', () => {
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('Should have mapping for all devices supported by zigbee-shepherd-converters', () => {
@@ -39,7 +38,7 @@ describe('HomeAssistant extension', () => {
 
     it('Should discover devices', () => {
         let payload = null;
-        sandbox.stub(settings, 'getDevice').callsFake(() => {
+        sinon.stub(settings, 'getDevice').callsFake(() => {
             return {friendly_name: 'my_device'};
         });
 
@@ -168,7 +167,7 @@ describe('HomeAssistant extension', () => {
 
     it('Should discover devices with precision', () => {
         let payload = null;
-        sandbox.stub(settings, 'getDevice').callsFake(() => {
+        sinon.stub(settings, 'getDevice').callsFake(() => {
             return {
                 friendly_name: 'my_device',
                 humidity_precision: 0,
@@ -302,7 +301,7 @@ describe('HomeAssistant extension', () => {
 
     it('Should discover devices with overriden user configuration', () => {
         let payload = null;
-        sandbox.stub(settings, 'getDevice').callsFake(() => {
+        sinon.stub(settings, 'getDevice').callsFake(() => {
             return {
                 friendly_name: 'my_device',
                 homeassistant: {
@@ -450,7 +449,7 @@ describe('HomeAssistant extension', () => {
 
     it('Should discover devices with cover_position', () => {
         let payload = null;
-        sandbox.stub(settings, 'getDevice').callsFake(() => {
+        sinon.stub(settings, 'getDevice').callsFake(() => {
             return {friendly_name: 'my_device'};
         });
 

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const assert = require('chai').assert;
 const sinon = require('sinon');
 const data = require('../lib/util/data');
 const proxyquire = require('proxyquire').noPreserveCache();
@@ -44,7 +44,7 @@ describe('Settings', () => {
         it('Should return default settings', () => {
             setup({});
             const s = settings.get();
-            chai.assert.deepEqual(s, settings._getDefaults());
+            assert.deepEqual(s, settings._getDefaults());
         });
 
         it('Should return settings', () => {
@@ -52,7 +52,7 @@ describe('Settings', () => {
             const s = settings.get();
             const expected = settings._getDefaults();
             expected.permit_join = true;
-            chai.assert.deepEqual(s, expected);
+            assert.deepEqual(s, expected);
         });
 
         it('Should add devices', () => {
@@ -69,7 +69,7 @@ describe('Settings', () => {
                 },
             };
 
-            chai.assert.deepEqual(actual, expected);
+            assert.deepEqual(actual, expected);
         });
 
         it('Should read devices', () => {
@@ -90,7 +90,7 @@ describe('Settings', () => {
                 retain: false,
             };
 
-            chai.assert.deepEqual(device, expected);
+            assert.deepEqual(device, expected);
         });
 
         it('Should read devices form a seperate file', () => {
@@ -114,7 +114,7 @@ describe('Settings', () => {
                 retain: false,
             };
 
-            chai.assert.deepEqual(device, expected);
+            assert.deepEqual(device, expected);
         });
 
         it('Should add devices to a seperate file', () => {
@@ -135,7 +135,7 @@ describe('Settings', () => {
 
             settings.addDevice('0x1234');
 
-            chai.assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
+            assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
 
             const expected = {
                 '0x12345678': {
@@ -148,7 +148,7 @@ describe('Settings', () => {
                 },
             };
 
-            chai.assert.deepEqual(read(devicesFile), expected);
+            assert.deepEqual(read(devicesFile), expected);
         });
 
         it('Should add devices to a seperate file if devices.yaml doesnt exist', () => {
@@ -161,7 +161,7 @@ describe('Settings', () => {
 
             settings.addDevice('0x1234');
 
-            chai.assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
+            assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
 
             const expected = {
                 '0x1234': {
@@ -170,7 +170,7 @@ describe('Settings', () => {
                 },
             };
 
-            chai.assert.deepEqual(read(devicesFile), expected);
+            assert.deepEqual(read(devicesFile), expected);
         });
 
         it('Should add and remove devices to a seperate file if devices.yaml doesnt exist', () => {
@@ -182,12 +182,12 @@ describe('Settings', () => {
             setup(contentConfiguration);
 
             settings.addDevice('0x1234');
-            chai.assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
+            assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
 
             settings.removeDevice('0x1234');
-            chai.assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
+            assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
 
-            chai.assert.deepEqual(read(devicesFile), {});
+            assert.deepEqual(read(devicesFile), {});
         });
 
         it('Should read groups', () => {
@@ -206,7 +206,7 @@ describe('Settings', () => {
                 friendly_name: '123',
             };
 
-            chai.assert.deepEqual(group, expected);
+            assert.deepEqual(group, expected);
         });
 
         it('Should read groups form a seperate file', () => {
@@ -228,7 +228,7 @@ describe('Settings', () => {
                 friendly_name: '123',
             };
 
-            chai.assert.deepEqual(group, expected);
+            assert.deepEqual(group, expected);
         });
 
         it('Combine everything! groups and devices from separte file :)', () => {
@@ -254,11 +254,11 @@ describe('Settings', () => {
                 groups: 'groups.yaml',
             };
 
-            chai.assert.deepEqual(read(configurationFile), expectedConfiguration);
+            assert.deepEqual(read(configurationFile), expectedConfiguration);
 
             settings.addDevice('0x1234');
 
-            chai.assert.deepEqual(read(configurationFile), expectedConfiguration);
+            assert.deepEqual(read(configurationFile), expectedConfiguration);
 
             const expectedDevice = {
                 '0x1234': {
@@ -267,23 +267,23 @@ describe('Settings', () => {
                 },
             };
 
-            chai.assert.deepEqual(read(devicesFile), expectedDevice);
+            assert.deepEqual(read(devicesFile), expectedDevice);
 
             const group = settings.getGroup('1');
             const expectedGroup = {
                 friendly_name: '123',
             };
 
-            chai.assert.deepEqual(group, expectedGroup);
+            assert.deepEqual(group, expectedGroup);
 
-            chai.assert.deepEqual(read(configurationFile), expectedConfiguration);
+            assert.deepEqual(read(configurationFile), expectedConfiguration);
 
             const expectedDevice2 = {
                 friendly_name: '0x1234',
                 retain: false,
             };
 
-            chai.assert.deepEqual(settings.getDevice('0x1234'), expectedDevice2);
+            assert.deepEqual(settings.getDevice('0x1234'), expectedDevice2);
         });
     });
 });

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -4,7 +4,6 @@ const data = require('../lib/util/data');
 const proxyquire = require('proxyquire').noPreserveCache();
 const settingsProxy = () => proxyquire('../lib/util/settings.js', {});
 const tmp = require('tmp');
-const sandbox = sinon.createSandbox();
 const path = require('path');
 const fs = require('fs');
 const yaml = require('js-yaml');
@@ -31,14 +30,14 @@ describe('Settings', () => {
 
     beforeEach(() => {
         dir = tmp.dirSync();
-        sandbox.stub(data, 'joinPath').callsFake((file) => {
+        sinon.stub(data, 'joinPath').callsFake((file) => {
             return path.join(dir.name, file);
         });
     });
 
     afterEach(() => {
         rimraf.sync(dir.name);
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Settings', () => {

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1,8 +1,6 @@
 const assert = require('chai').assert;
 const sinon = require('sinon');
 const data = require('../lib/util/data');
-const proxyquire = require('proxyquire').noPreserveCache();
-const settingsProxy = () => proxyquire('../lib/util/settings.js', {});
 const tmp = require('tmp');
 const path = require('path');
 const fs = require('fs');
@@ -25,7 +23,8 @@ describe('Settings', () => {
     const setup = (configuration) => {
         configurationFile = path.join(dir.name, 'configuration.yaml');
         write(configurationFile, configuration);
-        settings = settingsProxy();
+        delete require.cache[require.resolve('../lib/util/settings.js')];
+        settings = require('../lib/util/settings.js');
     };
 
     beforeEach(() => {

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -9,8 +9,6 @@ const rimraf = require('rimraf');
 
 describe('Settings', () => {
     let dir = null;
-    let settings = null;
-    let configurationFile = null;
 
     const write = (file, json) => {
         fs.writeFileSync(file, yaml.safeDump(json));
@@ -21,10 +19,11 @@ describe('Settings', () => {
     };
 
     const setup = (configuration) => {
-        configurationFile = path.join(dir.name, 'configuration.yaml');
+        const configurationFile = path.join(dir.name, 'configuration.yaml');
         write(configurationFile, configuration);
         delete require.cache[require.resolve('../lib/util/settings.js')];
-        settings = require('../lib/util/settings.js');
+        const settings = require('../lib/util/settings.js');
+        return {configurationFile, settings};
     };
 
     beforeEach(() => {
@@ -41,13 +40,13 @@ describe('Settings', () => {
 
     describe('Settings', () => {
         it('Should return default settings', () => {
-            setup({});
+            const {settings} = setup({});
             const s = settings.get();
             assert.deepEqual(s, settings._getDefaults());
         });
 
         it('Should return settings', () => {
-            setup({permit_join: true});
+            const {settings} = setup({permit_join: true});
             const s = settings.get();
             const expected = settings._getDefaults();
             expected.permit_join = true;
@@ -55,7 +54,7 @@ describe('Settings', () => {
         });
 
         it('Should add devices', () => {
-            setup({});
+            const {settings, configurationFile} = setup({});
             settings.addDevice('0x12345678');
 
             const actual = read(configurationFile);
@@ -81,7 +80,7 @@ describe('Settings', () => {
                 },
             };
 
-            setup(content);
+            const {settings} = setup(content);
 
             const device = settings.getDevice('0x12345678');
             const expected = {
@@ -105,7 +104,7 @@ describe('Settings', () => {
             };
 
             write(path.join(dir.name, 'devices.yaml'), contentDevices);
-            setup(contentConfiguration);
+            const {settings} = setup(contentConfiguration);
 
             const device = settings.getDevice('0x12345678');
             const expected = {
@@ -130,7 +129,7 @@ describe('Settings', () => {
 
             const devicesFile = path.join(dir.name, 'devices.yaml');
             write(devicesFile, contentDevices);
-            setup(contentConfiguration);
+            const {settings, configurationFile} = setup(contentConfiguration);
 
             settings.addDevice('0x1234');
 
@@ -156,7 +155,7 @@ describe('Settings', () => {
             };
 
             const devicesFile = path.join(dir.name, 'devices.yaml');
-            setup(contentConfiguration);
+            const {settings, configurationFile} = setup(contentConfiguration);
 
             settings.addDevice('0x1234');
 
@@ -178,7 +177,7 @@ describe('Settings', () => {
             };
 
             const devicesFile = path.join(dir.name, 'devices.yaml');
-            setup(contentConfiguration);
+            const {settings, configurationFile} = setup(contentConfiguration);
 
             settings.addDevice('0x1234');
             assert.deepEqual(read(configurationFile), {devices: 'devices.yaml'});
@@ -198,7 +197,7 @@ describe('Settings', () => {
                 },
             };
 
-            setup(content);
+            const {settings} = setup(content);
 
             const group = settings.getGroup('1');
             const expected = {
@@ -220,7 +219,7 @@ describe('Settings', () => {
             };
 
             write(path.join(dir.name, 'groups.yaml'), contentGroups);
-            setup(contentConfiguration);
+            const {settings} = setup(contentConfiguration);
 
             const group = settings.getGroup('1');
             const expected = {
@@ -243,10 +242,9 @@ describe('Settings', () => {
             };
 
             write(path.join(dir.name, 'groups.yaml'), contentGroups);
-            setup(contentConfiguration);
+            const {settings, configurationFile} = setup(contentConfiguration);
 
             const devicesFile = path.join(dir.name, 'devices.yaml');
-            setup(contentConfiguration);
 
             const expectedConfiguration = {
                 devices: 'devices.yaml',


### PR DESCRIPTION
In preparation for Jest, but none are Jest-specific.
No `jest` dependency yet, just bringing tests into more conventional and more robust form.
Please note that the PR is against `dev` branch intentionally.

Currently, all files except `settings.test.js` pass with `pnpx jest`.

```
 PASS  test/data.test.js
 PASS  test/deviceAvailability.test.js
 FAIL  test/settings.test.js
 PASS  test/deviceReceive.test.js
 PASS  test/homeassistant.test.js
 PASS  test/controller.test.js
 PASS  test/devicePublish.test.js
```