### PR TITLE
Network map styling improvements

### DIFF
--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -111,8 +111,8 @@ class NetworkMap {
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
             topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
-                const lineStyle = (e.routes.length) ? ''
-                    : (device.type=='EndDevice') ? 'style="dashed", ' : 'style="dotted", ';
+                const lineStyle = (device.type=='EndDevice') ? 'style="dashed", '
+                    : (!e.routes.length) ? 'style="dotted", ' : '';
                 const lineWeight = (!e.routes.length) ? 'weight=0, ' : '';
                 const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
                 const lineLabels = `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -111,10 +111,12 @@ class NetworkMap {
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
             topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
-                const lineStyle = (e.lqi==0) ? `style="dashed", ` : ``;
+                const lineStyle = (e.routes.length) ? ''
+                    : (device.type=='EndDevice') ? 'style="dashed", ' : 'style="dotted", ';
+                const lineWeight = (!e.routes.length) ? 'weight=0, ' : '';
                 const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
-                const lineLabels = e.lqi + '\\n[' + textRoutes.join(']\\n[') + ']';
-                text += `  "${e.parent}" -> "${device.ieeeAddr}" [`+lineStyle+`label="${lineLabels}"]\n`;
+                const lineLabels = `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;
+                text += `  "${e.parent}" -> "${device.ieeeAddr}" [${lineStyle}${lineWeight}${lineLabels}]\n`;
             });
         });
 


### PR DESCRIPTION
Another styling change for the network map to improve interpretation.

Changes line style to dashed for end devices - matches the end device outline.
Changes line style to dotted to links that don't have any active routes (route list is empty). Makes active routes much easier to identify.
Add a 'weight=0' style for links without routes. Doesn't impact circo rendering but improves dot rendering by tending to bring devices with active routes more central in the map.

I've also prepared some documentation for the map but its based on this styling change so will wait to see if this PR is ok before I do a separate PR for that https://github.com/clockbrain/zigbee2mqtt.io/commit/ef07fa8d091df28f08f385100ceaa3952ad4cd7a