### PR TITLE
Auto response with 'defaultRsp'

### DIFF
--- a/lib/extension/xiaomi.js
+++ b/lib/extension/xiaomi.js
@@ -15,8 +15,8 @@ class Xiaomi {
     }
 
     onZigbeeMessage(message, device, mappedDevice) {
-        //For Yunmi smart Lock device
-        //Auto response with 'defaultRsp' when received 'attReport'
+        // For Yunmi smart Lock device
+        // Auto response with 'defaultRsp' when received 'attReport'
         logger.info(`onZigbeeMessage(): 
                 message.type = ${message.type},
                 message.data.cid = ${message.data.cid},
@@ -25,23 +25,23 @@ class Xiaomi {
         const callback = (error, rsp) => {
             logger.info(`onZigbeeMessage(): callback(): error = ${error}, rsp = ${rsp}`);
         };
-    
+
         if (message.type === 'attReport' && message.data.cid === 'genPollCtrl') {
             this.zigbee.publish(
                 device.ieeeAddr,
                 'device',
-                'genPollCtrl', //cid
-                'defaultRsp', //cmd
+                'genPollCtrl', // cid
+                'defaultRsp', // cmd
                 'foundation',
-                { //zclData
+                { // zclData
                     cmdId: 0x0a,
                     statusCode: 0x0,
                 },
-                { //cfg
-                     manufSpec: 0,
-                     disDefaultRsp: 1,
+                { // cfg
+                    manufSpec: 0,
+                    disDefaultRsp: 1,
                 },
-                null, //default endpoint
+                null, // default endpoint
                 callback
             );
         }

--- a/lib/extension/xiaomi.js
+++ b/lib/extension/xiaomi.js
@@ -24,7 +24,7 @@ class Xiaomi {
                 device.ieeeAddr = ${device.ieeeAddr}`);
 
         const callback = (error, rsp) => {
-            if (!error) {
+            if (error) {
                 logger.error(`onZigbeeMessage(): callback(): error = ${error}`);
             } else {
                 logger.debug(`onZigbeeMessage(): callback(): OK`);

--- a/lib/extension/xiaomi.js
+++ b/lib/extension/xiaomi.js
@@ -31,7 +31,8 @@ class Xiaomi {
             }
         };
 
-        if (device.modelId === 'FNB56-DOR23FB1.3' && message.type === 'attReport' && message.data.cid === 'genPollCtrl') {
+        if (device.modelId === 'FNB56-DOR23FB1.3'
+                    && message.type === 'attReport' && message.data.cid === 'genPollCtrl') {
             this.zigbee.publish(
                 device.ieeeAddr,
                 'device',

--- a/lib/extension/xiaomi.js
+++ b/lib/extension/xiaomi.js
@@ -14,6 +14,39 @@ class Xiaomi {
         this.timer = null;
     }
 
+    onZigbeeMessage(message, device, mappedDevice) {
+        //For Yunmi smart Lock device
+        //Auto response with 'defaultRsp' when received 'attReport'
+        logger.info(`onZigbeeMessage(): 
+                message.type = ${message.type},
+                message.data.cid = ${message.data.cid},
+                device.ieeeAddr = ${device.ieeeAddr}`);
+
+        const callback = (error, rsp) => {
+            logger.info(`onZigbeeMessage(): callback(): error = ${error}, rsp = ${rsp}`);
+        };
+    
+        if (message.type === 'attReport' && message.data.cid === 'genPollCtrl') {
+            this.zigbee.publish(
+                device.ieeeAddr,
+                'device',
+                'genPollCtrl', //cid
+                'defaultRsp', //cmd
+                'foundation',
+                { //zclData
+                    cmdId: 0x0a,
+                    statusCode: 0x0,
+                },
+                { //cfg
+                     manufSpec: 0,
+                     disDefaultRsp: 1,
+                },
+                null, //default endpoint
+                callback
+            );
+        }
+    }
+
     onZigbeeStarted() {
         // Set all Xiaomi devices to be online, so shepherd won't try
         // to query info from devices (which would fail because they go to sleep).

--- a/lib/extension/xiaomi.js
+++ b/lib/extension/xiaomi.js
@@ -15,18 +15,23 @@ class Xiaomi {
     }
 
     onZigbeeMessage(message, device, mappedDevice) {
-        // For Yunmi smart Lock device
+        // For Yunmi smart Lock device (modelId = 'FNB56-DOR23FB1.3')
         // Auto response with 'defaultRsp' when received 'attReport'
-        logger.info(`onZigbeeMessage(): 
+        logger.debug(`onZigbeeMessage():
+                device.modelId = ${device.modelId},
                 message.type = ${message.type},
                 message.data.cid = ${message.data.cid},
                 device.ieeeAddr = ${device.ieeeAddr}`);
 
         const callback = (error, rsp) => {
-            logger.info(`onZigbeeMessage(): callback(): error = ${error}, rsp = ${rsp}`);
+            if (!error) {
+                logger.error(`onZigbeeMessage(): callback(): error = ${error}`);
+            } else {
+                logger.debug(`onZigbeeMessage(): callback(): OK`);
+            }
         };
 
-        if (message.type === 'attReport' && message.data.cid === 'genPollCtrl') {
+        if (device.modelId === 'FNB56-DOR23FB1.3' && message.type === 'attReport' && message.data.cid === 'genPollCtrl') {
             this.zigbee.publish(
                 device.ieeeAddr,
                 'device',


### PR DESCRIPTION
For Yunmi smart Lock device, it needs to auto response with '`defaultRsp`' when received '`attReport`'.

**Issue** need to be fixed:
The commands sent by `zigbee.publish` are always waiting for response from device side with 30000ms timeout, but the Lock device has no response for such '`defaultRsp`'. This will block the consequent commands in the queue sent by `zigbee.publish`.
See discussion [here](https://github.com/Koenkk/zigbee2mqtt/issues/1402).