### PR TITLE
Update controller.js

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -256,7 +256,8 @@ class Controller {
             Object.keys(messagePayload).forEach((key) => {
                 if (typeof messagePayload[key] == 'object') {
                     Object.keys(messagePayload[key]).forEach((subKey) => {
-                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`, `${messagePayload[key][subKey]}`, options);
+                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`,
+                                          `${messagePayload[key][subKey]}`, options);
                     });
                 } else {
                     this.mqtt.publish(`${entity.friendlyName}/${key}`, `${messagePayload[key]}`, options);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -257,7 +257,7 @@ class Controller {
                 if (typeof messagePayload[key] == 'object') {
                     Object.keys(messagePayload[key]).forEach((subKey) => {
                         this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`,
-                                          `${messagePayload[key][subKey]}`, options);
+                            `${messagePayload[key][subKey]}`, options);
                     });
                 } else {
                     this.mqtt.publish(`${entity.friendlyName}/${key}`, `${messagePayload[key]}`, options);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -256,10 +256,10 @@ class Controller {
             Object.keys(messagePayload).forEach((key) => {
                 if (typeof messagePayload[key] == 'object') {
                     Object.keys(messagePayload[key]).forEach((subKey) => {
-                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`, `${messagePayload[key][subKey])}`, options);
+                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`, `${messagePayload[key][subKey]}`, options);
                     });
                 } else {
-                    this.mqtt.publish(`${entity.friendlyName}/${key}`, `${messagePayload[key])}`, options);
+                    this.mqtt.publish(`${entity.friendlyName}/${key}`, `${messagePayload[key]}`, options);
                 }
             });
         }

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -256,11 +256,10 @@ class Controller {
             Object.keys(messagePayload).forEach((key) => {
                 if (typeof messagePayload[key] == 'object') {
                     Object.keys(messagePayload[key]).forEach((subKey) => {
-                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`,
-                            JSON.stringify(messagePayload[key][subKey]), options);
+                        this.mqtt.publish(`${entity.friendlyName}/${key}-${subKey}`, `${messagePayload[key][subKey])}`, options);
                     });
                 } else {
-                    this.mqtt.publish(`${entity.friendlyName}/${key}`, JSON.stringify(messagePayload[key]), options);
+                    this.mqtt.publish(`${entity.friendlyName}/${key}`, `${messagePayload[key])}`, options);
                 }
             });
         }


### PR DESCRIPTION
Do not use JSON.stringify when outputting Non-JSON to MQTT. When using JSON.stringify strings are quoted in the MQTT messages but they should not be quoted (MQTT is different from JSON).

I was happy to see the **experimental** feature to output **attributes** rather than **JSON**. Strings where published with quotes to the MQTT topic. Not sure if that is standard for MQTT but as there are no var types in MQTT everything should be handled as a string no matter if they are int, date or string.

Real issue I had:
I pointed openHAB's MQTT binding to the new MQTT topics while having the experimental z2m feature activated but openHAB complained that it didn't know the state '"OFF"' (see the double quotes?).