### PR TITLE
Configurable home assistant status topic

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -773,10 +773,11 @@ class HomeAssistant {
         }
 
         this.discoveryTopic = settings.get().advanced.homeassistant_discovery_topic;
+        this.statusTopic = settings.get().advanced.homeassistant_status_topic;
     }
 
     onMQTTConnected() {
-        this.mqtt.subscribe('hass/status');
+        this.mqtt.subscribe(this.statusTopic);
 
         // MQTT discovery of all paired devices on startup.
         this.zigbee.getAllClients().forEach((device) => {
@@ -932,7 +933,7 @@ class HomeAssistant {
     }
 
     onMQTTMessage(topic, message) {
-        if (!topic === 'hass/status') {
+        if (!topic === this.statusTopic) {
             return false;
         }
 

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -71,6 +71,11 @@ const defaults = {
          * Home Assistant discovery topic
          */
         homeassistant_discovery_topic: 'homeassistant',
+
+        /**
+         * Home Assistant status topic
+         */
+        homeassistant_status_topic: 'hass/status',
     },
 };
 

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -606,7 +606,7 @@ describe('HomeAssistant extension', () => {
                 output: 'json',
             },
             advanced: {
-                homeassistant_discovery_topic: 'my_custom_topic',
+                homeassistant_discovery_topic: 'my_custom_discovery_topic',
             },
         });
 
@@ -627,6 +627,33 @@ describe('HomeAssistant extension', () => {
         homeassistant.discover('0x12345678', WSDCGQ11LM, false);
 
         expect(mqtt.publish).toHaveBeenCalledTimes(5);
-        expect(mqtt.publish.mock.calls[0][4]).toBe('my_custom_topic');
+        expect(mqtt.publish.mock.calls[0][4]).toBe('my_custom_discovery_topic');
+    });
+
+    it('Should subscribe to custom status topic', () => {
+        jest.spyOn(settings, 'get').mockReturnValue({
+            experimental: {
+                output: 'json',
+            },
+            advanced: {
+                homeassistant_status_topic: 'my_custom_status_topic',
+            },
+        });
+
+        const zigbee = {
+            getAllClients: jest.fn().mockReturnValue([]),
+        };
+
+        mqtt = {
+            subscribe: jest.fn(),
+        };
+
+
+        homeassistant = new HomeassistantExtension(zigbee, mqtt, null, null);
+
+        homeassistant.onMQTTConnected();
+
+        expect(mqtt.subscribe).toHaveBeenCalledTimes(1);
+        expect(mqtt.subscribe.mock.calls[0][0]).toBe('my_custom_status_topic');
     });
 });


### PR DESCRIPTION
The home assistant status topic is [configurable in home assistant itself](https://www.home-assistant.io/docs/mqtt/birth_will/). Therefore it should also be configurable in zigbee2mqtt.