### PR TITLE
query groups through MQTT bridge/config/groups

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -20,6 +20,7 @@ class BridgeConfig {
         this.reset = this.reset.bind(this);
         this.logLevel = this.logLevel.bind(this);
         this.devices = this.devices.bind(this);
+        this.groups = this.groups.bind(this);
         this.rename = this.rename.bind(this);
         this.remove = this.remove.bind(this);
         this.ban = this.ban.bind(this);
@@ -35,6 +36,7 @@ class BridgeConfig {
             'reset': this.reset,
             'log_level': this.logLevel,
             'devices': this.devices,
+            'groups': this.groups,
             'rename': this.rename,
             'remove': this.remove,
             'ban': this.ban,
@@ -139,6 +141,10 @@ class BridgeConfig {
         });
 
         this.mqtt.log('devices', devices);
+    }
+
+    groups(topic, message) {
+        this.mqtt.log('groups', settings.getGroups());
     }
 
     rename(topic, message) {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -289,6 +289,7 @@ module.exports = {
 
     getDevice,
     getGroup,
+    getGroups,
     getDevices,
     addDevice: (ieeeAddr) => addDevice(ieeeAddr),
     removeDevice: (ieeeAddr) => removeDevice(ieeeAddr),

--- a/test/bridgeConfig.test.js
+++ b/test/bridgeConfig.test.js
@@ -118,24 +118,23 @@ describe('BridgeConfig', () => {
 
     it('Get groups', async () => {
         jest.spyOn(mqtt, 'log').mockImplementation((type, message) => {
-	    expect(type).toBe('groups');
-	    expect(Object.keys(message).length).toBe(2);
-	    expect(message['1'].friendly_name).toBe('test1');
-	    expect(message['4711'].friendly_name).toBe('test42');
-	});
+            expect(type).toBe('groups');
+            expect(Object.keys(message)).toHaveLength(2);
+            expect(message['1'].friendly_name).toBe('test1');
+            expect(message['4711'].friendly_name).toBe('test42');
+        });
 
         write(configurationFile, {
-	    groups: {
+            groups: {
                 '1': {
-		    friendly_name: 'test1',
+                    friendly_name: 'test1',
 		},
-		'4711': {
-		    friendly_name: 'test42',
-		},
-	    },
-	});
+                '4711': {
+                    friendly_name: 'test42',
+                },
+            },
+        });
 
 	bridgeConfig.onMQTTMessage('zigbee2mqtt/bridge/config/groups', 'whatever');
     });
-
 });

--- a/test/bridgeConfig.test.js
+++ b/test/bridgeConfig.test.js
@@ -7,6 +7,7 @@ const configurationFile = data.joinPath('configuration.yaml');
 
 const mqtt = {
     subscribe: (topic) => {},
+    log: (type, message) => {},
 };
 
 describe('BridgeConfig', () => {
@@ -114,4 +115,27 @@ describe('BridgeConfig', () => {
 
         expect(read(configurationFile)).toStrictEqual(expected);
     });
+
+    it('Get groups', async () => {
+        jest.spyOn(mqtt, 'log').mockImplementation((type, message) => {
+	    expect(type).toBe('groups');
+	    expect(Object.keys(message).length).toBe(2);
+	    expect(message['1'].friendly_name).toBe('test1');
+	    expect(message['4711'].friendly_name).toBe('test42');
+	});
+
+        write(configurationFile, {
+	    groups: {
+                '1': {
+		    friendly_name: 'test1',
+		},
+		'4711': {
+		    friendly_name: 'test42',
+		},
+	    },
+	});
+
+	bridgeConfig.onMQTTMessage('zigbee2mqtt/bridge/config/groups', 'whatever');
+    });
+
 });

--- a/test/bridgeConfig.test.js
+++ b/test/bridgeConfig.test.js
@@ -128,13 +128,13 @@ describe('BridgeConfig', () => {
             groups: {
                 '1': {
                     friendly_name: 'test1',
-		},
+                },
                 '4711': {
                     friendly_name: 'test42',
                 },
             },
         });
 
-	bridgeConfig.onMQTTMessage('zigbee2mqtt/bridge/config/groups', 'whatever');
+        bridgeConfig.onMQTTMessage('zigbee2mqtt/bridge/config/groups', 'whatever');
     });
 });


### PR DESCRIPTION
While working on a new Node-Red Dashboard for zigbee2mqtt, i found that its not possible to query groups like you can query devices.
This PR adds the possiblity to send a message to zigbee2mqtt/bridge/config/groups and receive the current group list on the topic zigbee2mqtt/bridge/log with type "groups"