### PR TITLE
Simpler network map scan

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -296,15 +296,8 @@ class Zigbee {
         var allScans = this.getScanable().map(dev => {
             return this.shepherd.lqi(dev.ieeeAddr).then(processResponse(dev.ieeeAddr, this.shepherd));
         }, this);
-        Promise.all(allScans).then(result => {
-            var linkMap = [];
-            result.forEach(getResults);
-            function getResults(value) {
-                value.forEach(collectLinks);
-            }
-            function collectLinks(value) {
-                linkMap.push(value);
-            }
+        Promise.all(allScans).then(linkSets => {
+            const linkMap = [].concat(...linkSets);
             logger.info('Network scan completed');
             callback(linkMap);
         })

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -267,15 +267,52 @@ class Zigbee {
         return this.shepherd.find(device.ieeeAddr, 1);
     }
 
+    getScanable() {
+        return this.getDevices().filter((d) => d.type != 'EndDevice');
+    }
+
     getGroup(ID) {
         return this.shepherd.getGroup(ID);
     }
 
     networkScan(callback) {
-        logger.info('Starting network scan...');
-        this.shepherd.lqiScan().then((result) => {
+        logger.info('Network scan commenced');
+
+        const processResponse = function(parent, shepherd){
+            return function(data){
+                const linkSet = [];
+                return new Promise(resolve => {
+                    data.forEach(function (devinfo) {
+                        const childIeeeAddr = devinfo.ieeeAddr;
+                        const linkKey = parent + '|' + childIeeeAddr
+                        let childDev = shepherd._findDevByAddr(childIeeeAddr);
+                        devinfo.parent = parent;
+                        devinfo.status = childDev ? childDev.status : "offline";
+                        linkSet.push(devinfo);
+                    });
+                    resolve(linkSet);
+                });
+            }
+        }
+
+        var allScans = this.getScanable().map(dev => {
+            return this.shepherd.lqi(dev.ieeeAddr).then(processResponse(dev.ieeeAddr, this.shepherd));
+        }, this);
+        Promise.all(allScans).then(result => {
+            var linkMap = [];
+            result.forEach(getResults);
+            function getResults(value) {
+                value.forEach(collectLinks);
+            }
+            function collectLinks(value) {
+                linkMap.push(value);
+            }
             logger.info('Network scan completed');
-            callback(result);
+            callback(linkMap);
+        })
+        .catch(function(){
+            logger.info('Network scan failed');
+            callback([]);
         });
     }
 

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -278,33 +278,33 @@ class Zigbee {
     networkScan(callback) {
         logger.info('Starting network scan...');
 
-        const processResponse = function(parent, shepherd){
-            return function(data){
+        const processResponse = function(parent, shepherd) {
+            return function(data) {
                 const linkSet = [];
-                return new Promise(resolve => {
-                    data.forEach(function (devinfo) {
-                        let childDev = shepherd._findDevByAddr(devinfo.ieeeAddr);
+                return new Promise((resolve) => {
+                    data.forEach(function(devinfo) {
+                        const childDev = shepherd._findDevByAddr(devinfo.ieeeAddr);
                         devinfo.parent = parent;
-                        devinfo.status = childDev ? childDev.status : "offline";
+                        devinfo.status = childDev ? childDev.status : 'offline';
                         linkSet.push(devinfo);
                     });
                     resolve(linkSet);
                 });
-            }
-        }
+            };
+        };
 
-        var allScans = this.getScanable().map(dev => {
+        const allScans = this.getScanable().map((dev) => {
             return this.shepherd.lqi(dev.ieeeAddr).then(processResponse(dev.ieeeAddr, this.shepherd));
         }, this);
-        Promise.all(allScans).then(linkSets => {
+        Promise.all(allScans).then((linkSets) => {
             const linkMap = [].concat(...linkSets);
             logger.info('Network scan completed');
             callback(linkMap);
         })
-        .catch(function(){
-            logger.info('Network scan failed');
-            callback([]);
-        });
+            .catch(function() {
+                logger.info('Network scan failed');
+                callback([]);
+            });
     }
 
     getEndpoint(ieeeAddr, ep) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -283,9 +283,7 @@ class Zigbee {
                 const linkSet = [];
                 return new Promise(resolve => {
                     data.forEach(function (devinfo) {
-                        const childIeeeAddr = devinfo.ieeeAddr;
-                        const linkKey = parent + '|' + childIeeeAddr
-                        let childDev = shepherd._findDevByAddr(childIeeeAddr);
+                        let childDev = shepherd._findDevByAddr(devinfo.ieeeAddr);
                         devinfo.parent = parent;
                         devinfo.status = childDev ? childDev.status : "offline";
                         linkSet.push(devinfo);

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -276,7 +276,7 @@ class Zigbee {
     }
 
     networkScan(callback) {
-        logger.info('Network scan commenced');
+        logger.info('Starting network scan...');
 
         const processResponse = function(parent, shepherd){
             return function(data){


### PR DESCRIPTION
So the network map is currently built by a recursive treewalk of connected devices by this code in zigbee-shepherd https://github.com/Koenkk/zigbee-shepherd/blob/52d54ddb30a4ddc0722c51e077b4d843f0f52a6e/lib/shepherd.js#L479

However, this seems fragile even with enhancements I made a few days ago https://github.com/Koenkk/zigbee-shepherd/pull/23. The treewalk needs to keep track of nodes already visited and any failures can leave child branches unexplored unless there is a redundant path.

Rethinking the whole approach, it isn't necessary to walk the tree. All that is needed is to check each and every coordinator/router to get their neighbor table which has the necessary lqi information. So, this PR instead does a simple loop through all coordinator/router devices regardless of their actual network relationship. The code has been moved to zigbee.js as that is the best place that has access to the device list and can still invoke the zigbee-shepherd lqi request https://github.com/Koenkk/zigbee-shepherd/blob/52d54ddb30a4ddc0722c51e077b4d843f0f52a6e/lib/shepherd.js#L442

I believe this approach should be intrinsically more robust however I am not sure I've got the promise error handling exactly right. I'd be keen to see if this can be tested on some larger networks, particularly those that are having problems generating their network map.