### PR TITLE
Auto response for Yunmi device

### DIFF
--- a/lib/extension/responder.js
+++ b/lib/extension/responder.js
@@ -1,4 +1,5 @@
 const zclId = require('zcl-id');
+const logger = require('../util/logger');
 
 const OneJanuary2000 = new Date('January 01, 2000 00:00:00').getTime();
 
@@ -63,11 +64,50 @@ class ExtensionResponder {
         };
     }
 
+    yunmiAutoResponse(message, endpoint) {
+        const response = { // zclData
+            cmdId: 0x0a,
+            statusCode: 0x0,
+        }
+
+        this.zigbee.publish(
+            endpoint.device.ieeeAddr, 'device', 'genPollCtrl', 'defaultRsp', 'foundation', response,
+            {direction: 1, seqNum: message.zclMsg.seqNum, disDefaultRsp: 1}, endpoint.epId,
+        );
+
+        const write_data = [{ // zclData, must be array here
+            attrId: 0x410d,
+            dataType: 0x20,
+            attrData: 0x0,
+        }];
+
+        setTimeout(() => {
+            this.zigbee.publish(
+                endpoint.device.ieeeAddr, 'device', 'genBasic', 'write', 'foundation', write_data,
+                {direction: 0, seqNum: message.zclMsg.seqNum, disDefaultRsp: 1}, endpoint.epId,
+            );
+        }, 500);
+    }
+
     onZclFoundation(message, endpoint) {
         const cmd = message.zclMsg.cmdId;
+        const cluster = zclId.cluster(message.clusterid).key;
+
+        logger.debug(`onZclFoundation(): received cmd = ${cmd}, cluster = ${cluster}`);
 
         if (cmd === 'read') {
             this.readResponse(message, endpoint);
+        }
+        // Yunmi
+        else if (cmd === 'report' && cluster === 'genPollCtrl') {
+            if (message.zclMsg.payload[0].attrId === 20480) {  // Heart beat for every 20mins
+                this.yunmiAutoResponse(message, endpoint);
+            }
+        }
+        else if (cmd === 'report' && cluster === 'genBasic') {
+            if (message.zclMsg.payload[0].attrId === 18) {  // deviceEnabled
+                this.yunmiAutoResponse(message, endpoint);
+            }
         }
     }
 }

--- a/lib/extension/responder.js
+++ b/lib/extension/responder.js
@@ -68,14 +68,14 @@ class ExtensionResponder {
         const response = { // zclData
             cmdId: 0x0a,
             statusCode: 0x0,
-        }
+        };
 
         this.zigbee.publish(
             endpoint.device.ieeeAddr, 'device', 'genPollCtrl', 'defaultRsp', 'foundation', response,
             {direction: 1, seqNum: message.zclMsg.seqNum, disDefaultRsp: 1}, endpoint.epId,
         );
 
-        const write_data = [{ // zclData, must be array here
+        const writeData = [{ // zclData, must be array here
             attrId: 0x410d,
             dataType: 0x20,
             attrData: 0x0,
@@ -83,7 +83,7 @@ class ExtensionResponder {
 
         setTimeout(() => {
             this.zigbee.publish(
-                endpoint.device.ieeeAddr, 'device', 'genBasic', 'write', 'foundation', write_data,
+                endpoint.device.ieeeAddr, 'device', 'genBasic', 'write', 'foundation', writeData,
                 {direction: 0, seqNum: message.zclMsg.seqNum, disDefaultRsp: 1}, endpoint.epId,
             );
         }, 500);
@@ -97,15 +97,12 @@ class ExtensionResponder {
 
         if (cmd === 'read') {
             this.readResponse(message, endpoint);
-        }
-        // Yunmi
-        else if (cmd === 'report' && cluster === 'genPollCtrl') {
-            if (message.zclMsg.payload[0].attrId === 20480) {  // Heart beat for every 20mins
+        } else if (cmd === 'report' && cluster === 'genPollCtrl') {
+            if (message.zclMsg.payload[0].attrId === 20480) {// Yunmi Heart beat for every 20mins
                 this.yunmiAutoResponse(message, endpoint);
             }
-        }
-        else if (cmd === 'report' && cluster === 'genBasic') {
-            if (message.zclMsg.payload[0].attrId === 18) {  // deviceEnabled
+        } else if (cmd === 'report' && cluster === 'genBasic') {
+            if (message.zclMsg.payload[0].attrId === 18) {// Yunmi deviceEnabled
                 this.yunmiAutoResponse(message, endpoint);
             }
         }


### PR DESCRIPTION
For Yunmi smart Lock device,  the coordinator needs to auto response with '`defaultRsp`' and write data with attrId 0x410d when received Heart beat and deviceEnabled.
