### PR TITLE
Make all tests pass in jest

### DIFF
--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -1,0 +1,16 @@
+const yaml = require('js-yaml');
+const fs = require('fs');
+
+function readYaml(file) {
+    return yaml.safeLoad(fs.readFileSync(file, 'utf8'));
+}
+
+function readYamlIfExists(file) {
+    return fs.existsSync(file) ? readYaml(file) : null;
+}
+
+function writeYaml(file, content) {
+    fs.writeFileSync(file, yaml.safeDump(content));
+}
+
+module.exports = {readYaml, readYamlIfExists, writeYaml};

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -1,10 +1,8 @@
-const yaml = require('js-yaml');
-const fs = require('fs');
 const data = require('./data');
 const file = data.joinPath('configuration.yaml');
 const objectAssignDeep = require(`object-assign-deep`);
 const path = require('path');
-
+const fs = require('./fs');
 const onChangeHandlers = [];
 
 const defaults = {
@@ -85,40 +83,32 @@ function write() {
     const toWrite = objectAssignDeep.noMutate(settings);
 
     // Read settings to check if we have to split devices/groups into separate file.
-    const actual = readYaml(file);
+    const actual = fs.readYaml(file);
     if (typeof actual.devices === 'string') {
-        writeYaml(data.joinPath(actual.devices), settings.devices);
+        fs.writeYaml(data.joinPath(actual.devices), settings.devices);
         toWrite.devices = actual.devices;
     }
 
     if (typeof actual.groups === 'string') {
-        writeYaml(data.joinPath(actual.groups), settings.groups);
+        fs.writeYaml(data.joinPath(actual.groups), settings.groups);
         toWrite.groups = actual.groups;
     }
 
-    writeYaml(file, toWrite);
-}
-
-function readYaml(file) {
-    return yaml.safeLoad(fs.readFileSync(file, 'utf8'));
-}
-
-function writeYaml(file, content) {
-    fs.writeFileSync(file, yaml.safeDump(content));
+    fs.writeYaml(file, toWrite);
 }
 
 function read() {
-    const s = readYaml(file);
+    const s = fs.readYaml(file);
 
     // Read devices/groups configuration from separate file.
     if (typeof s.devices === 'string') {
         const file = data.joinPath(s.devices);
-        s.devices = fs.existsSync(file) ? readYaml(file) : null;
+        s.devices = fs.readYamlIfExists(file);
     }
 
     if (typeof s.groups === 'string') {
         const file = data.joinPath(s.groups);
-        s.groups = fs.existsSync(file) ? readYaml(file) : null;
+        s.groups = fs.readYamlIfExists(file);
     }
 
     return s;

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -84,7 +84,7 @@ function write() {
     const settings = getSettings();
     const toWrite = objectAssignDeep.noMutate(settings);
 
-    // Read settings to check if we have to split devices/groups into seperate file.
+    // Read settings to check if we have to split devices/groups into separate file.
     const actual = readYaml(file);
     if (typeof actual.devices === 'string') {
         writeYaml(data.joinPath(actual.devices), settings.devices);

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -91,7 +91,7 @@ describe('Settings', () => {
             assert.deepEqual(device, expected);
         });
 
-        it('Should read devices form a seperate file', () => {
+        it('Should read devices form a separate file', () => {
             const contentConfiguration = {
                 devices: 'devices.yaml',
             };
@@ -115,7 +115,7 @@ describe('Settings', () => {
             assert.deepEqual(device, expected);
         });
 
-        it('Should add devices to a seperate file', () => {
+        it('Should add devices to a separate file', () => {
             const contentConfiguration = {
                 devices: 'devices.yaml',
             };
@@ -149,7 +149,7 @@ describe('Settings', () => {
             assert.deepEqual(read(devicesFile), expected);
         });
 
-        it('Should add devices to a seperate file if devices.yaml doesnt exist', () => {
+        it('Should add devices to a separate file if devices.yaml doesnt exist', () => {
             const contentConfiguration = {
                 devices: 'devices.yaml',
             };
@@ -171,7 +171,7 @@ describe('Settings', () => {
             assert.deepEqual(read(devicesFile), expected);
         });
 
-        it('Should add and remove devices to a seperate file if devices.yaml doesnt exist', () => {
+        it('Should add and remove devices to a separate file if devices.yaml doesnt exist', () => {
             const contentConfiguration = {
                 devices: 'devices.yaml',
             };
@@ -207,7 +207,7 @@ describe('Settings', () => {
             assert.deepEqual(group, expected);
         });
 
-        it('Should read groups form a seperate file', () => {
+        it('Should read groups form a separate file', () => {
             const contentConfiguration = {
                 groups: 'groups.yaml',
             };
@@ -229,7 +229,7 @@ describe('Settings', () => {
             assert.deepEqual(group, expected);
         });
 
-        it('Combine everything! groups and devices from separte file :)', () => {
+        it('Combine everything! groups and devices from separate file :)', () => {
             const contentConfiguration = {
                 devices: 'devices.yaml',
                 groups: 'groups.yaml',

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -11,8 +11,6 @@ const devicesFile = data.joinPath('devices.yaml');
 const groupsFile = data.joinPath('groups.yaml');
 
 describe('Settings', () => {
-    // eslint-disable-next-line padded-blocks Good git diffs - they're not easy.
-
     const write = (file, json) => fs.writeYaml(file, json);
 
     const read = (file) => fs.readYaml(file);


### PR DESCRIPTION
To facilitate this, all `fs` IO (and `js-yaml`) was extracted from `settings.js`
In the future, this file should be mocked for all tests, to speed them up and not depend on the `data` folder.
Perhaps should also add a test for this file, but it only uses `fs` and external dependency `js-yaml`. All actual logic like external devices file is still in `settings.js`, so there's nothing to test, really. Let's keep it that way with that file.
Also fixed a comment/testname typo.