### PR TITLE
eCozy homeassitant discovery

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -297,7 +297,7 @@ const configurations = {
         },
     },
 
-    //Thermostat/HVAC
+    // Thermostat/HVAC
     'thermostat': {
         type: 'climate',
         object_id: 'climate',
@@ -313,7 +313,7 @@ const configurations = {
             temperature_state_topic: true,
             temperature_state_template: '{{ value_json.occupied_heating_setpoint }}',
             temperature_command_topic: true,
-        }
+        },
     },
 };
 

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -776,23 +776,23 @@ class HomeAssistant {
             }
 
             if (payload.mode_state_topic) {
-                payload.mode_state_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/`;
+                payload.mode_state_topic = stateTopic;
             }
 
             if (payload.mode_command_topic) {
-                payload.mode_command_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/set/system_mode`;
+                payload.mode_command_topic = `${stateTopic}/set/system_mode`;
             }
 
             if (payload.current_temperature_topic) {
-                payload.current_temperature_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/`;
+                payload.current_temperature_topic = stateTopic;
             }
 
             if (payload.temperature_state_topic) {
-                payload.temperature_state_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/`;
+                payload.temperature_state_topic = stateTopic;
             }
 
             if (payload.temperature_command_topic) {
-                payload.temperature_command_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/set/occupied_heating_setpoint`;
+                payload.temperature_command_topic = `${stateTopic}/set/occupied_heating_setpoint`;
             }
 
             // Override configuration with user settings.

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -296,6 +296,25 @@ const configurations = {
             value_template: '{{ value_json.state }}',
         },
     },
+
+    //Thermostat/HVAC
+    'thermostat': {
+        type: 'climate',
+        object_id: 'climate',
+        discovery_payload: {
+            min_temp: 7,
+            max_temp: 30,
+            modes: ['off', 'auto', 'heat'],
+            mode_state_topic: true,
+            mode_state_template: '{{ value_json.system_mode }}',
+            mode_command_topic: true,
+            current_temperature_topic: true,
+            current_temperature_template: '{{ value_json.local_temperature }}',
+            temperature_state_topic: true,
+            temperature_state_template: '{{ value_json.occupied_heating_setpoint }}',
+            temperature_command_topic: true,
+        }
+    },
 };
 
 const switchWithPostfix = (postfix) => {
@@ -501,7 +520,7 @@ const mapping = {
     'GL-B-008Z': [configurations.light_brightness_colortemp_colorxy],
     'AV2010/25': [configurations.switch, configurations.sensor_power],
     'E12-N14': [configurations.light_brightness],
-    '1TST-EU': [],
+    '1TST-EU': [configurations.thermostat, configurations.sensor_battery],
     'RB 178 T': [configurations.light_brightness_colortemp],
     '45856GE': [configurations.switch],
     'GL-D-003Z': [configurations.light_brightness_colortemp_colorxy],
@@ -629,12 +648,6 @@ const mapping = {
     '45853GE': [configurations.switch],
     '50064': [configurations.light_brightness_colortemp],
     '9290011998B': [configurations.light_brightness_colortemp],
-    '4096730U7': [configurations.light_brightness_colortemp],
-    'RB 278 T': [configurations.light_brightness],
-    '3315-G': [
-        configurations.sensor_temperature, configurations.sensor_battery, configurations.binary_sensor_water_leak,
-    ],
-    'N2G-SP': [configurations.sensor_power, configurations.switch],
 };
 
 Object.keys(mapping).forEach((key) => {
@@ -709,7 +722,7 @@ class HomeAssistant {
 
             // Set json_attributes_topic for types which support this
             // https://github.com/Koenkk/zigbee2mqtt/issues/840
-            if (['binary_sensor', 'sensor', 'lock'].includes(config.type)) {
+            if (['binary_sensor', 'sensor', 'lock', 'climate'].includes(config.type)) {
                 payload.json_attributes_topic = payload.state_topic;
             }
 
@@ -760,6 +773,26 @@ class HomeAssistant {
 
             if (payload.set_position_topic && payload.command_topic) {
                 payload.set_position_topic = payload.command_topic;
+            }
+
+            if (payload.mode_state_topic) {
+                payload.mode_state_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/`;
+            }
+
+            if (payload.mode_command_topic) {
+                payload.mode_command_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/set/system_mode`;
+            }
+
+            if (payload.current_temperature_topic) {
+                payload.current_temperature_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/`;
+            }
+
+            if (payload.temperature_state_topic) {
+                payload.temperature_state_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/`;
+            }
+
+            if (payload.temperature_command_topic) {
+                payload.temperature_command_topic = `${settings.get().mqtt.base_topic}/${entity.friendlyName}/set/occupied_heating_setpoint`;
             }
 
             // Override configuration with user settings.

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -648,6 +648,12 @@ const mapping = {
     '45853GE': [configurations.switch],
     '50064': [configurations.light_brightness_colortemp],
     '9290011998B': [configurations.light_brightness_colortemp],
+    '4096730U7': [configurations.light_brightness_colortemp],
+    'RB 278 T': [configurations.light_brightness],
+    '3315-G': [
+        configurations.sensor_temperature, configurations.sensor_battery, configurations.binary_sensor_water_leak,
+    ],
+    'N2G-SP': [configurations.sensor_power, configurations.switch],
 };
 
 Object.keys(mapping).forEach((key) => {


### PR DESCRIPTION
As promised here's the homeassistant auto discovery of eCozy devices.
I added `configurations.sensor_battery` although it's not currently supported by zigbee-shepherd-converters because I'm currently testing that change before I'll make a PR for it but it shouldn't be an issue as homeassistant will just show a sensor without value.