### PR TITLE
Network map fixes

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -324,7 +324,8 @@ class Zigbee {
 
         const allScans = this.getScanable().map((dev) => {
             logger.debug(`Preparing asynch network scan for '${dev.ieeeAddr}'`);
-            return this.shepherd.lqi(dev.ieeeAddr)
+            // Delay the start of each device scan by a random time to avoid network congestion
+            return Promise.delay(Math.random()*4000, this.shepherd.lqi(dev.ieeeAddr))
                 .then(processResponse(dev.ieeeAddr))
                 .catch(() => {
                     return new Promise((resolve) => []);
@@ -333,9 +334,10 @@ class Zigbee {
         logger.debug('All network map promises created');
         // Collect all lqi scan results but timeout after specified miliseconds if any haven't completed
         Promise.raceAll(allScans, 8000, []).then((linkSets) => {
-            const linkMap = [].concat(...linkSets);
-            logger.info('Network scan completed');
+            // Assemble the individual scan results then sort by ieeeAddr to generate consistent maps
+            const linkMap = [].concat(...linkSets).sort((a,b) => (a.ieeeAddr > b.ieeeAddr) ? 1 : ((b.ieeeAddr > a.ieeeAddr) ? -1 : 0));
             logger.debug(`Link map: %j`, linkMap);
+            logger.info('Network scan completed');
             callback(linkMap);
         })
             .catch(function(result) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -325,7 +325,7 @@ class Zigbee {
         const allScans = this.getScanable().map((dev) => {
             logger.debug(`Preparing asynch network scan for '${dev.ieeeAddr}'`);
             // Delay the start of each device scan by a random time to avoid network congestion
-            return Promise.delay(Math.random()*4000, this.shepherd.lqi(dev.ieeeAddr))
+            return Promise.delay(Math.random()*3000, this.shepherd.lqi(dev.ieeeAddr))
                 .then(processResponse(dev.ieeeAddr))
                 .catch(() => {
                     return new Promise((resolve) => []);
@@ -335,7 +335,9 @@ class Zigbee {
         // Collect all lqi scan results but timeout after specified miliseconds if any haven't completed
         Promise.raceAll(allScans, 8000, []).then((linkSets) => {
             // Assemble the individual scan results then sort by ieeeAddr to generate consistent maps
-            const linkMap = [].concat(...linkSets).sort((a,b) => (a.ieeeAddr > b.ieeeAddr) ? 1 : ((b.ieeeAddr > a.ieeeAddr) ? -1 : 0));
+            const linkMap = [].concat(...linkSets)
+                .sort((a,b) => ((a.parent + '|' + a.ieeeAddr) > (a.parent + '|' + b.ieeeAddr)) ? 1
+                    : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
             logger.info('Network scan completed');
             logger.debug(`Link map: %j`, linkMap);
             callback(linkMap);

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -336,7 +336,7 @@ class Zigbee {
         Promise.raceAll(allScans, 8000, []).then((linkSets) => {
             // Assemble the individual scan results then sort by ieeeAddr to generate consistent maps
             const linkMap = [].concat(...linkSets)
-                .sort((a,b) => ((a.parent + '|' + a.ieeeAddr) > (a.parent + '|' + b.ieeeAddr)) ? 1
+                .sort((a,b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
                     : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
             logger.info('Network scan completed');
             logger.debug(`Link map: %j`, linkMap);

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -336,8 +336,8 @@ class Zigbee {
         Promise.raceAll(allScans, 8000, []).then((linkSets) => {
             // Assemble the individual scan results then sort by ieeeAddr to generate consistent maps
             const linkMap = [].concat(...linkSets).sort((a,b) => (a.ieeeAddr > b.ieeeAddr) ? 1 : ((b.ieeeAddr > a.ieeeAddr) ? -1 : 0));
-            logger.debug(`Link map: %j`, linkMap);
             logger.info('Network scan completed');
+            logger.debug(`Link map: %j`, linkMap);
             callback(linkMap);
         })
             .catch(function(result) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -304,7 +304,7 @@ class Zigbee {
             }));
         };
 
-        const processResponse = function(parent, shepherd) {
+        const processResponse = function(parent) {
             logger.debug(`Scanning device: '${parent}'`);
             return function(data) {
                 const linkSet = [];
@@ -312,9 +312,7 @@ class Zigbee {
                     logger.debug(`Processing scan for: '${parent}'`);
                     if (data) {
                         data.forEach(function(devinfo) {
-                            const childDev = shepherd._findDevByAddr(devinfo.ieeeAddr);
                             devinfo.parent = parent;
-                            devinfo.status = childDev ? childDev.status : 'offline';
                             linkSet.push(devinfo);
                         });
                     }
@@ -327,7 +325,7 @@ class Zigbee {
         const allScans = this.getScanable().map((dev) => {
             logger.debug(`Preparing asynch network scan for '${dev.ieeeAddr}'`);
             return this.shepherd.lqi(dev.ieeeAddr)
-                .then(processResponse(dev.ieeeAddr, this.shepherd))
+                .then(processResponse(dev.ieeeAddr))
                 .catch(() => {
                     return new Promise((resolve) => []);
                 });

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -336,7 +336,7 @@ class Zigbee {
         Promise.raceAll(allScans, 8000, []).then((linkSets) => {
             // Assemble the individual scan results then sort by ieeeAddr to generate consistent maps
             const linkMap = [].concat(...linkSets)
-                .sort((a,b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
+                .sort((a, b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
                     : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
             logger.info('Network scan completed');
             logger.debug(`Link map: %j`, linkMap);


### PR DESCRIPTION
Remove invalid device status from network map topology plus add a random delay to the start of each scan request to avoid overloading the network. Sort the resultant network map links so the map is generated consistently.