### PR TITLE
fix: 'Message type' could be a string or an array

### DIFF
--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -73,10 +73,11 @@ class DeviceReceive {
         const cmdId = message.data.cmdId;
         const converters = mappedDevice.fromZigbee.filter((c) => {
             if (cid) {
-                // readRsp messages have the same structure as attReport messages.
-                // search for attReport converters on readRsp.
-                const search = message.type === 'readRsp' ? 'attReport' : message.type;
-                return c.cid === cid && c.type === search;
+                if (typeof c.type == "string") {                        
+                    return c.cid === cid && c.type === message.type;
+                } else {
+                    return c.cid === cid && (c.type.indexOf(message.type) != -1);
+                }                
             } else if (cmdId) {
                 return c.cmd === cmdId;
             }


### PR DESCRIPTION
The file fromZigbee.js from zigbee-shepherd-converters repository (branch master) contains the definition of all converters. The field 'type' could be a string or an array. So it necessary to adapt the code in deviceReceive.js file. The test on 'readRsp' message has been deleted because some converters now defined 'type' for 'readRsp' and 'attrReport' (that's why 'type' field could be an array).

Without this change, no converters can be found for all devices which has multiply values for 'type' (Ex. Xiaomi device MCCGQ11LM).  