### PR TITLE
Network map rewrite using queue

### DIFF
--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -341,7 +341,7 @@ class Zigbee {
             });
         });
 
-        // Wait up to 8 seconds for all device scans before forcing map with whatever results are already in
+        // Wait for all device scans before forcing map with whatever results are already in
         setTimeout(() => {
             if (scanList.size === 0) {
                 logger.info('Network scan timeout no outstanding requests');
@@ -354,7 +354,7 @@ class Zigbee {
                     : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
                 callback(linkMap);
             }
-        }, 8000);
+        }, scanList.size * 1000);
     }
 
     getEndpoint(ieeeAddr, ep) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -335,9 +335,9 @@ class Zigbee {
             this.queue.push(dev.ieeeAddr, (queueCallback) => {
                 this.shepherd.controller.request('ZDO', 'mgmtLqiReq', {dstaddr: dev.nwkAddr, startindex: 0},
                     (error, rsp, parent) => {
-                    processResponse(error, rsp, dev.ieeeAddr);
-                    queueCallback(error);
-                });
+                        processResponse(error, rsp, dev.ieeeAddr);
+                        queueCallback(error);
+                    });
             });
         });
 

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -301,7 +301,7 @@ class Zigbee {
                 if (scanList.has(parent)) {
                     // Haven't processed this one yet
                     if (rsp && rsp.status === 0 && rsp.neighborlqilist) {
-                        logger.debug(`Network scan ok for device: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
+                        logger.debug(`Network scan ok for: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
                         rsp.neighborlqilist.forEach(function(neighbor) {
                             linkMap.push({
                                 parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
@@ -320,12 +320,12 @@ class Zigbee {
                         }
                     } else {
                         logger.warn(`Empty network scan result for: '${parent}'`);
-                    };
+                    }
                 } else {
                     // This ieeeAddr has already been removed due to timeout so don't add to result network map
-                    console.warn(`Ignoring late network scan result for: '${parent}'`);
-                };
-            };
+                    logger.warn(`Ignoring late network scan result for: '${parent}'`);
+                }
+            }
         };
 
         // Queue up an lqi scan for coordinator and each router
@@ -333,7 +333,8 @@ class Zigbee {
             logger.debug(`Queing network scan for device: '${dev.ieeeAddr}'`);
             scanList.add(dev.ieeeAddr);
             this.queue.push(dev.ieeeAddr, (queueCallback) => {
-                this.shepherd.controller.request('ZDO', 'mgmtLqiReq', { dstaddr: dev.nwkAddr, startindex: 0 }, (error, rsp, parent) => {
+                this.shepherd.controller.request('ZDO', 'mgmtLqiReq', {dstaddr: dev.nwkAddr, startindex: 0},
+                    (error, rsp, parent) => {
                     processResponse(error, rsp, dev.ieeeAddr);
                     queueCallback(error);
                 });
@@ -354,7 +355,6 @@ class Zigbee {
                 callback(linkMap);
             }
         }, 8000);
-
     }
 
     getEndpoint(ieeeAddr, ep) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -291,61 +291,70 @@ class Zigbee {
 
     networkScan(callback) {
         logger.info('Starting network scan...');
+        const routerList = new Set();
+        const linkMap = [];
 
-        Promise.delay = function(t, val) {
-            return new Promise((resolve) => {
-                setTimeout(resolve.bind(null, val), t);
-            });
-        };
-
-        Promise.raceAll = function(promises, timeoutTime, timeoutVal) {
-            return Promise.all(promises.map((p) => {
-                return Promise.race([p, Promise.delay(timeoutTime, timeoutVal)]);
-            }));
-        };
-
-        const processResponse = function(parent) {
-            logger.debug(`Scanning device: '${parent}'`);
-            return function(data) {
-                const linkSet = [];
-                return new Promise((resolve) => {
-                    logger.debug(`Processing scan for: '${parent}'`);
-                    if (data) {
-                        data.forEach(function(devinfo) {
-                            devinfo.parent = parent;
-                            linkSet.push(devinfo);
+        const processResponse = (error, rsp, parent) => {
+            if (error) {
+                logger.warn(`Failed network scan for device: '${parent}' with error: '${error}'`);
+            } else {
+                if (routerList.has(parent)) {
+                    // Haven't processed this one yet
+                    if (rsp && rsp.status === 0 && rsp.neighborlqilist) {
+                        logger.debug(`Network scan ok for device: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
+                        rsp.neighborlqilist.forEach(function(neighbor) {
+                            linkMap.push({
+                                parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
+                                lqi: neighbor.lqi, depth: neighbor.depth});
                         });
-                    }
-                    resolve(linkSet);
-                    logger.debug(`Processed device: '${parent}', linkSet: %j`, linkSet);
-                });
+                        // Remove from list and if this was the last one return the completed network map
+                        routerList.delete(parent);
+                        if (routerList.size === 0) {
+                            logger.info('Network scan completed');
+                            linkMap.sort((a, b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
+                                : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
+                            logger.debug(`Link map (complete): %j`, linkMap);
+                            callback(linkMap);
+                        } else {
+                            logger.debug(`Still waiting for network scans for devices: '${[...routerList].join(' ')}'`);
+                        }
+                    } else {
+                        logger.warn(`Empty network scan result for: '${parent}'`);
+                    };
+                } else {
+                    // This ieeeAddr has already been removed due to timeout so don't add to result network map
+                    console.warn(`Ignoring late network scan result for: '${parent}'`);
+                };
             };
         };
 
-        const allScans = this.getScanable().map((dev) => {
-            logger.debug(`Preparing asynch network scan for '${dev.ieeeAddr}'`);
-            // Delay the start of each device scan by a random time to avoid network congestion
-            return Promise.delay(Math.random()*3000, this.shepherd.lqi(dev.ieeeAddr))
-                .then(processResponse(dev.ieeeAddr))
-                .catch(() => {
-                    return new Promise((resolve) => []);
+        // Queue up an lqi scan for coordinator and each router
+        this.getScanable().forEach((dev) => {
+            logger.debug(`Queing network scan for device: '${dev.ieeeAddr}'`);
+            routerList.add(dev.ieeeAddr);
+            this.queue.push(dev.ieeeAddr, (queueCallback) => {
+                this.shepherd.controller.request('ZDO', 'mgmtLqiReq', { dstaddr: dev.nwkAddr, startindex: 0 }, (error, rsp, parent) => {
+                    processResponse(error, rsp, dev.ieeeAddr);
+                    queueCallback(error);
                 });
-        }, this);
-        logger.debug('All network map promises created');
-        // Collect all lqi scan results but timeout after specified miliseconds if any haven't completed
-        Promise.raceAll(allScans, 8000, []).then((linkSets) => {
-            // Assemble the individual scan results then sort by ieeeAddr to generate consistent maps
-            const linkMap = [].concat(...linkSets)
-                .sort((a, b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
-                    : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
-            logger.info('Network scan completed');
-            logger.debug(`Link map: %j`, linkMap);
-            callback(linkMap);
-        })
-            .catch(function(result) {
-                logger.info(`Network scan failed: '${result}'`);
-                callback([]);
             });
+        });
+
+        // Wait up to 8 seconds for all device scans before forcing map with whatever results are already in
+        setTimeout(() => {
+            if (routerList.size === 0) {
+                logger.info('Network scan timeout no outstanding requests');
+            } else {
+                logger.warn(`Network scan timeout, skipping outstanding scans for '${[...routerList].join(' ')}'`);
+                // Clear remaining devices so they don't process when/if they eventually complete
+                routerList.clear();
+                logger.debug(`Link map (timeout): %j`, linkMap);
+                linkMap.sort((a, b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
+                    : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
+                callback(linkMap);
+            }
+        }, 8000);
+
     }
 
     getEndpoint(ieeeAddr, ep) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -291,14 +291,14 @@ class Zigbee {
 
     networkScan(callback) {
         logger.info('Starting network scan...');
-        const routerList = new Set();
+        const scanList = new Set();
         const linkMap = [];
 
         const processResponse = (error, rsp, parent) => {
             if (error) {
                 logger.warn(`Failed network scan for device: '${parent}' with error: '${error}'`);
             } else {
-                if (routerList.has(parent)) {
+                if (scanList.has(parent)) {
                     // Haven't processed this one yet
                     if (rsp && rsp.status === 0 && rsp.neighborlqilist) {
                         logger.debug(`Network scan ok for device: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
@@ -308,15 +308,15 @@ class Zigbee {
                                 lqi: neighbor.lqi, depth: neighbor.depth});
                         });
                         // Remove from list and if this was the last one return the completed network map
-                        routerList.delete(parent);
-                        if (routerList.size === 0) {
+                        scanList.delete(parent);
+                        if (scanList.size === 0) {
                             logger.info('Network scan completed');
                             linkMap.sort((a, b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
                                 : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
                             logger.debug(`Link map (complete): %j`, linkMap);
                             callback(linkMap);
                         } else {
-                            logger.debug(`Still waiting for network scans for devices: '${[...routerList].join(' ')}'`);
+                            logger.debug(`Still waiting for network scans for devices: '${[...scanList].join(' ')}'`);
                         }
                     } else {
                         logger.warn(`Empty network scan result for: '${parent}'`);
@@ -331,7 +331,7 @@ class Zigbee {
         // Queue up an lqi scan for coordinator and each router
         this.getScanable().forEach((dev) => {
             logger.debug(`Queing network scan for device: '${dev.ieeeAddr}'`);
-            routerList.add(dev.ieeeAddr);
+            scanList.add(dev.ieeeAddr);
             this.queue.push(dev.ieeeAddr, (queueCallback) => {
                 this.shepherd.controller.request('ZDO', 'mgmtLqiReq', { dstaddr: dev.nwkAddr, startindex: 0 }, (error, rsp, parent) => {
                     processResponse(error, rsp, dev.ieeeAddr);
@@ -342,12 +342,12 @@ class Zigbee {
 
         // Wait up to 8 seconds for all device scans before forcing map with whatever results are already in
         setTimeout(() => {
-            if (routerList.size === 0) {
+            if (scanList.size === 0) {
                 logger.info('Network scan timeout no outstanding requests');
             } else {
-                logger.warn(`Network scan timeout, skipping outstanding scans for '${[...routerList].join(' ')}'`);
+                logger.warn(`Network scan timeout, skipping outstanding scans for '${[...scanList].join(' ')}'`);
                 // Clear remaining devices so they don't process when/if they eventually complete
-                routerList.clear();
+                scanList.clear();
                 logger.debug(`Link map (timeout): %j`, linkMap);
                 linkMap.sort((a, b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
                     : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));


### PR DESCRIPTION
Total rewrite of network scan code to use the queue. Had to ditch all the promise style coding and revert to callbacks. Also elevated the actual lqi scan code out of zigbee-shepherd and embeded it here.

So both zigbee-shepherd lqi https://github.com/Koenkk/zigbee-shepherd/blob/f6dc5b4469a87c90007dfc9f0d329cdb01d35072/lib/shepherd.js#L443 and  zigbee-shepherd lqiScan https://github.com/Koenkk/zigbee-shepherd/blob/f6dc5b4469a87c90007dfc9f0d329cdb01d35072/lib/shepherd.js#L480 are presumably dead code but no need to clean up immediately.

This rewrite follows previous method: collect a list of all scanable devices then scan them individually with no regard to tree structure. Returns the map immediately once it gets all device scans back but will otherwise timeout after 8 seconds and return all results it has collected by then.

I've tested with some routers powered off etc but since this is a total rewrite it is going to need broader testing especially around error handling.