### PR TITLE
log friendly name when possible

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -224,7 +224,7 @@ class Zigbee {
         }
 
         const friendlyName = this.getDeviceFriendlyName(deviceID);
-        
+
         this.shepherd.remove(deviceID, {reJoin: true}, (error) => {
             if (error) {
                 logger.warn(`Failed to remove '${friendlyName}', trying force remove...`);
@@ -238,7 +238,7 @@ class Zigbee {
 
     forceRemove(deviceID, callback) {
         const device = this.shepherd._findDevByAddr(deviceID);
-        
+
         if (device) {
             const friendlyName = this.getDeviceFriendlyName(deviceID);
             return this.shepherd._unregisterDev(device, (error) => {
@@ -264,11 +264,11 @@ class Zigbee {
     getDevice(ieeeAddr) {
         return this.getDevices().find((d) => d.ieeeAddr === ieeeAddr);
     }
-    
+
     getDeviceFriendlyName(ieeeAddr) {
         let friendlyName = null;
         friendlyName = settings.getDevice(ieeeAddr).friendly_name;
-        return (friendlyName ? friendlyName : ieeeAddr)
+        return (friendlyName ? friendlyName : ieeeAddr);
     }
 
     getCoordinator() {
@@ -279,11 +279,11 @@ class Zigbee {
     getGroup(ID) {
         return this.shepherd.getGroup(ID);
     }
-    
+
     getGroupFriendlyName(ID) {
         let friendlyName = null;
         friendlyName = settings.getGroup(ID).friendly_name;
-        return (friendlyName ? friendlyName : ID)
+        return (friendlyName ? friendlyName : ID);
     }
 
     networkScan(callback) {
@@ -335,7 +335,8 @@ class Zigbee {
             const callback_ = (error, rsp) => {
                 if (error) {
                     logger.error(
-                        `Zigbee publish to ${entityType} '${friendlyName}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} ` +
+                        `Zigbee publish to ${entityType} '${friendlyName}', ${cid} ` +
+                        `- ${cmd} - ${JSON.stringify(zclData)} ` +
                         `- ${JSON.stringify(cfg)} - ${ep} ` +
                         `failed with error ${error}`);
                 }

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -94,7 +94,7 @@ class Zigbee {
 
         this.getAllClients().forEach((device) => {
             if (settings.get().ban.includes(device.ieeeAddr)) {
-                logger.warn(`Banned device is connected (${device.ieeeAddr}), removing..`);
+                logger.warn(`Banned device is connected (${device.ieeeAddr}), removing...`);
                 this.removeDevice(device.ieeeAddr, false, () => {});
             }
         });
@@ -193,7 +193,7 @@ class Zigbee {
                     if (error) {
                         logger.error('Failed to reenable joining');
                     } else {
-                        logger.info('Succesfully reenabled joining');
+                        logger.info('Successfully reenabled joining');
                     }
                 });
             }, utils.secondsToMilliseconds(200));
@@ -223,12 +223,14 @@ class Zigbee {
             settings.banDevice(deviceID);
         }
 
+        const friendlyName = this.getDeviceFriendlyName(deviceID);
+        
         this.shepherd.remove(deviceID, {reJoin: true}, (error) => {
             if (error) {
-                logger.warn(`Failed to remove '${deviceID}', trying force remove...`);
+                logger.warn(`Failed to remove '${friendlyName}', trying force remove...`);
                 this.forceRemove(deviceID, callback);
             } else {
-                logger.info(`Removed ${deviceID}`);
+                logger.info(`Removed ${friendlyName}`);
                 callback(null);
             }
         });
@@ -236,10 +238,11 @@ class Zigbee {
 
     forceRemove(deviceID, callback) {
         const device = this.shepherd._findDevByAddr(deviceID);
-
+        
         if (device) {
+            const friendlyName = this.getDeviceFriendlyName(deviceID);
             return this.shepherd._unregisterDev(device, (error) => {
-                logger.info(`Force removed ${deviceID}`);
+                logger.info(`Force removed ${friendlyName}`);
                 callback(error);
             });
         } else {
@@ -261,6 +264,12 @@ class Zigbee {
     getDevice(ieeeAddr) {
         return this.getDevices().find((d) => d.ieeeAddr === ieeeAddr);
     }
+    
+    getDeviceFriendlyName(ieeeAddr) {
+        let friendlyName = null;
+        friendlyName = settings.getDevice(ieeeAddr).friendly_name;
+        return (friendlyName ? friendlyName : ieeeAddr)
+    }
 
     getCoordinator() {
         const device = this.getDevices().find((d) => d.type === 'Coordinator');
@@ -269,6 +278,12 @@ class Zigbee {
 
     getGroup(ID) {
         return this.shepherd.getGroup(ID);
+    }
+    
+    getGroupFriendlyName(ID) {
+        let friendlyName = null;
+        friendlyName = settings.getGroup(ID).friendly_name;
+        return (friendlyName ? friendlyName : ID)
     }
 
     networkScan(callback) {
@@ -295,10 +310,13 @@ class Zigbee {
 
     publish(entityID, entityType, cid, cmd, cmdType, zclData, cfg=defaultCfg, ep, callback) {
         let entity = null;
+        let friendlyName = null;
         if (entityType === 'device') {
             entity = this.getEndpoint(entityID, ep);
+            friendlyName = this.getDeviceFriendlyName(entityID);
         } else if (entityType === 'group') {
             entity = this.getGroup(entityID);
+            friendlyName = this.getGroupFriendlyName(entityID);
         }
 
         if (!entity) {
@@ -310,14 +328,14 @@ class Zigbee {
 
         this.queue.push(entityID, (queueCallback) => {
             logger.info(
-                `Zigbee publish to ${entityType} '${entityID}', ${cid} - ${cmd} - ` +
+                `Zigbee publish to ${entityType} '${friendlyName}', ${cid} - ${cmd} - ` +
                 `${JSON.stringify(zclData)} - ${JSON.stringify(cfg)} - ${ep}`
             );
 
             const callback_ = (error, rsp) => {
                 if (error) {
                     logger.error(
-                        `Zigbee publish to ${entityType} '${entityID}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} ` +
+                        `Zigbee publish to ${entityType} '${friendlyName}', ${cid} - ${cmd} - ${JSON.stringify(zclData)} ` +
                         `- ${JSON.stringify(cfg)} - ${ep} ` +
                         `failed with error ${error}`);
                 }
@@ -340,11 +358,12 @@ class Zigbee {
     }
 
     ping(ieeeAddr, errorLogLevel='error', cb, mechanism='default') {
+        const friendlyName = this.getDeviceFriendlyName(ieeeAddr);
         const callback = (error) => {
             if (error) {
-                logger[errorLogLevel](`Failed to ping ${ieeeAddr}`);
+                logger[errorLogLevel](`Failed to ping '${friendlyName}'`);
             } else {
-                logger.debug(`Successfully pinged ${ieeeAddr}`);
+                logger.debug(`Successfully pinged '${friendlyName}'`);
             }
 
             if (cb) {
@@ -378,7 +397,8 @@ class Zigbee {
     }
 
     bind(ep, cluster, target, callback) {
-        const log = ` ${ep.device.ieeeAddr} - ${cluster}`;
+        const friendlyName = this.getDeviceFriendlyName(ep.device.ieeeAddr);
+        const log = ` '${friendlyName}' - ${cluster}`;
         target = !target ? this.getCoordinator() : target;
 
         this.queue.push(ep.device.ieeeAddr, (queueCallback) => {
@@ -397,7 +417,8 @@ class Zigbee {
     }
 
     unbind(ep, cluster, target, callback) {
-        const log = ` ${ep.device.ieeeAddr} - ${cluster}`;
+        const friendlyName = this.getDeviceFriendlyName(ep.device.ieeeAddr);
+        const log = ` '${friendlyName}' - ${cluster}`;
         target = !target ? this.getCoordinator() : target;
 
         this.queue.push(ep.device.ieeeAddr, (queueCallback) => {
@@ -425,6 +446,7 @@ class Zigbee {
      *     change  the minimum amount of change before sending a report
      */
     report(ep, cluster, attributes) {
+        const friendlyName = this.getDeviceFriendlyName(ep.device.ieeeAddr);
         const cfgArr = attributes.map((attribute) => {
             const attrId = zclId.attr(cluster, attribute.attr).value;
             const dataType = zclId.attrType(cluster, attribute.attr).value;
@@ -438,7 +460,7 @@ class Zigbee {
             };
         });
 
-        const log=`for ${ep.device.ieeeAddr} - ${cluster} - ${attributes.length}`;
+        const log=`for '${friendlyName}' - ${cluster} - ${attributes.length}`;
 
         const configReport = () => {
             this.queue.push(ep.device.ieeeAddr, (queueCallback) => {


### PR DESCRIPTION
Modifed logging to use friendly_name when defined via settings. Makes logging more consistent as now logs for MQTT publish as well as logs for Zigbee publish/bind/ping/report show the friendly_name.