### PR TITLE
Network map error handling

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -327,11 +327,13 @@ class Zigbee {
         const allScans = this.getScanable().map((dev) => {
             logger.debug(`Preparing asynch network scan for '${dev.ieeeAddr}'`);
             return this.shepherd.lqi(dev.ieeeAddr)
-                .then(processResponse(dev.ieeeAddr, this.shepherd)) 
-                .catch(() => {return new Promise((resolve) => [])});
+                .then(processResponse(dev.ieeeAddr, this.shepherd))
+                .catch(() => {
+                    return new Promise((resolve) => []);
+                });
         }, this);
         logger.debug('All network map promises created');
-        // Collect all lqi scan results but timeout after specified miliseconds if any haven't completed 
+        // Collect all lqi scan results but timeout after specified miliseconds if any haven't completed
         Promise.raceAll(allScans, 8000, []).then((linkSets) => {
             const linkMap = [].concat(...linkSets);
             logger.info('Network scan completed');

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -317,13 +317,9 @@ class Zigbee {
                             devinfo.status = childDev ? childDev.status : 'offline';
                             linkSet.push(devinfo);
                         });
-                        resolve(linkSet);
-                        logger.debug(`Processed device: '${parent}', linkSet: %j`, linkSet);
-                    } else {
-                        // Scan failed but return an empty result that can still be aggregated
-                        resolve([]);
-                        logger.debug(`Failing processing for: '${parent}'`);
                     }
+                    resolve(linkSet);
+                    logger.debug(`Processed device: '${parent}', linkSet: %j`, linkSet);
                 });
             };
         };

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -309,25 +309,34 @@ class Zigbee {
             return function(data) {
                 const linkSet = [];
                 return new Promise((resolve) => {
-                    data.forEach(function(devinfo) {
-                        const childDev = shepherd._findDevByAddr(devinfo.ieeeAddr);
-                        devinfo.parent = parent;
-                        devinfo.status = childDev ? childDev.status : 'offline';
-                        linkSet.push(devinfo);
-                    });
-                    resolve(linkSet);
-                    logger.debug(`Processed device: '${parent}', linkSet: %j`, linkSet);
+                    logger.debug(`Processing scan for: '${parent}'`);
+                    if (data) {
+                        data.forEach(function(devinfo) {
+                            const childDev = shepherd._findDevByAddr(devinfo.ieeeAddr);
+                            devinfo.parent = parent;
+                            devinfo.status = childDev ? childDev.status : 'offline';
+                            linkSet.push(devinfo);
+                        });
+                        resolve(linkSet);
+                        logger.debug(`Processed device: '${parent}', linkSet: %j`, linkSet);
+                    } else {
+                        // Scan failed but return an empty result that can still be aggregated
+                        resolve([]);
+                        logger.debug(`Failing processing for: '${parent}'`);
+                    }
                 });
             };
         };
 
         const allScans = this.getScanable().map((dev) => {
             logger.debug(`Preparing asynch network scan for '${dev.ieeeAddr}'`);
-            return this.shepherd.lqi(dev.ieeeAddr).then(processResponse(dev.ieeeAddr, this.shepherd));
+            return this.shepherd.lqi(dev.ieeeAddr)
+                .then(processResponse(dev.ieeeAddr, this.shepherd)) 
+                .catch(() => {return new Promise((resolve) => [])});
         }, this);
         logger.debug('All network map promises created');
-        // Collect all lqi scans but timeout after 2 seconds if any fail
-        Promise.raceAll(allScans, 2000, []).then((linkSets) => {
+        // Collect all lqi scan results but timeout after specified miliseconds if any haven't completed 
+        Promise.raceAll(allScans, 8000, []).then((linkSets) => {
             const linkMap = [].concat(...linkSets);
             logger.info('Network scan completed');
             logger.debug(`Link map: %j`, linkMap);


### PR DESCRIPTION
Catch errors from individual router lqi scans so the overall network map can still be constructed excluding those failed routers.