### PR TITLE
set reportableChange default value to 1 to avoid report flooding

### DIFF
--- a/lib/extension/deviceReport.js
+++ b/lib/extension/deviceReport.js
@@ -21,7 +21,7 @@ const reportInterval = {
     max: 3600,
 };
 
-const reportableChange = 0;
+const reportableChange = 1;
 
 class DeviceReport {
     constructor(zigbee, mqtt, state, publishEntityState) {


### PR DESCRIPTION
When activating device reporting, my Müller Licht Tint (RGB) bulbs start reporting their status (always the same values) once per second. This somehow slows down the whole zigbee network due to a lot of unnecessary traffic. Setting the reportableChange default to one stops this and still ensures that the bulbs report changes through the remote control immediatly. 