### PR TITLE
add more details to device list

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -135,6 +135,13 @@ class BridgeConfig {
                 const friendlyDevice = settings.getDevice(device.ieeeAddr);
                 payload.model = mappedDevice ? mappedDevice.model : device.modelId;
                 payload.friendly_name = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
+                payload.nwkAddr = device.nwkAddr;
+                payload.manufId = device.manufId;
+                payload.manufName = device.manufName;
+                payload.powerSource = device.powerSource;
+                payload.modelId = device.modelId;
+                payload.hwVersion = device.hwVersion;
+                payload.swBuildId = device.swBuildId;
             }
 
             return payload;


### PR DESCRIPTION
Some more work for #1213: Add extended informations to the device list send to bridge/log type "devices".
Btw, on my installation (latest dev) no device reports sw and hw version, just model informations, manufacturer informations and nwkAddr is added. 
