### PR TITLE
Improved devicePublish topic parsing

### DIFF
--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -5,8 +5,7 @@ const logger = require('../util/logger');
 const utils = require('../util/utils');
 
 const postfixes = utils.getPostfixes();
-const baseTopic = settings.get().mqtt.base_topic;
-const topicRegex = new RegExp(`^${baseTopic}/(.+?)(?:/(${postfixes.join('|')}))?/(get|set)(?:/(.+))?`);
+const topicRegex = new RegExp(`^(.+?)(?:/(${postfixes.join('|')}))?/(get|set)(?:/(.+))?`);
 
 const maxDepth = 20;
 
@@ -27,6 +26,7 @@ class DevicePublish {
 
     onMQTTConnected() {
         // Subscribe to topics.
+        const baseTopic = settings.get().mqtt.base_topic;
         for (let step = 1; step < maxDepth; step++) {
             const topic = `${baseTopic}/${'+/'.repeat(step)}`;
             this.mqtt.subscribe(`${topic}set`);
@@ -42,7 +42,13 @@ class DevicePublish {
             return null;
         }
 
-        return {ID: match[1], postfix: match[2], type: match[3], attribute: match[4]};
+        const ID = match[1].replace(`${settings.get().mqtt.base_topic}/`, '');
+        // If we didn't repalce base_topic we received something we don't care about
+        if (ID === match[1] || ID.match(/bridge\/config/)) {
+            return null;
+        }
+
+        return {ID: ID, postfix: match[2] || '', type: match[3], attribute: match[4]};
     }
 
     handlePublishError(entity, message, error) {

--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -4,8 +4,9 @@ const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 const logger = require('../util/logger');
 const utils = require('../util/utils');
 
-const topicRegex = new RegExp(`^${settings.get().mqtt.base_topic}/.+/(set|get)$`);
 const postfixes = utils.getPostfixes();
+const baseTopic = settings.get().mqtt.base_topic;
+const topicRegex = new RegExp(`^${baseTopic}/(.+?)(?:/(${postfixes.join('|')}))?/(get|set)(?:/(.+))?`);
 
 const maxDepth = 20;
 
@@ -27,40 +28,19 @@ class DevicePublish {
     onMQTTConnected() {
         // Subscribe to topics.
         for (let step = 1; step < maxDepth; step++) {
-            const topic = `${settings.get().mqtt.base_topic}/${'+/'.repeat(step)}`;
+            const topic = `${baseTopic}/${'+/'.repeat(step)}`;
             this.mqtt.subscribe(`${topic}set`);
             this.mqtt.subscribe(`${topic}get`);
         }
     }
 
     parseTopic(topic) {
-        if (!topic.match(topicRegex)) {
+        const match = topic.match(topicRegex);
+        if (!match) {
             return null;
         }
 
-        // Remove base from topic
-        topic = topic.replace(`${settings.get().mqtt.base_topic}/`, '');
-        if (topic.match(/bridge\/config/)) {
-            return null;
-        }
-        // Parse type from topic
-        const type = topic.substr(topic.lastIndexOf('/') + 1, topic.length);
-
-        // Remove type from topic
-        topic = topic.replace(`/${type}`, '');
-
-        // Check if we have to deal with a postfix.
-        let postfix = '';
-        if (postfixes.find((p) => topic.endsWith(`/${p}`))) {
-            postfix = topic.substr(topic.lastIndexOf('/') + 1, topic.length);
-
-            // Remove postfix from topic
-            topic = topic.replace(`/${postfix}`, '');
-        }
-
-        const ID = topic;
-
-        return {type, ID, postfix};
+        return {ID: match[1], postfix: match[2], type: match[3], attribute: match[4]};
     }
 
     handlePublishError(entity, message, error) {
@@ -132,11 +112,15 @@ class DevicePublish {
 
         // Convert the MQTT message to a Zigbee message.
         let json = null;
-        try {
-            json = JSON.parse(message);
-        } catch (e) {
-            // Cannot be parsed to JSON, assume state message.
-            json = {state: message.toString()};
+        if (topic.hasOwnProperty("attribute") && topic.attribute) {
+            json[topic.attribute] = message.toString();
+        } else {
+            try {
+                json = JSON.parse(message);
+            } catch (e) {
+                // Cannot be parsed to JSON, assume state message.
+                json = {state: message.toString()};
+            }
         }
 
         /**

--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -30,7 +30,9 @@ class DevicePublish {
         for (let step = 1; step < maxDepth; step++) {
             const topic = `${baseTopic}/${'+/'.repeat(step)}`;
             this.mqtt.subscribe(`${topic}set`);
+            this.mqtt.subscribe(`${topic}set/+`);
             this.mqtt.subscribe(`${topic}get`);
+            this.mqtt.subscribe(`${topic}get/+`);
         }
     }
 
@@ -111,7 +113,7 @@ class DevicePublish {
         }
 
         // Convert the MQTT message to a Zigbee message.
-        let json = null;
+        let json = {};
         if (topic.hasOwnProperty("attribute") && topic.attribute) {
             json[topic.attribute] = message.toString();
         } else {

--- a/lib/extension/devicePublish.js
+++ b/lib/extension/devicePublish.js
@@ -120,7 +120,7 @@ class DevicePublish {
 
         // Convert the MQTT message to a Zigbee message.
         let json = {};
-        if (topic.hasOwnProperty("attribute") && topic.attribute) {
+        if (topic.hasOwnProperty('attribute') && topic.attribute) {
             json[topic.attribute] = message.toString();
         } else {
             try {

--- a/test/devicePublish.test.js
+++ b/test/devicePublish.test.js
@@ -725,6 +725,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('my_device_id');
             expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBeUndefined();
         });
 
         it('Should parse get topic', () => {
@@ -733,6 +734,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('get');
             expect(parsed.ID).toBe('my_device_id2');
             expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBeUndefined();
         });
 
 
@@ -768,6 +770,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('get');
             expect(parsed.ID).toBe('my_device_id2');
             expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBeUndefined();
         });
 
         it('Should parse topic with when deviceID has multiple slashes', () => {
@@ -776,6 +779,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('floor0/basement/my_device_id2');
             expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBeUndefined();
         });
 
         it('Should parse topic with when base and deviceID have multiple slashes', () => {
@@ -790,8 +794,18 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('floor0/basement/my_device_id2');
             expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBeUndefined();
         }
         );
+
+        it('Should parse set with attribute topic', () => {
+            const topic = 'zigbee2mqtt/0x12345689/set/foobar';
+            const parsed = devicePublish.parseTopic(topic);
+            expect(parsed.type).toBe('set');
+            expect(parsed.ID).toBe('0x12345689');
+            expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBe('foobar');
+        });
 
         it('Should parse set with ieeAddr topic', () => {
             const topic = 'zigbee2mqtt/0x12345689/set';
@@ -799,6 +813,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('0x12345689');
             expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBeUndefined();
         });
 
         it('Should parse set with postfix topic', () => {
@@ -807,6 +822,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('0x12345689');
             expect(parsed.postfix).toBe('left');
+            expect(parsed.attribute).toBeUndefined();
         });
 
         it('Should parse set with almost postfix topic', () => {
@@ -815,6 +831,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('wohnzimmer.light.wall.right');
             expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBeUndefined();
         });
 
         it('Should parse set with postfix topic', () => {
@@ -823,6 +840,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('0x12345689');
             expect(parsed.postfix).toBe('right');
+            expect(parsed.attribute).toBeUndefined();
         });
 
         it('Should parse set with postfix topic', () => {
@@ -831,6 +849,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('0x12345689');
             expect(parsed.postfix).toBe('bottom_left');
+            expect(parsed.attribute).toBeUndefined();
         });
 
         it('Shouldnt parse set with invalid postfix topic', () => {
@@ -839,6 +858,16 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('set');
             expect(parsed.ID).toBe('0x12345689/invalid');
             expect(parsed.postfix).toBe('');
+            expect(parsed.attribute).toBeUndefined();
+        });
+
+        it('Should parse set with postfix topic and attribute', () => {
+            const topic = 'zigbee2mqtt/0x12345689/bottom_left/set/foobar';
+            const parsed = devicePublish.parseTopic(topic);
+            expect(parsed.type).toBe('set');
+            expect(parsed.ID).toBe('0x12345689');
+            expect(parsed.postfix).toBe('bottom_left');
+            expect(parsed.attribute).toBe('foobar');
         });
 
         it('Should parse set with and slashes in base and deviceID postfix topic', () => {
@@ -853,6 +882,7 @@ describe('DevicePublish', () => {
             expect(parsed.type).toBe('get');
             expect(parsed.ID).toBe('my/device/in/basement/sensor');
             expect(parsed.postfix).toBe('bottom_left');
+            expect(parsed.attribute).toBeUndefined();
         }
         );
     });


### PR DESCRIPTION
I have refactored the devicePublish topic parsing to use regex capture groups as this seems more natural than manually splitting on slashes.
Furthermore I have added the ability to set attributes directly using the mqtt topic rather than having to set it using JSON while still maintaining backwards compatibility with the JSON approach.
This was mainly done to enable thermostat integration with homeassistant's MQTT climate component: https://www.home-assistant.io/components/climate.mqtt/ which does not support templating for the command topics to set the target temperature or mode.
In my case I have an eCozy thermostat named `zigbee2mqtt/livingroom/thermostat_right` which means I can now publish to the following topic to set the target temperature: `zigbee2mqtt/livingroom/thermostat_right/set/occupied_heating_setpoint`.

As such I can now control it from homeassitant with the following yaml:
```
- platform: mqtt
  name: Living room right
  min_temp: 7
  max_temp: 30
  availability_topic: "zigbee2mqtt/bridge/state"
  modes: ["off", "auto", "heat"]
  mode_command_topic: "zigbee2mqtt/livingroom/thermostat_right/set/system_mode"
  mode_state_topic: "zigbee2mqtt/livingroom/thermostat_right"
  mode_state_template: "{{ value_json.system_mode }}"
  current_temperature_topic: "zigbee2mqtt/livingroom/thermostat_right"
  current_temperature_template: "{{ value_json.local_temperature }}"
  temperature_command_topic: "zigbee2mqtt/livingroom/thermostat_right/set/occupied_heating_setpoint"
  temperature_state_topic: "zigbee2mqtt/livingroom/thermostat_right"
  temperature_state_template: "{{ value_json.occupied_heating_setpoint }}"
```

Next step is to add climate device discovery but that'll be later in a different PR.