### PR TITLE
colors for network map

### DIFF
--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -53,15 +53,7 @@ class NetworkMap {
     }
 
     graphviz(zigbee, topology) {
-        // fetch node/edge colors
-        const cColor = settings.get().map_options.coordinator_color;
-        const cFillColor = settings.get().map_options.coordinator_fillcolor;
-        const rColor = settings.get().map_options.router_color;
-        const rFillColor = settings.get().map_options.router_fillcolor;
-        const eColor = settings.get().map_options.enddevice_color;
-        const eFillColor = settings.get().map_options.enddevice_fillcolor;
-        const rActiveColor = settings.get().map_options.route_active_color;
-        const rInactiveColor = settings.get().map_options.route_inactive_color;
+        const colors = settings.get().map_options.colors;
 
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
@@ -105,11 +97,14 @@ class NetworkMap {
 
             // Shape the record according to device type
             if (deviceType == 'Coordinator') {
-                devStyle = `style="bold, filled", fillcolor="${cFillColor}", fontcolor="${cColor}"`;
+                devStyle = `style="bold, filled", fillcolor="${colors.fill.coordinator}", ` +
+                    `fontcolor="${colors.font.coordinator}"`;
             } else if (deviceType == 'Router') {
-                devStyle = `style="rounded, filled", fillcolor="${rFillColor}", fontcolor="${rColor}"`;
+                devStyle = `style="rounded, filled", fillcolor="${colors.fill.router}", ` +
+                    `fontcolor="${colors.font.router}"`;
             } else {
-                devStyle = `style="rounded, dashed, filled", fillcolor="${eFillColor}", fontcolor="${eColor}"`;
+                devStyle = `style="rounded, dashed, filled", fillcolor="${colors.fill.enddevice}", `
+                    + `fontcolor="${colors.font.enddevice}"`;
             }
 
             // Add the device with its labels to the graph as a node.
@@ -123,8 +118,8 @@ class NetworkMap {
             topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
                 const lineStyle = (device.type=='EndDevice') ? 'style="dashed", '
                     : (!e.routes.length) ? 'style="dotted", ' : '';
-                const lineWeight = (!e.routes.length) ? `weight=0, color="${rInactiveColor}", `
-                    : `weight=1, color="${rActiveColor}", `;
+                const lineWeight = (!e.routes.length) ? `weight=0, color="${colors.line.inactive}", `
+                    : `weight=1, color="${colors.line.active}", `;
                 const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
                 const lineLabels = `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;
                 text += `  "${e.parent}" -> "${device.ieeeAddr}" [${lineStyle}${lineWeight}${lineLabels}]\n`;

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -54,8 +54,6 @@ class NetworkMap {
 
     graphviz(zigbee, topology) {
         // fetch node/edge colors
-        const tColor = settings.get().map_options.timestamp_color;
-        const tFillColor = settings.get().map_options.timestamp_fillcolor;
         const cColor = settings.get().map_options.coordinator_color;
         const cFillColor = settings.get().map_options.coordinator_fillcolor;
         const rColor = settings.get().map_options.router_color;
@@ -67,11 +65,6 @@ class NetworkMap {
 
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
-
-        // add timestamp node
-        const now = utils.toLocalISOString(new Date(Date.now()));
-        text += `  "timestamp" [style="rounded, filled", fillcolor="${tFillColor}", fontcolor="${tColor}",`;
-        text += ` label="Map created: ${now}"];\n`;
 
         zigbee.getDevices().forEach((device) => {
             const labels = [];
@@ -128,11 +121,13 @@ class NetworkMap {
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
             topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
-                const lineStyle = (deviceType=='EndDevice') ? `style="dashed", `
-                    : (!e.routes.length) ? `style="dotted", ` : ``;
+                const lineStyle = (device.type=='EndDevice') ? 'style="dashed", '
+                    : (!e.routes.length) ? 'style="dotted", ' : '';
                 const lineWeight = (!e.routes.length) ? `weight=0, color="${rInactiveColor}", `
                     : `weight=1, color="${rActiveColor}", `;
-                text += `  "${device.ieeeAddr}" -> "${e.parent}" [`+lineStyle+lineWeight+`label="${e.lqi}"]\n`;
+                const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
+                const lineLabels = `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;
+                text += `  "${e.parent}" -> "${device.ieeeAddr}" [${lineStyle}${lineWeight}${lineLabels}]\n`;
             });
         });
 

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -54,23 +54,24 @@ class NetworkMap {
 
     graphviz(zigbee, topology) {
         // fetch node/edge colors
-        const timestamp_color = settings.get().map_options.timestamp_color
-        const timestamp_fillcolor = settings.get().map_options.timestamp_fillcolor
-        const coordinator_color = settings.get().map_options.coordinator_color
-        const coordinator_fillcolor = settings.get().map_options.coordinator_fillcolor
-        const router_color = settings.get().map_options.router_color
-        const router_fillcolor = settings.get().map_options.router_fillcolor
-        const enddevice_color = settings.get().map_options.enddevice_color
-        const enddevice_fillcolor = settings.get().map_options.enddevice_fillcolor
-        const route_active_color = settings.get().map_options.route_active_color
-        const route_inactive_color = settings.get().map_options.route_inactive_color
-        
+        const tColor = settings.get().map_options.timestamp_color;
+        const tFillColor = settings.get().map_options.timestamp_fillcolor;
+        const cColor = settings.get().map_options.coordinator_color;
+        const cFillColor = settings.get().map_options.coordinator_fillcolor;
+        const rColor = settings.get().map_options.router_color;
+        const rFillColor = settings.get().map_options.router_fillcolor;
+        const eColor = settings.get().map_options.enddevice_color;
+        const eFillColor = settings.get().map_options.enddevice_fillcolor;
+        const rActiveColor = settings.get().map_options.route_active_color;
+        const rInactiveColor = settings.get().map_options.route_inactive_color;
+
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
-        
+
         // add timestamp node
         const now = utils.toLocalISOString(new Date(Date.now()));
-        text += `  "timestamp" [style="rounded, filled", fillcolor="${timestamp_fillcolor}", fontcolor="${timestamp_color}", label="Map created: ${now}"];\n`;
+        text += `  "timestamp" [style="rounded, filled", fillcolor="${tFillColor}", fontcolor="${tColor}",`
+        text += ` label="Map created: ${now}"];\n`;
 
         zigbee.getDevices().forEach((device) => {
             const labels = [];
@@ -111,11 +112,11 @@ class NetworkMap {
 
             // Shape the record according to device type
             if (deviceType == 'Coordinator') {
-                devStyle = `style="bold, filled", fillcolor="${coordinator_fillcolor}", fontcolor="${coordinator_color}"`;
+                devStyle = `style="bold, filled", fillcolor="${cFillColor}", fontcolor="${cColor}"`;
             } else if (deviceType == 'Router') {
-                devStyle = `style="rounded, filled", fillcolor="${router_fillcolor}", fontcolor="${router_color}"`;
+                devStyle = `style="rounded, filled", fillcolor="${rFillColor}", fontcolor="${rColor}"`;
             } else {
-                devStyle = `style="rounded, dashed, filled", fillcolor="${enddevice_fillcolor}", fontcolor="${enddevice_color}"`;
+                devStyle = `style="rounded, dashed, filled", fillcolor="${eFillColor}", fontcolor="${eColor}"`;
             }
 
             // Add the device with its labels to the graph as a node.
@@ -127,8 +128,10 @@ class NetworkMap {
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
             topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
-                const lineStyle = (deviceType=='EndDevice') ? `style="dashed", `: (!e.routes.length) ? `style="dotted", ` : ``;
-                const lineWeight = (!e.routes.length) ? `weight=0, color="${route_inactive_color}", ` : `weight=1, color="${route_active_color}", `;
+                const lineStyle = (deviceType=='EndDevice') ? `style="dashed", `
+                    : (!e.routes.length) ? `style="dotted", ` : ``;
+                const lineWeight = (!e.routes.length) ? `weight=0, color="${rInactiveColor}", `
+                    : `weight=1, color="${rActiveColor}", `;
                 text += `  "${device.ieeeAddr}" -> "${e.parent}" [`+lineStyle+lineWeight+`label="${e.lqi}"]\n`;
             });
         });

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -53,8 +53,24 @@ class NetworkMap {
     }
 
     graphviz(zigbee, topology) {
+        // fetch node/edge colors
+        const timestamp_color = settings.get().map_options.timestamp_color
+        const timestamp_fillcolor = settings.get().map_options.timestamp_fillcolor
+        const coordinator_color = settings.get().map_options.coordinator_color
+        const coordinator_fillcolor = settings.get().map_options.coordinator_fillcolor
+        const router_color = settings.get().map_options.router_color
+        const router_fillcolor = settings.get().map_options.router_fillcolor
+        const enddevice_color = settings.get().map_options.enddevice_color
+        const enddevice_fillcolor = settings.get().map_options.enddevice_fillcolor
+        const route_active_color = settings.get().map_options.route_active_color
+        const route_inactive_color = settings.get().map_options.route_inactive_color
+        
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
+        
+        // add timestamp node
+        const now = utils.toLocalISOString(new Date(Date.now()));
+        text += `  "timestamp" [style="rounded, filled", fillcolor="${timestamp_fillcolor}", fontcolor="${timestamp_color}", label="Map created: ${now}"];\n`;
 
         zigbee.getDevices().forEach((device) => {
             const labels = [];
@@ -95,11 +111,11 @@ class NetworkMap {
 
             // Shape the record according to device type
             if (deviceType == 'Coordinator') {
-                devStyle = 'style="bold"';
+                devStyle = `style="bold, filled", fillcolor="${coordinator_fillcolor}", fontcolor="${coordinator_color}"`;
             } else if (deviceType == 'Router') {
-                devStyle = 'style="rounded"';
+                devStyle = `style="rounded, filled", fillcolor="${router_fillcolor}", fontcolor="${router_color}"`;
             } else {
-                devStyle = 'style="rounded, dashed"';
+                devStyle = `style="rounded, dashed, filled", fillcolor="${enddevice_fillcolor}", fontcolor="${enddevice_color}"`;
             }
 
             // Add the device with its labels to the graph as a node.
@@ -111,10 +127,9 @@ class NetworkMap {
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
             topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
-                const lineStyle = (e.lqi==0) ? `style="dashed", ` : ``;
-                const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
-                const lineLabels = e.lqi + '\\n[' + textRoutes.join(']\\n[') + ']';
-                text += `  "${e.parent}" -> "${device.ieeeAddr}" [`+lineStyle+`label="${lineLabels}"]\n`;
+                const lineStyle = (deviceType=='EndDevice') ? `style="dashed", `: (!e.routes.length) ? `style="dotted", ` : ``;
+                const lineWeight = (!e.routes.length) ? `weight=0, color="${route_inactive_color}", ` : `weight=1, color="${route_active_color}", `;
+                text += `  "${device.ieeeAddr}" -> "${e.parent}" [`+lineStyle+lineWeight+`label="${e.lqi}"]\n`;
             });
         });
 

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -70,7 +70,7 @@ class NetworkMap {
 
         // add timestamp node
         const now = utils.toLocalISOString(new Date(Date.now()));
-        text += `  "timestamp" [style="rounded, filled", fillcolor="${tFillColor}", fontcolor="${tColor}",`
+        text += `  "timestamp" [style="rounded, filled", fillcolor="${tFillColor}", fontcolor="${tColor}",`;
         text += ` label="Map created: ${now}"];\n`;
 
         zigbee.getDevices().forEach((device) => {

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -53,7 +53,7 @@ class NetworkMap {
     }
 
     graphviz(zigbee, topology) {
-        const colors = settings.get().map_options.colors;
+        const colors = settings.get().map_options.graphviz.colors;
 
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -14,14 +14,22 @@ const defaults = {
     groups: {},
     device_options: {},
     map_options: {
-        coordinator_color: '#ffffff',
-        coordinator_fillcolor: '#e04e5d',
-        router_color: '#ffffff',
-        router_fillcolor: '#4ea3e0',
-        enddevice_color: '#000000',
-        enddevice_fillcolor: '#fff8ce',
-        route_active_color: '#009900',
-        route_inactive_color: '#994444',
+        colors: {
+            fill: {
+                enddevice: '#fff8ce',
+                coordinator: '#e04e5d',
+                router: '#4ea3e0',
+            },
+            font: {
+                coordinator: '#ffffff',
+                router: '#ffffff',
+                enddevice: '#000000',
+            },
+            line: {
+                active: '#009900',
+                inactive: '#994444',
+            },
+        },
     },
     experimental: {
         livolo: false,

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -14,8 +14,6 @@ const defaults = {
     groups: {},
     device_options: {},
     map_options: {
-        timestamp_color: '#ffffff',
-        timestamp_fillcolor: '#784399',
         coordinator_color: '#ffffff',
         coordinator_fillcolor: '#e04e5d',
         router_color: '#ffffff',

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -13,6 +13,18 @@ const defaults = {
     },
     groups: {},
     device_options: {},
+    map_options: {
+        timestamp_color: '#ffffff',
+        timestamp_fillcolor: '#784399',
+        coordinator_color: '#ffffff',
+        coordinator_fillcolor: '#e04e5d',
+        router_color: '#ffffff',
+        router_fillcolor: '#4ea3e0',
+        enddevice_color: '#000000',
+        enddevice_fillcolor: '#fff8ce',
+        route_active_color: '#009900',
+        route_inactive_color: '#994444',
+    },
     experimental: {
         livolo: false,
         // json or attribute

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -14,20 +14,22 @@ const defaults = {
     groups: {},
     device_options: {},
     map_options: {
-        colors: {
-            fill: {
-                enddevice: '#fff8ce',
-                coordinator: '#e04e5d',
-                router: '#4ea3e0',
-            },
-            font: {
-                coordinator: '#ffffff',
-                router: '#ffffff',
-                enddevice: '#000000',
-            },
-            line: {
-                active: '#009900',
-                inactive: '#994444',
+        graphviz: {
+            colors: {
+                fill: {
+                    enddevice: '#fff8ce',
+                    coordinator: '#e04e5d',
+                    router: '#4ea3e0',
+                },
+                font: {
+                    coordinator: '#ffffff',
+                    router: '#ffffff',
+                    enddevice: '#000000',
+                },
+                line: {
+                    active: '#009900',
+                    inactive: '#994444',
+                },
             },
         },
     },


### PR DESCRIPTION
I added some colors to the nodes and edges to make the map even clearer. I also added a node containing the creation timestamp. Not sure if this is okay with you but I thought it would be good to know what point in time the map pictures.

Colors can be re-defined in `configuration.yaml`.

NOTE: I removed the `textRoutes` labels from a previous commit by @clockbrain as they were somehow crashing my zigbee2mqtt instance. I haven't had the time to investigate why this happened. 