### PR TITLE
Include network routes on the map

### DIFF
--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -75,9 +75,6 @@ class DeviceReceive {
             return;
         }
 
-        // Add last_seen to state
-        this.state.set(device.ieeeAddr, {'last_seen': Date.now()});
-
         // After this point we cant handle message withoud cid or cmdId anymore.
         if (!message.data || (!message.data.cid && !message.data.cmdId)) {
             return;

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -75,6 +75,9 @@ class DeviceReceive {
             return;
         }
 
+        // Add last_seen to state
+        this.state.set(device.ieeeAddr, {'last_seen': Date.now()});
+
         // After this point we cant handle message withoud cid or cmdId anymore.
         if (!message.data || (!message.data.cid && !message.data.cmdId)) {
             return;

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -1,4 +1,5 @@
 const settings = require('../util/settings');
+const logger = require('../util/logger');
 const utils = require('../util/utils');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 
@@ -27,7 +28,7 @@ class NetworkMap {
 
         if (topic === this.topic && this.supportedFormats.hasOwnProperty(message)) {
             this.zigbee.networkScan((result)=> {
-                const converted = this.supportedFormats[message](this.zigbee, result);
+                const converted = this.supportedFormats[message](this.zigbee, this.state, result);
                 this.mqtt.publish(`bridge/networkmap/${message}`, converted, {});
             });
 
@@ -37,11 +38,11 @@ class NetworkMap {
         return false;
     }
 
-    raw(zigbee, topology) {
+    raw(zigbee, state, topology) {
         return JSON.stringify(topology);
     }
 
-    graphviz(zigbee, topology) {
+    graphviz(zigbee, state, topology) {
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
 
@@ -67,8 +68,35 @@ class NetworkMap {
                 labels.push(zigbeeModel ? zigbeeModel : 'No model information available');
             }
 
-            // Add the device status (online/offline)
-            labels.push(device.status);
+            // Add the device status (online/offline) and last_seen timestamp
+            let last_seen = 'unknown';
+            const dev_state = state.get(device.ieeeAddr);
+            if (device.type == 'Coordinator' || (dev_state && dev_state.last_seen)) {
+                let now = Date.now();
+                let then = now;
+                if (dev_state && dev_state.last_seen) {
+                    then = dev_state.last_seen;
+                }
+                switch (settings.get().advanced.last_seen) {
+                case 'ISO_8601':
+                    last_seen = new Date(then).toISOString();
+                    break;
+                case 'ISO_8601_local':
+                    last_seen = utils.toLocalISOString(new Date(then));
+                    break;
+                case 'epoch':
+                    last_seen = then;
+                    break;
+                default:
+                    if (device.type == 'Coordinator') {
+                        last_seen = utils.toLocalISOString(new Date(then));
+                    } else {
+                        last_seen = new Date(now - then).toISOString().substr(11, 8) + 's ago';
+                    }
+                    break;
+                }
+            }
+            labels.push(device.status + ' ' + last_seen);
 
             // Shape the record according to device type
             if (deviceType == 'Coordinator') {
@@ -89,7 +117,8 @@ class NetworkMap {
              */
             topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
                 const lineStyle = (e.lqi==0) ? `style="dashed", ` : ``;
-                text += `  "${device.ieeeAddr}" -> "${e.parent}" [`+lineStyle+`label="${e.lqi}"]\n`;
+                const lineLabels = e.lqi + '\\n[' + e.routes.join(']\\n[') + ']';
+                text += `  "${e.parent}" -> "${device.ieeeAddr}" [`+lineStyle+`label="${lineLabels}"]\n`;
             });
         });
 

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -52,7 +52,7 @@ class NetworkMap {
             const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
 
             // Add friendly name
-            labels.push(`${friendlyName}:${device.nwkAddr}`);
+            labels.push(`${friendlyName}:${`0x${device.nwkAddr.toString(16)}`}`);
 
             // Add the device type
             const deviceType = utils.correctDeviceType(device);
@@ -117,7 +117,8 @@ class NetworkMap {
              */
             topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
                 const lineStyle = (e.lqi==0) ? `style="dashed", ` : ``;
-                const lineLabels = e.lqi + '\\n[' + e.routes.join(']\\n[') + ']';
+                const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
+                const lineLabels = e.lqi + '\\n[' + textRoutes.join(']\\n[') + ']';
                 text += `  "${e.parent}" -> "${device.ieeeAddr}" [`+lineStyle+`label="${lineLabels}"]\n`;
             });
         });

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -1,5 +1,4 @@
 const settings = require('../util/settings');
-const logger = require('../util/logger');
 const utils = require('../util/utils');
 const zigbeeShepherdConverters = require('zigbee-shepherd-converters');
 
@@ -28,7 +27,7 @@ class NetworkMap {
 
         if (topic === this.topic && this.supportedFormats.hasOwnProperty(message)) {
             this.zigbee.networkScan((result)=> {
-                const converted = this.supportedFormats[message](this.zigbee, this.state, result);
+                const converted = this.supportedFormats[message](this.zigbee, result);
                 this.mqtt.publish(`bridge/networkmap/${message}`, converted, {});
             });
 
@@ -38,11 +37,11 @@ class NetworkMap {
         return false;
     }
 
-    raw(zigbee, state, topology) {
+    raw(zigbee, topology) {
         return JSON.stringify(topology);
     }
 
-    graphviz(zigbee, state, topology) {
+    graphviz(zigbee, topology) {
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
 
@@ -52,7 +51,7 @@ class NetworkMap {
             const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
 
             // Add friendly name
-            labels.push(`${friendlyName}:${`0x${device.nwkAddr.toString(16)}`}`);
+            labels.push(`${friendlyName}:${device.nwkAddr}`);
 
             // Add the device type
             const deviceType = utils.correctDeviceType(device);
@@ -68,35 +67,8 @@ class NetworkMap {
                 labels.push(zigbeeModel ? zigbeeModel : 'No model information available');
             }
 
-            // Add the device status (online/offline) and last_seen timestamp
-            let last_seen = 'unknown';
-            const dev_state = state.get(device.ieeeAddr);
-            if (device.type == 'Coordinator' || (dev_state && dev_state.last_seen)) {
-                let now = Date.now();
-                let then = now;
-                if (dev_state && dev_state.last_seen) {
-                    then = dev_state.last_seen;
-                }
-                switch (settings.get().advanced.last_seen) {
-                case 'ISO_8601':
-                    last_seen = new Date(then).toISOString();
-                    break;
-                case 'ISO_8601_local':
-                    last_seen = utils.toLocalISOString(new Date(then));
-                    break;
-                case 'epoch':
-                    last_seen = then;
-                    break;
-                default:
-                    if (device.type == 'Coordinator') {
-                        last_seen = utils.toLocalISOString(new Date(then));
-                    } else {
-                        last_seen = new Date(now - then).toISOString().substr(11, 8) + 's ago';
-                    }
-                    break;
-                }
-            }
-            labels.push(device.status + ' ' + last_seen);
+            // Add the device status (online/offline)
+            labels.push(device.status);
 
             // Shape the record according to device type
             if (deviceType == 'Coordinator') {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -320,9 +320,9 @@ class Zigbee {
                 if (lqiScanList.has(parent)) {
                     // Haven't processed this one yet
                     if (rsp && rsp.status === 0 && rsp.neighborlqilist) {
-                        logger.debug(`Network lqi scan ok for: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
+                        logger.debug(`lqi scan ok for: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
                         rsp.neighborlqilist.forEach(function(neighbor) {
-                            const key = parent + "|" + neighbor.nwkAddr;
+                            const key = parent + '|' + neighbor.nwkAddr;
                             linkMap.push({
                                 key: key, parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
                                 lqi: neighbor.lqi, depth: neighbor.depth, routes: []});
@@ -333,8 +333,8 @@ class Zigbee {
                             logger.info('Network scan completed');
                             collateMap();
                         } else {
-                            logger.debug(`Still waiting for network lqi scans for devices: '${[...lqiScanList].join(' ')}'`);
-                            logger.debug(`Still waiting for network rtg scans for devices: '${[...rtgScanList].join(' ')}'`);
+                            logger.debug(`Outstanding network lqi scans for devices: '${[...lqiScanList].join(' ')}'`);
+                            logger.debug(`Outstanding network rtg scans for devices: '${[...rtgScanList].join(' ')}'`);
                         }
                     } else {
                         logger.warn(`Empty network lqi scan result for: '${parent}'`);
@@ -350,13 +350,13 @@ class Zigbee {
             if (error) {
                 logger.warn(`Failed network rtg scan for device: '${parent}' with error: '${error}'`);
             } else {
-               if (rtgScanList.has(parent)) {
+                if (rtgScanList.has(parent)) {
                     // Haven't processed this one yet
                     if (rsp && rsp.status === 0 && rsp.routingtablelist) {
-                        logger.debug(`Network rtg scan ok for: '${parent}' with '${rsp.routingtablelistcount}' entries`);
+                        logger.debug(`rtg scan ok for: '${parent}' with '${rsp.routingtablelistcount}' entries`);
                         rsp.routingtablelist.forEach(function(route) {
                             if (route.routeStatus === 0) {
-                                const key = parent + "|" + route.nextHopNwkAddr; 
+                                const key = parent + '|' + route.nextHopNwkAddr;
                                 routeMap.push({
                                     key: key, destAddr: route.destNwkAddr});
                             }
@@ -367,8 +367,8 @@ class Zigbee {
                             logger.info('Network scan completed');
                             collateMap();
                         } else {
-                            logger.debug(`Still waiting for network lqi scans for devices: '${[...lqiScanList].join(' ')}'`);
-                            logger.debug(`Still waiting for network rtg scans for devices: '${[...rtgScanList].join(' ')}'`);
+                            logger.debug(`Outstanding network lqi scans for devices: '${[...lqiScanList].join(' ')}'`);
+                            logger.debug(`Outstanding network rtg scans for devices: '${[...rtgScanList].join(' ')}'`);
                         }
                     } else {
                         logger.warn(`Empty network rtg scan result for: '${parent}'`);
@@ -399,7 +399,6 @@ class Zigbee {
                         queueCallback(error);
                     });
             });
-
         });
 
         // Wait for all device scans before forcing map with whatever results are already in

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -292,70 +292,129 @@ class Zigbee {
 
     networkScan(callback) {
         logger.info('Starting network scan...');
-        const scanList = new Set();
+        const lqiScanList = new Set();
+        const rtgScanList = new Set();
         const linkMap = [];
+        const routeMap = [];
 
-        const processResponse = (error, rsp, parent) => {
+        const collateMap = () => {
+            linkMap.sort((a, b) => (a.key > b.key) ? 1 : 0);
+            logger.debug(`Link map (complete): %j`, linkMap);
+            logger.debug(`Route map (complete): %j`, routeMap);
+            // Merge the routes into the linkMap
+            routeMap.forEach((route) => {
+                linkMap.forEach((link) => {
+                    if (route.key == link.key) {
+                        link.routes.push(route.destAddr);
+                    }
+                });
+            });
+            logger.debug(`Merged map: %j`, linkMap);
+            callback(linkMap);
+        };
+
+        const processLqiResponse = (error, rsp, parent) => {
             if (error) {
-                logger.warn(`Failed network scan for device: '${parent}' with error: '${error}'`);
+                logger.warn(`Failed network lqi scan for device: '${parent}' with error: '${error}'`);
             } else {
-                if (scanList.has(parent)) {
+                if (lqiScanList.has(parent)) {
                     // Haven't processed this one yet
                     if (rsp && rsp.status === 0 && rsp.neighborlqilist) {
                         logger.debug(`Network scan ok for: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
                         rsp.neighborlqilist.forEach(function(neighbor) {
+                            const key = parent + "|" + neighbor.nwkAddr;
                             linkMap.push({
-                                parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
-                                lqi: neighbor.lqi, depth: neighbor.depth});
+                                key: key, parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
+                                lqi: neighbor.lqi, depth: neighbor.depth, routes: []});
                         });
                         // Remove from list and if this was the last one return the completed network map
-                        scanList.delete(parent);
-                        if (scanList.size === 0) {
+                        lqiScanList.delete(parent);
+                        if (lqiScanList.size === 0 && rtgScanList === 0) {
                             logger.info('Network scan completed');
-                            linkMap.sort((a, b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
-                                : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
-                            logger.debug(`Link map (complete): %j`, linkMap);
-                            callback(linkMap);
+                            collateMap();
                         } else {
-                            logger.debug(`Still waiting for network scans for devices: '${[...scanList].join(' ')}'`);
+                            logger.debug(`Still waiting for network lqi scans for devices: '${[...lqiScanList].join(' ')}'`);
+                            logger.debug(`Still waiting for network rtg scans for devices: '${[...rtgScanList].join(' ')}'`);
                         }
                     } else {
-                        logger.warn(`Empty network scan result for: '${parent}'`);
+                        logger.warn(`Empty network lqi scan result for: '${parent}'`);
                     }
                 } else {
                     // This ieeeAddr has already been removed due to timeout so don't add to result network map
-                    logger.warn(`Ignoring late network scan result for: '${parent}'`);
+                    logger.warn(`Ignoring late network lqi scan result for: '${parent}'`);
                 }
             }
         };
 
-        // Queue up an lqi scan for coordinator and each router
+        const processRtgResponse = (error, rsp, parent) => {
+            if (error) {
+                logger.warn(`Failed network rtg scan for device: '${parent}' with error: '${error}'`);
+            } else {
+               if (rtgScanList.has(parent)) {
+                    // Haven't processed this one yet
+                    if (rsp && rsp.status === 0 && rsp.routingtablelist) {
+                        logger.debug(`Network rtg scan ok for: '${parent}' with '${rsp.routingtablelistcount}' entries`);
+                        rsp.routingtablelist.forEach(function(route) {
+                            if (route.routeStatus === 0) {
+                                const key = parent + "|" + route.nextHopNwkAddr; 
+                                routeMap.push({
+                                    key: key, destAddr: route.destNwkAddr});
+                            }
+                        });
+                        // Remove from list and if this was the last one return the completed network map
+                        rtgScanList.delete(parent);
+                        if (lqiScanList.size === 0 && rtgScanList.size === 0) {
+                            logger.info('Network scan completed');
+                            collateMap();
+                        } else {
+                            logger.debug(`Still waiting for network lqi scans for devices: '${[...lqiScanList].join(' ')}'`);
+                            logger.debug(`Still waiting for network rtg scans for devices: '${[...rtgScanList].join(' ')}'`);
+                        }
+                    } else {
+                        logger.warn(`Empty network rtg scan result for: '${parent}'`);
+                    }
+                } else {
+                    // This ieeeAddr has already been removed due to timeout so don't add to result network map
+                    logger.warn(`Ignoring late network rtg scan result for: '${parent}'`);
+                }
+            }
+        };
+
+        // Queue up an lqi scan  and an rtg for coordinator and each router
         this.getScanable().forEach((dev) => {
-            logger.debug(`Queing network scan for device: '${dev.ieeeAddr}'`);
-            scanList.add(dev.ieeeAddr);
+            logger.debug(`Queing network scans for device: '${dev.ieeeAddr}'`);
+            lqiScanList.add(dev.ieeeAddr);
             this.queue.push(dev.ieeeAddr, (queueCallback) => {
                 this.shepherd.controller.request('ZDO', 'mgmtLqiReq', {dstaddr: dev.nwkAddr, startindex: 0},
                     (error, rsp, parent) => {
-                        processResponse(error, rsp, dev.ieeeAddr);
+                        processLqiResponse(error, rsp, dev.ieeeAddr);
                         queueCallback(error);
                     });
             });
+            rtgScanList.add(dev.ieeeAddr);
+            this.queue.push(dev.ieeeAddr, (queueCallback) => {
+                this.shepherd.controller.request('ZDO', 'mgmtRtgReq', {dstaddr: dev.nwkAddr, startindex: 0},
+                    (error, rsp, parent) => {
+                        processRtgResponse(error, rsp, dev.ieeeAddr);
+                        queueCallback(error);
+                    });
+            });
+
         });
 
         // Wait for all device scans before forcing map with whatever results are already in
         setTimeout(() => {
-            if (scanList.size === 0) {
+            if (lqiScanList.size === 0 && rtgScanList.size === 0) {
                 logger.info('Network scan timeout no outstanding requests');
             } else {
-                logger.warn(`Network scan timeout, skipping outstanding scans for '${[...scanList].join(' ')}'`);
+                logger.warn(`Network scan timeout, skipping outstanding lqi scans for '${[...lqiScanList].join(' ')}'`);
+                logger.warn(`Network scan timeout, skipping outstanding rtg scans for '${[...rtgScanList].join(' ')}'`);
                 // Clear remaining devices so they don't process when/if they eventually complete
-                scanList.clear();
-                logger.debug(`Link map (timeout): %j`, linkMap);
-                linkMap.sort((a, b) => ((a.parent + '|' + a.ieeeAddr) > (b.parent + '|' + b.ieeeAddr)) ? 1
-                    : (((b.parent + '|' + b.ieeeAddr) > (a.parent + '|' + a.ieeeAddr)) ? -1 : 0));
-                callback(linkMap);
+                lqiScanList.clear();
+                rtgScanList.clear();
+                collateMap();
             }
-        }, scanList.size * 1000);
+        }, lqiScanList.size * 1000);
     }
 
     getEndpoint(ieeeAddr, ep) {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -297,17 +297,17 @@ class Zigbee {
         const linkMap = [];
         const routeMap = [];
 
+        // Gather the lqi and the route info into separate lists and only collate them when done.
         const collateMap = () => {
             linkMap.sort((a, b) => (a.key > b.key) ? 1 : 0);
-            logger.debug(`Link map (complete): %j`, linkMap);
-            logger.debug(`Route map (complete): %j`, routeMap);
+            logger.debug(`Link map: %j`, linkMap);
+            logger.debug(`Route map: %j`, routeMap);
             // Merge the routes into the linkMap
-            routeMap.forEach((route) => {
-                linkMap.forEach((link) => {
-                    if (route.key == link.key) {
-                        link.routes.push(route.destAddr);
-                    }
+            linkMap.forEach((link) => {
+                routeMap.filter((e) => e.key === link.key).forEach((e) => {
+                    link.routes.push(e.destAddr);
                 });
+                delete link.key;
             });
             logger.debug(`Merged map: %j`, linkMap);
             callback(linkMap);
@@ -320,7 +320,7 @@ class Zigbee {
                 if (lqiScanList.has(parent)) {
                     // Haven't processed this one yet
                     if (rsp && rsp.status === 0 && rsp.neighborlqilist) {
-                        logger.debug(`Network scan ok for: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
+                        logger.debug(`Network lqi scan ok for: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
                         rsp.neighborlqilist.forEach(function(neighbor) {
                             const key = parent + "|" + neighbor.nwkAddr;
                             linkMap.push({


### PR DESCRIPTION
This PR shows the network route targets (short address) for each link below the lqi value. Here's a sample:
![image](https://user-images.githubusercontent.com/40568549/59560183-23ddcd00-9051-11e9-82d2-214062e155b5.png)

zigbee.js has been changed to fire off 2 requests to each router:
- one for the neighbor table to get lqi values
- a second to get the routing table

The two scan requests may return at different times so the network scan process waits (subject to timeout) for both sets to complete then merges the results and shows on the map. Routes show for each link which of the downstream devices will also have traffic sent that way. One notable change though is the direction of the arrows on the map had to be reversed so the routes make sense. Links to end devices will always have an empty set of routes because those end devices poll their parent for messages hence no routing occurs.

This of course will generate more network traffic so perhaps the routing scan should be selectable by a configuration option. Might also look a bit thick on a large network with lots of devices and routes but maybe there is another way to represent the routes on the map??