### PR TITLE
Publish and respond to bridge/config/devices/get

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -106,6 +106,7 @@ class BridgeConfig {
         if (message.toString() != '') {
             return;
         }
+
         const devices = this.zigbee.getAllClients().map((device) => {
             const mappedDevice = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
             const friendlyDevice = settings.getDevice(device.ieeeAddr);
@@ -117,11 +118,12 @@ class BridgeConfig {
                 friendly_name: friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr,
             };
         });
+
         if (topic.split('/').pop() == 'get') {
             this.mqtt.publish(`bridge/config/devices`, JSON.stringify(devices), {});
+        } else {
+            this.mqtt.log('devices', devices);
         }
-
-        this.mqtt.log('devices', devices);
     }
 
     rename(topic, message) {

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -103,9 +103,9 @@ class BridgeConfig {
     }
 
     devices(topic, message) {
-        if(message.toString() != ''){
-	    return
-	}
+        if (message.toString() != '') {
+            return;
+        }
         const devices = this.zigbee.getAllClients().map((device) => {
             const mappedDevice = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
             const friendlyDevice = settings.getDevice(device.ieeeAddr);
@@ -117,9 +117,9 @@ class BridgeConfig {
                 friendly_name: friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr,
             };
         });
-	if(topic.split('/').pop() == 'get'){
-	  this.mqtt.publish(`bridge/config/devices`, JSON.stringify(devices), {});
-	}
+        if (topic.split('/').pop() == 'get') {
+            this.mqtt.publish(`bridge/config/devices`, JSON.stringify(devices), {});
+        }
 
         this.mqtt.log('devices', devices);
     }

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -2,7 +2,7 @@ const settings = require('../util/settings');
 const logger = require('../util/logger');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 
-const configRegex = new RegExp(`${settings.get().mqtt.base_topic}/bridge/config/\\w+`, 'g');
+const configRegex = new RegExp(`${settings.get().mqtt.base_topic}/bridge/config/((?:\\w+/get)|(?:\\w+))`);
 const allowedLogLevels = ['error', 'warn', 'info', 'debug'];
 
 class BridgeConfig {
@@ -30,6 +30,7 @@ class BridgeConfig {
             'reset': this.reset,
             'log_level': this.logLevel,
             'devices': this.devices,
+            'devices/get': this.devices,
             'rename': this.rename,
             'remove': this.remove,
             'ban': this.ban,
@@ -102,6 +103,9 @@ class BridgeConfig {
     }
 
     devices(topic, message) {
+        if(message.toString() != ''){
+	    return
+	}
         const devices = this.zigbee.getAllClients().map((device) => {
             const mappedDevice = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
             const friendlyDevice = settings.getDevice(device.ieeeAddr);
@@ -113,6 +117,9 @@ class BridgeConfig {
                 friendly_name: friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr,
             };
         });
+	if(topic.split('/').pop() == 'get'){
+	  this.mqtt.publish(`bridge/config/devices`, JSON.stringify(devices), {});
+	}
 
         this.mqtt.log('devices', devices);
     }
@@ -193,7 +200,7 @@ class BridgeConfig {
             return false;
         }
 
-        const option = topic.split('/').slice(-1)[0];
+        const option = topic.match(configRegex)[1];
 
         if (!this.supportedOptions.hasOwnProperty(option)) {
             return false;

--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -70,8 +70,8 @@ class DevicePublish {
 
         // Remove base from topic
         topic = topic.replace(`${settings.get().mqtt.base_topic}/`, '');
-        if(topic.match(/bridge\/config/)) {
-	    return null;
+        if (topic.match(/bridge\/config/)) {
+            return null;
         }
         // Parse type from topic
         const type = topic.substr(topic.lastIndexOf('/') + 1, topic.length);

--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -70,7 +70,9 @@ class DevicePublish {
 
         // Remove base from topic
         topic = topic.replace(`${settings.get().mqtt.base_topic}/`, '');
-
+        if(topic.match(/bridge\/config/)) {
+	    return null;
+        }
         // Parse type from topic
         const type = topic.substr(topic.lastIndexOf('/') + 1, topic.length);
 

--- a/test/devicePublish.test.js
+++ b/test/devicePublish.test.js
@@ -581,6 +581,27 @@ describe('DevicePublish', () => {
             assert.strictEqual(parsed.postfix, '');
         });
 
+
+        it('Should not respond to bridge/config/devices/get', () => {
+            const topic = 'zigbee2mqtt/bridge/config/devices/get';
+            const parsed = devicePublish.parseTopic(topic);
+            assert.strictEqual(parsed, null);
+        });
+
+        it('Should not respond to bridge/config/devices/set', () => {
+            const topic = 'zigbee2mqtt/bridge/config/devices/set';
+            const parsed = devicePublish.parseTopic(topic);
+            assert.strictEqual(parsed, null);
+        });
+
+
+        it('Should not respond to bridge/config/devices', () => {
+            const topic = 'zigbee2mqtt/bridge/config/devices';
+            const parsed = devicePublish.parseTopic(topic);
+            assert.strictEqual(parsed, null);
+        });
+
+
         it('Should parse topic with when base topic has multiple slashes', () => {
             sinon.stub(settings, 'get').callsFake(() => {
                 return {


### PR DESCRIPTION
Regarding: https://github.com/Koenkk/zigbee2mqtt/issues/1305

- When sent a empty payload to bridge/config/devices/get , publish to 
  'bridge/config/devices'
- For bridge/config/devices & bridge/config/devices/get only ever
  publish to the corresponding topic if a empty payload is sent.
- Make sure devicesPublish doesn't treat messages to
  bridge/config/devices/get as a zigbee device.

