### PR TITLE
Include last seen in device boxes on graphviz map

### DIFF
--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -75,6 +75,9 @@ class DeviceReceive {
             return;
         }
 
+        // Add last_seen to state
+        this.state.set(device.ieeeAddr, {'last_seen': Date.now()});
+
         // After this point we cant handle message withoud cid or cmdId anymore.
         if (!message.data || (!message.data.cid && !message.data.cmdId)) {
             return;

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -75,9 +75,6 @@ class DeviceReceive {
             return;
         }
 
-        // Add last_seen to state
-        this.state.set(device.ieeeAddr, {'last_seen': Date.now()});
-
         // After this point we cant handle message withoud cid or cmdId anymore.
         if (!message.data || (!message.data.cid && !message.data.cmdId)) {
             return;
@@ -161,16 +158,8 @@ class DeviceReceive {
 
             // Add last seen timestamp
             const now = Date.now();
-            switch (settings.get().advanced.last_seen) {
-            case 'ISO_8601':
-                payload.last_seen = new Date(now).toISOString();
-                break;
-            case 'ISO_8601_local':
-                payload.last_seen = utils.toLocalISOString(new Date(now));
-                break;
-            case 'epoch':
-                payload.last_seen = now;
-                break;
+            if (settings.get().advanced.last_seen !== 'disable') {
+                payload.last_seen = utils.formatDate(now, settings.get().advanced.last_seen);
             }
 
             if (settings.get().advanced.elapsed) {

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -1,5 +1,4 @@
 const settings = require('../util/settings');
-const logger = require('../util/logger');
 const utils = require('../util/utils');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 
@@ -8,6 +7,7 @@ class NetworkMap {
         this.zigbee = zigbee;
         this.mqtt = mqtt;
         this.state = state;
+        this.lastSeenMap = {};
 
         // Subscribe to topic.
         this.topic = `${settings.get().mqtt.base_topic}/bridge/networkmap`;
@@ -19,6 +19,12 @@ class NetworkMap {
         };
     }
 
+    onZigbeeMessage(message, device, mappedDevice) {
+        if (device) {
+            this.lastSeenMap[device.ieeeAddr] = Date.now();
+        }
+    }
+
     onMQTTConnected() {
         this.mqtt.subscribe(this.topic);
     }
@@ -28,7 +34,7 @@ class NetworkMap {
 
         if (topic === this.topic && this.supportedFormats.hasOwnProperty(message)) {
             this.zigbee.networkScan((result)=> {
-                const converted = this.supportedFormats[message](this.zigbee, this.state, result);
+                const converted = this.supportedFormats[message](this.zigbee, result);
                 this.mqtt.publish(`bridge/networkmap/${message}`, converted, {});
             });
 
@@ -38,11 +44,11 @@ class NetworkMap {
         return false;
     }
 
-    raw(zigbee, state, topology) {
+    raw(zigbee, topology) {
         return JSON.stringify(topology);
     }
 
-    graphviz(zigbee, state, topology) {
+    graphviz(zigbee, topology) {
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
 
@@ -69,34 +75,10 @@ class NetworkMap {
             }
 
             // Add the device status (online/offline) and last_seen timestamp
-            let last_seen = 'unknown';
-            const dev_state = state.get(device.ieeeAddr);
-            if (device.type == 'Coordinator' || (dev_state && dev_state.last_seen)) {
-                let now = Date.now();
-                let then = now;
-                if (dev_state && dev_state.last_seen) {
-                    then = dev_state.last_seen;
-                }
-                switch (settings.get().advanced.last_seen) {
-                case 'ISO_8601':
-                    last_seen = new Date(then).toISOString();
-                    break;
-                case 'ISO_8601_local':
-                    last_seen = utils.toLocalISOString(new Date(then));
-                    break;
-                case 'epoch':
-                    last_seen = then;
-                    break;
-                default:
-                    if (device.type == 'Coordinator') {
-                        last_seen = utils.toLocalISOString(new Date(then));
-                    } else {
-                        last_seen = new Date(now - then).toISOString().substr(11, 8) + 's ago';
-                    }
-                    break;
-                }
-            }
-            labels.push(device.status + ' ' + last_seen);
+            let lastSeen = device.type == 'Coordinator' ? Date.now() : this.lastSeenMap[device.ieeeAddr] || 'unknown';
+            const defaultLastSeen = `${new Date(Date.now() - lastSeen).toISOString().substr(11, 8)}'s ago`;
+            lastSeen = utils.formatDate(lastSeen, settings.get().advanced.last_seen, defaultLastSeen);
+            labels.push(`${device.status} (${lastSeen})`);
 
             // Shape the record according to device type
             if (deviceType == 'Coordinator') {

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -85,7 +85,7 @@ class NetworkMap {
                     utils.toLocalISOString(new Date(Date.now())));
             } else {
                 if (this.lastSeenMap[device.ieeeAddr]) {
-                    const lastSeenAgo = 
+                    const lastSeenAgo =
                         `${new Date(Date.now() - this.lastSeenMap[device.ieeeAddr]).toISOString().substr(11, 8)}s ago`;
                     lastSeen = utils.formatDate(this.lastSeenMap[device.ieeeAddr],
                         settings.get().advanced.last_seen, lastSeenAgo);

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -12,6 +12,10 @@ class NetworkMap {
         // Subscribe to topic.
         this.topic = `${settings.get().mqtt.base_topic}/bridge/networkmap`;
 
+        // Bind
+        this.raw = this.raw.bind(this);
+        this.graphviz = this.graphviz.bind(this);
+
         // Set supported formats
         this.supportedFormats = {
             'raw': this.raw,

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -1,4 +1,5 @@
 const settings = require('../util/settings');
+const logger = require('../util/logger');
 const utils = require('../util/utils');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 
@@ -27,7 +28,7 @@ class NetworkMap {
 
         if (topic === this.topic && this.supportedFormats.hasOwnProperty(message)) {
             this.zigbee.networkScan((result)=> {
-                const converted = this.supportedFormats[message](this.zigbee, result);
+                const converted = this.supportedFormats[message](this.zigbee, this.state, result);
                 this.mqtt.publish(`bridge/networkmap/${message}`, converted, {});
             });
 
@@ -37,11 +38,11 @@ class NetworkMap {
         return false;
     }
 
-    raw(zigbee, topology) {
+    raw(zigbee, state, topology) {
         return JSON.stringify(topology);
     }
 
-    graphviz(zigbee, topology) {
+    graphviz(zigbee, state, topology) {
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
 
@@ -67,8 +68,35 @@ class NetworkMap {
                 labels.push(zigbeeModel ? zigbeeModel : 'No model information available');
             }
 
-            // Add the device status (online/offline)
-            labels.push(device.status);
+            // Add the device status (online/offline) and last_seen timestamp
+            let last_seen = 'unknown';
+            const dev_state = state.get(device.ieeeAddr);
+            if (device.type == 'Coordinator' || (dev_state && dev_state.last_seen)) {
+                let now = Date.now();
+                let then = now;
+                if (dev_state && dev_state.last_seen) {
+                    then = dev_state.last_seen;
+                }
+                switch (settings.get().advanced.last_seen) {
+                case 'ISO_8601':
+                    last_seen = new Date(then).toISOString();
+                    break;
+                case 'ISO_8601_local':
+                    last_seen = utils.toLocalISOString(new Date(then));
+                    break;
+                case 'epoch':
+                    last_seen = then;
+                    break;
+                default:
+                    if (device.type == 'Coordinator') {
+                        last_seen = utils.toLocalISOString(new Date(then));
+                    } else {
+                        last_seen = new Date(now - then).toISOString().substr(11, 8) + 's ago';
+                    }
+                    break;
+                }
+            }
+            labels.push(device.status + ' ' + last_seen);
 
             // Shape the record according to device type
             if (deviceType == 'Coordinator') {

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -79,9 +79,18 @@ class NetworkMap {
             }
 
             // Add the device status (online/offline) and last_seen timestamp
-            let lastSeen = device.type == 'Coordinator' ? Date.now() : this.lastSeenMap[device.ieeeAddr] || 'unknown';
-            const defaultLastSeen = `${new Date(Date.now() - lastSeen).toISOString().substr(11, 8)}'s ago`;
-            lastSeen = utils.formatDate(lastSeen, settings.get().advanced.last_seen, defaultLastSeen);
+            let lastSeen = 'unknown';
+            if (device.type == 'Coordinator') {
+                lastSeen = utils.formatDate(Date.now(), settings.get().advanced.last_seen,
+                    utils.toLocalISOString(new Date(Date.now())));
+            } else {
+                if (this.lastSeenMap[device.ieeeAddr]) {
+                    const lastSeenAgo = 
+                        `${new Date(Date.now() - this.lastSeenMap[device.ieeeAddr]).toISOString().substr(11, 8)}s ago`;
+                    lastSeen = utils.formatDate(this.lastSeenMap[device.ieeeAddr],
+                        settings.get().advanced.last_seen, lastSeenAgo);
+                }
+            }
             labels.push(`${device.status} (${lastSeen})`);
 
             // Shape the record according to device type

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -100,6 +100,27 @@ function getZigbee2mqttVersion(callback) {
     });
 }
 
+function formatDate(date, type, _default) {
+    let result;
+
+    switch (type) {
+    case 'ISO_8601':
+        result = new Date(date).toISOString();
+        break;
+    case 'ISO_8601_local':
+        result = toLocalISOString(new Date(date));
+        break;
+    case 'epoch':
+        result = date;
+        break;
+    default:
+        result = _default;
+        break;
+    }
+
+    return result;
+}
+
 module.exports = {
     millisecondsToSeconds: (milliseconds) => milliseconds / 1000,
     secondsToMilliseconds: (seconds) => seconds * 1000,
@@ -113,6 +134,7 @@ module.exports = {
     isNumeric: (string) => /^\d+$/.test(string),
     toLocalISOString: (dDate) => toLocalISOString(dDate),
     getPostfixes: () => postfixes,
+    formatDate: (date, type, _default=null) => formatDate(date, type, _default),
     correctDeviceType: (device) => {
         if (device) {
             if (forceEndDevice.includes(device.modelId)) {

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -45,6 +45,7 @@ describe('Controller', () => {
                 },
                 advanced: {
                     cache_state: false,
+                    last_seen: 'disable',
                 },
                 experimental: {
                     output: 'json',

--- a/test/deviceReceive.test.js
+++ b/test/deviceReceive.test.js
@@ -41,7 +41,7 @@ describe('DeviceReceive', () => {
         });
 
         it('Should handle a zigbee message and counter it when Home Assistant integration is enabled', () => {
-            jest.spyOn(settings, 'get').mockReturnValue({homeassistant: true, advanced: {last_seen: 'disabled'}});
+            jest.spyOn(settings, 'get').mockReturnValue({homeassistant: true, advanced: {last_seen: 'disable'}});
             const device = {ieeeAddr: '0x12345678'};
             const message = utils.zigbeeMessage(device, 'genOnOff', 'attReport', {onOff: 1}, 1);
             deviceReceive.onZigbeeMessage(message, device, WXKG11LM);


### PR DESCRIPTION
Adds a last seen timestamp to the devices on network map alongside the online/offline status. Coordinator always gets an absolute timestamp but other devices get whatever format is configured for advanced last_seen or a relative time if last_seen isn't configured.

Had to include capturing of last_seen to state for every message received so this works regardless of whether availability is configured or not.

This change highlights that something still isn't right with status as routers pretty much always show as offline even when active but looking into that is a problem for another day.

It maps the map a bit busier but hopefully this change can help users ascertain if problems they are experiencing are with the map or actual network communications.

Here's an example map fragment.
![image](https://user-images.githubusercontent.com/40568549/59509691-18758f00-8ef5-11e9-9062-4b0d8a98aa19.png)

