### PR TITLE
shutdown controller on SIGTERM

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const controller = new Controller();
 controller.start();
 
 process.on('SIGINT', handleQuit);
+process.on('SIGTERM', handleQuit);
 
 function handleQuit() {
     controller.stop(() => process.exit());


### PR DESCRIPTION
Previously, the controller was only properly shutdown on SIGINT.
SIGTERM is used by kill (unix) and to stop Docker containers.