### PR TITLE
Also match network map link by short address

### DIFF
--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -50,7 +50,7 @@ class NetworkMap {
             const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
 
             // Add friendly name
-            labels.push(friendlyName);
+            labels.push(friendlyName+":"+device.nwkAddr);
 
             // Add the device type
             labels.push(device.type);
@@ -85,7 +85,7 @@ class NetworkMap {
              * NOTE: There are situations where a device is NOT in the topology, this can be e.g.
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
-            topology.filter((e) => e.ieeeAddr === device.ieeeAddr).forEach((e) => {
+            topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
                 const lineStyle = (e.lqi==0) ? `style="dashed", ` : ``;
                 text += `  "${device.ieeeAddr}" -> "${e.parent}" [`+lineStyle+`label="${e.lqi}"]\n`;
             });


### PR DESCRIPTION
Helps keep the network map complete even if a router neighbor table gets corrupted with ieee address set to all zeros. It does this by also matching links and devices on short address.

Also displays the short address alongside the ieee address in the map.