### PR TITLE
Add Home Assistant autodiscovery for Paulmann 50043 switch

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -437,6 +437,7 @@ const mapping = {
         configurations.binary_sensor_gas,
         configurations.sensor_gas_density,
     ],
+    '50043': [configurations.switch],
     '50045': [configurations.light_brightness],
     'AV2010/22': [configurations.binary_sensor_occupancy, configurations.sensor_battery],
     '3210-L': [configurations.switch],


### PR DESCRIPTION
Depends on https://github.com/Koenkk/zigbee-shepherd-converters/pull/424 being merged.