### PR TITLE
Expand attribute output. #493

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -248,8 +248,7 @@ class Controller {
                 if (typeof messagePayload[key] == 'object') {
                     Object.keys(messagePayload[key]).forEach((subKey) => {
                         this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`,
-                                          JSON.stringify(messagePayload[key][subKey]),
-                                          options);
+                            JSON.stringify(messagePayload[key][subKey]), options);
                     });
                 } else {
                     this.mqtt.publish(`${entity.friendlyName}/${key}`, JSON.stringify(messagePayload[key]), options);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -245,9 +245,10 @@ class Controller {
             this.mqtt.publish(entity.friendlyName, JSON.stringify(messagePayload), options);
         } else if (settings.get().experimental.output === 'attribute') {
             Object.keys(messagePayload).forEach((key) => {
-                if (typeof messagePayload[key] == 'object'){
+                if (typeof messagePayload[key] == 'object') {
                     Object.keys(messagePayload[key]).forEach((subKey) => {
-    	                this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`, JSON.stringify(messagePayload[key][subKey]), options);
+                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`, \
+                                          JSON.stringify(messagePayload[key][subKey]), options);
                     });
                 } else {
                     this.mqtt.publish(`${entity.friendlyName}/${key}`, JSON.stringify(messagePayload[key]), options);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -247,8 +247,9 @@ class Controller {
             Object.keys(messagePayload).forEach((key) => {
                 if (typeof messagePayload[key] == 'object') {
                     Object.keys(messagePayload[key]).forEach((subKey) => {
-                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`, \
-                                          JSON.stringify(messagePayload[key][subKey]), options);
+                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`,
+                                          JSON.stringify(messagePayload[key][subKey]),
+                                          options);
                     });
                 } else {
                     this.mqtt.publish(`${entity.friendlyName}/${key}`, JSON.stringify(messagePayload[key]), options);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -245,7 +245,13 @@ class Controller {
             this.mqtt.publish(entity.friendlyName, JSON.stringify(messagePayload), options);
         } else if (settings.get().experimental.output === 'attribute') {
             Object.keys(messagePayload).forEach((key) => {
-                this.mqtt.publish(`${entity.friendlyName}/${key}`, JSON.stringify(messagePayload[key]), options);
+                if (typeof messagePayload[key] == 'object'){
+                    Object.keys(messagePayload[key]).forEach((subKey) => {
+    	                this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`, JSON.stringify(messagePayload[key][subKey]), options);
+                    });
+                } else {
+                    this.mqtt.publish(`${entity.friendlyName}/${key}`, JSON.stringify(messagePayload[key]), options);
+                }
             });
         }
     }


### PR DESCRIPTION
If attribute is actually an `object`, expand it in the format `topic/key-subkey` in order to keep the same amount of topic levels for predictable parsing.
This only expands the first level of contained object. If more expansion are needed a more robust method should be implemented rather than just nesting `if`.