### PR TITLE
Network map fixes

### DIFF
--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -58,17 +58,17 @@ class NetworkMap {
         let text = 'digraph G {\nnode[shape=record];\n';
         let devStyle = '';
 
-        zigbee.getDevices().forEach((device) => {
+        topology.nodes.forEach((device) => {
             const labels = [];
-            const friendlyDevice = settings.getDevice(device.ieeeAddr);
-            const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
 
             // Add friendly name
-            labels.push(`${friendlyName}:${`0x${device.nwkAddr.toString(16)}`}`);
+            labels.push(`${device.friendlyName}:${`0x${device.nwkAddr.toString(16)}`}`);
 
             // Add the device type
-            const deviceType = utils.correctDeviceType(device);
-            labels.push(deviceType);
+            let scanNote = '';
+            if (device.scanfailed.includes('lqi')) {scanNote += ' no lqi';}
+            if (device.scanfailed.includes('rtg')) {scanNote += ' no routes';}
+            labels.push(device.type+scanNote);
 
             // Add the device model
             const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);
@@ -96,10 +96,10 @@ class NetworkMap {
             labels.push(`${device.status} (${lastSeen})`);
 
             // Shape the record according to device type
-            if (deviceType == 'Coordinator') {
+            if (device.type == 'Coordinator') {
                 devStyle = `style="bold, filled", fillcolor="${colors.fill.coordinator}", ` +
                     `fontcolor="${colors.font.coordinator}"`;
-            } else if (deviceType == 'Router') {
+            } else if (device.type == 'Router') {
                 devStyle = `style="rounded, filled", fillcolor="${colors.fill.router}", ` +
                     `fontcolor="${colors.font.router}"`;
             } else {
@@ -115,7 +115,7 @@ class NetworkMap {
              * NOTE: There are situations where a device is NOT in the topology, this can be e.g.
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
-            topology.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
+            topology.links.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
                 const lineStyle = (device.type=='EndDevice') ? 'style="dashed", '
                     : (!e.routes.length) ? 'style="dotted", ' : '';
                 const lineWeight = (!e.routes.length) ? `weight=0, color="${colors.line.inactive}", `

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -66,8 +66,12 @@ class NetworkMap {
 
             // Add the device type
             let scanNote = '';
-            if (device.scanfailed.includes('lqi')) {scanNote += ' no lqi';}
-            if (device.scanfailed.includes('rtg')) {scanNote += ' no routes';}
+            if (device.scanfailed.includes('lqi')) {
+                scanNote += ' no lqi';
+            }
+            if (device.scanfailed.includes('rtg')) {
+                scanNote += ' no routes';
+            }
             labels.push(device.type+scanNote);
 
             // Add the device model
@@ -123,7 +127,8 @@ class NetworkMap {
                         : `weight=1, color="${colors.line.active}", `;
                     const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
                     const lineLabels = `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;
-                    text += `  "${device.ieeeAddr}" -> "${e.targetIeeeAddr}" [${lineStyle}${lineWeight}${lineLabels}]\n`;
+                    text += `  "${device.ieeeAddr}" -> "${e.targetIeeeAddr}"`;
+                    text += ` [${lineStyle}${lineWeight}${lineLabels}]\n`;
                 });
         });
 

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -126,7 +126,8 @@ class NetworkMap {
                     const lineWeight = (!e.routes.length) ? `weight=0, color="${colors.line.inactive}", `
                         : `weight=1, color="${colors.line.active}", `;
                     const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
-                    const lineLabels = `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;
+                    const lineLabels = (!e.routes.length) ? `label="${e.lqi}"`
+                        : `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;
                     text += `  "${device.ieeeAddr}" -> "${e.targetIeeeAddr}"`;
                     text += ` [${lineStyle}${lineWeight}${lineLabels}]\n`;
                 });

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -111,19 +111,20 @@ class NetworkMap {
             text += `  "${device.ieeeAddr}" [`+devStyle+`, label="{${labels.join('|')}}"];\n`;
 
             /**
-             * Add an edge between the device and its parent to the graph
+             * Add an edge between the device and its child to the graph
              * NOTE: There are situations where a device is NOT in the topology, this can be e.g.
              * due to not responded to the lqi scan. In that case we do not add an edge for this device.
              */
-            topology.links.filter((e) => (e.ieeeAddr === device.ieeeAddr) || (e.nwkAddr === device.nwkAddr)).forEach((e) => {
-                const lineStyle = (device.type=='EndDevice') ? 'style="dashed", '
-                    : (!e.routes.length) ? 'style="dotted", ' : '';
-                const lineWeight = (!e.routes.length) ? `weight=0, color="${colors.line.inactive}", `
-                    : `weight=1, color="${colors.line.active}", `;
-                const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
-                const lineLabels = `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;
-                text += `  "${e.parent}" -> "${device.ieeeAddr}" [${lineStyle}${lineWeight}${lineLabels}]\n`;
-            });
+            topology.links.filter((e) => (e.sourceIeeeAddr === device.ieeeAddr) || (e.SourceNwkAddr === device.nwkAddr))
+                .forEach((e) => {
+                    const lineStyle = (device.type=='EndDevice') ? 'style="dashed", '
+                        : (!e.routes.length) ? 'style="dotted", ' : '';
+                    const lineWeight = (!e.routes.length) ? `weight=0, color="${colors.line.inactive}", `
+                        : `weight=1, color="${colors.line.active}", `;
+                    const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);
+                    const lineLabels = `label="${e.lqi}\\n[${textRoutes.join(']\\n[')}]"`;
+                    text += `  "${device.ieeeAddr}" -> "${e.targetIeeeAddr}" [${lineStyle}${lineWeight}${lineLabels}]\n`;
+                });
         });
 
         text += '}';

--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -62,9 +62,9 @@ class NetworkMap {
             const labels = [];
 
             // Add friendly name
-            labels.push(`${device.friendlyName}:${`0x${device.nwkAddr.toString(16)}`}`);
+            labels.push(`${device.friendlyName}`);
 
-            // Add the device type
+            // Add the device short network address and scan note (if any)
             let scanNote = '';
             if (device.scanfailed.includes('lqi')) {
                 scanNote += ' no lqi';
@@ -72,7 +72,7 @@ class NetworkMap {
             if (device.scanfailed.includes('rtg')) {
                 scanNote += ' no routes';
             }
-            labels.push(device.type+scanNote);
+            labels.push(`0x${device.nwkAddr.toString(16)} ${scanNote}`);
 
             // Add the device model
             const mappedModel = zigbeeShepherdConverters.findByZigbeeModel(device.modelId);

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -327,8 +327,23 @@ class Zigbee {
                 });
                 delete link.key;
             });
-            logger.debug(`Merged map: %j`, linkMap);
-            callback(linkMap);
+            const networkMap = {nodes: [], links: linkMap};
+            this.getDevices().forEach((device) => {
+                const friendlyDevice = settings.getDevice(device.ieeeAddr);
+                const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
+                const deviceType = utils.correctDeviceType(device);
+                let scanfailed = [];
+                if (lqiScanList.has(device.ieeeAddr)) {scanfailed.push('lqi')};
+                if (rtgScanList.has(device.ieeeAddr)) {scanfailed.push('rtg')};
+                networkMap.nodes.push({ieeeAddr: device.ieeeAddr, friendlyName: friendlyName, type: deviceType,
+                    nwkAddr: device.nwkAddr, manufName: device.manufName, modelId: device.modelId,
+                    status: device.status, scanfailed: scanfailed});
+            });
+            // Clear remaining devices so they don't process when/if they eventually complete
+            lqiScanList.clear();
+            rtgScanList.clear();
+            logger.debug(`Merged map: %j`, networkMap);
+            callback(networkMap);
         };
 
         const processLqiResponse = (error, rsp, parent) => {
@@ -345,7 +360,7 @@ class Zigbee {
                                 key: key, parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
                                 lqi: neighbor.lqi, depth: neighbor.depth, routes: []});
                         });
-                        // Remove from list and if this was the last one return the completed network map
+                        // Remove from scan list and if both lists are done return the completed network map
                         lqiScanList.delete(parent);
                         if (lqiScanList.size === 0 && rtgScanList === 0) {
                             logger.info('Network scan completed');
@@ -379,7 +394,7 @@ class Zigbee {
                                     key: key, destAddr: route.destNwkAddr});
                             }
                         });
-                        // Remove from list and if this was the last one return the completed network map
+                        // Remove from scan list and if both lists are done return the completed network map
                         rtgScanList.delete(parent);
                         if (lqiScanList.size === 0 && rtgScanList.size === 0) {
                             logger.info('Network scan completed');
@@ -398,7 +413,7 @@ class Zigbee {
             }
         };
 
-        // Queue up an lqi scan  and an rtg for coordinator and each router
+        // Queue up an lqi scan and an rtg scan for coordinator and each router
         this.getScanable().forEach((dev) => {
             logger.debug(`Queing network scans for device: '${dev.ieeeAddr}'`);
             lqiScanList.add(dev.ieeeAddr);
@@ -426,9 +441,6 @@ class Zigbee {
             } else {
                 logger.warn(`Network scan timeout, skipping outstanding lqi scans for '${[...lqiScanList].join(' ')}'`);
                 logger.warn(`Network scan timeout, skipping outstanding rtg scans for '${[...rtgScanList].join(' ')}'`);
-                // Clear remaining devices so they don't process when/if they eventually complete
-                lqiScanList.clear();
-                rtgScanList.clear();
                 collateMap();
             }
         }, lqiScanList.size * 1000);

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -317,7 +317,7 @@ class Zigbee {
 
         // Gather the lqi and the route info into separate lists and only collate them when done.
         const collateMap = () => {
-            linkMap.sort((a, b) => (a.key > b.key) ? 1 : 0);
+            linkMap.sort();
             logger.debug(`Link map: %j`, linkMap);
             logger.debug(`Route map: %j`, routeMap);
             // Merge the routes into the linkMap by matching on 'source|target' link short addresses
@@ -325,6 +325,7 @@ class Zigbee {
                 routeMap.filter((e) => e.key === link.key).forEach((e) => {
                     link.routes.push(e.destAddr);
                 });
+                link.routes.sort(function(a, b){return a-b});
                 delete link.key;
             });
             const networkMap = {nodes: [], links: linkMap};

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -334,10 +334,10 @@ class Zigbee {
                 const deviceType = utils.correctDeviceType(device);
                 const scanfailed = [];
                 if (lqiScanList.has(device.ieeeAddr)) {
-                    scanfailed.push('lqi')
+                    scanfailed.push('lqi');
                 }
                 if (rtgScanList.has(device.ieeeAddr)) {
-                    scanfailed.push('rtg')
+                    scanfailed.push('rtg');
                 }
                 networkMap.nodes.push({ieeeAddr: device.ieeeAddr, friendlyName: friendlyName, type: deviceType,
                     nwkAddr: device.nwkAddr, manufName: device.manufName, modelId: device.modelId,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -325,7 +325,9 @@ class Zigbee {
                 routeMap.filter((e) => e.key === link.key).forEach((e) => {
                     link.routes.push(e.destAddr);
                 });
-                link.routes.sort(function(a, b){return a-b});
+                link.routes.sort(function(a, b) {
+                    return a-b;
+                });
                 delete link.key;
             });
             const networkMap = {nodes: [], links: linkMap};

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -320,7 +320,7 @@ class Zigbee {
             linkMap.sort((a, b) => (a.key > b.key) ? 1 : 0);
             logger.debug(`Link map: %j`, linkMap);
             logger.debug(`Route map: %j`, routeMap);
-            // Merge the routes into the linkMap
+            // Merge the routes into the linkMap by matching on 'source|target' link short addresses
             linkMap.forEach((link) => {
                 routeMap.filter((e) => e.key === link.key).forEach((e) => {
                     link.routes.push(e.destAddr);
@@ -346,26 +346,27 @@ class Zigbee {
             callback(networkMap);
         };
 
-        const processLqiResponse = (error, rsp, parent) => {
+        const processLqiResponse = (error, rsp, targetIeeeAddr, targetNwkAddr) => {
             if (error) {
-                logger.warn(`Failed network lqi scan for device: '${parent}' with error: '${error}'`);
+                logger.warn(`Failed network lqi scan for device: '${targetIeeeAddr}' with error: '${error}'`);
             } else {
-                if (lqiScanList.has(parent)) {
+                if (lqiScanList.has(targetIeeeAddr)) {
                     // Haven't processed this one yet
                     if (rsp && rsp.status === 0 && rsp.neighborlqilist) {
-                        logger.debug(`lqi scan ok for: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
+                        logger.debug(`lqi scan: '${targetIeeeAddr}' with '${rsp.neighborlqilistcount}' neighbors`);
                         rsp.neighborlqilist.forEach(function(neighbor) {
                             // only include active relationships
                             if (neighbor.relationship <= 3) {
-                                const key = parent + '|' + neighbor.nwkAddr;
+                                // lqi is measured at receiver so link is from neighbor (source) to scanned router
+                                const key =  neighbor.nwkAddr + '|' + targetNwkAddr;
                                 linkMap.push({
-                                    key: key, parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
-                                    lqi: neighbor.lqi, depth: neighbor.depth, relationship: neighbor.relationship,
-                                    routes: []});
+                                    key: key, sourceIeeeAddr: neighbor.extAddr, targetIeeeAddr: targetIeeeAddr,
+                                    sourceNwkAddr: neighbor.nwkAddr, lqi: neighbor.lqi, depth: neighbor.depth,
+                                    relationship: neighbor.relationship, routes: []});
                             }
                         });
                         // Remove from scan list and if both lists are done return the completed network map
-                        lqiScanList.delete(parent);
+                        lqiScanList.delete(targetIeeeAddr);
                         if (lqiScanList.size === 0 && rtgScanList === 0) {
                             logger.info('Network scan completed');
                             collateMap();
@@ -374,32 +375,32 @@ class Zigbee {
                             logger.debug(`Outstanding network rtg scans for devices: '${[...rtgScanList].join(' ')}'`);
                         }
                     } else {
-                        logger.warn(`Empty network lqi scan result for: '${parent}'`);
+                        logger.warn(`Empty network lqi scan result for: '${targetIeeeAddr}'`);
                     }
                 } else {
-                    // This ieeeAddr has already been removed due to timeout so don't add to result network map
-                    logger.warn(`Ignoring late network lqi scan result for: '${parent}'`);
+                    // This target has already had timeout so don't add to result network map
+                    logger.warn(`Ignoring late network lqi scan result for: '${targetIeeeAddr}'`);
                 }
             }
         };
 
-        const processRtgResponse = (error, rsp, parent) => {
+        const processRtgResponse = (error, rsp, sourceIeeeAddr, sourceNwkAddr) => {
             if (error) {
-                logger.warn(`Failed network rtg scan for device: '${parent}' with error: '${error}'`);
+                logger.warn(`Failed network rtg scan for device: '${sourceIeeeAddr}' with error: '${error}'`);
             } else {
-                if (rtgScanList.has(parent)) {
+                if (rtgScanList.has(sourceIeeeAddr)) {
                     // Haven't processed this one yet
                     if (rsp && rsp.status === 0 && rsp.routingtablelist) {
-                        logger.debug(`rtg scan ok for: '${parent}' with '${rsp.routingtablelistcount}' entries`);
+                        logger.debug(`rtg scan: '${sourceIeeeAddr}' with '${rsp.routingtablelistcount}' entries`);
                         rsp.routingtablelist.forEach(function(route) {
                             if (route.routeStatus === 0) {
-                                const key = parent + '|' + route.nextHopNwkAddr;
+                                const key = sourceNwkAddr + '|' + route.nextHopNwkAddr;
                                 routeMap.push({
                                     key: key, destAddr: route.destNwkAddr});
                             }
                         });
                         // Remove from scan list and if both lists are done return the completed network map
-                        rtgScanList.delete(parent);
+                        rtgScanList.delete(sourceIeeeAddr);
                         if (lqiScanList.size === 0 && rtgScanList.size === 0) {
                             logger.info('Network scan completed');
                             collateMap();
@@ -408,11 +409,11 @@ class Zigbee {
                             logger.debug(`Outstanding network rtg scans for devices: '${[...rtgScanList].join(' ')}'`);
                         }
                     } else {
-                        logger.warn(`Empty network rtg scan result for: '${parent}'`);
+                        logger.warn(`Empty network rtg scan result for: '${sourceIeeeAddr}'`);
                     }
                 } else {
-                    // This ieeeAddr has already been removed due to timeout so don't add to result network map
-                    logger.warn(`Ignoring late network rtg scan result for: '${parent}'`);
+                    // This source has already had timeout so don't add to result network map
+                    logger.warn(`Ignoring late network rtg scan result for: '${sourceIeeeAddr}'`);
                 }
             }
         };
@@ -423,16 +424,16 @@ class Zigbee {
             lqiScanList.add(dev.ieeeAddr);
             this.queue.push(dev.ieeeAddr, (queueCallback) => {
                 this.shepherd.controller.request('ZDO', 'mgmtLqiReq', {dstaddr: dev.nwkAddr, startindex: 0},
-                    (error, rsp, parent) => {
-                        processLqiResponse(error, rsp, dev.ieeeAddr);
+                    (error, rsp, ieeeAddr) => {
+                        processLqiResponse(error, rsp, dev.ieeeAddr, dev.nwkAddr);
                         queueCallback(error);
                     });
             });
             rtgScanList.add(dev.ieeeAddr);
             this.queue.push(dev.ieeeAddr, (queueCallback) => {
                 this.shepherd.controller.request('ZDO', 'mgmtRtgReq', {dstaddr: dev.nwkAddr, startindex: 0},
-                    (error, rsp, parent) => {
-                        processRtgResponse(error, rsp, dev.ieeeAddr);
+                    (error, rsp, ieeeAddr) => {
+                        processRtgResponse(error, rsp, dev.ieeeAddr, dev.nwkAddr);
                         queueCallback(error);
                     });
             });

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -355,10 +355,14 @@ class Zigbee {
                     if (rsp && rsp.status === 0 && rsp.neighborlqilist) {
                         logger.debug(`lqi scan ok for: '${parent}' with '${rsp.neighborlqilistcount}' neighbors`);
                         rsp.neighborlqilist.forEach(function(neighbor) {
-                            const key = parent + '|' + neighbor.nwkAddr;
-                            linkMap.push({
-                                key: key, parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
-                                lqi: neighbor.lqi, depth: neighbor.depth, routes: []});
+                            // only include active relationships
+                            if (neighbor.relationship <= 3) {
+                                const key = parent + '|' + neighbor.nwkAddr;
+                                linkMap.push({
+                                    key: key, parent: parent, ieeeAddr: neighbor.extAddr, nwkAddr: neighbor.nwkAddr,
+                                    lqi: neighbor.lqi, depth: neighbor.depth, relationship: neighbor.relationship,
+                                    routes: []});
+                            }
                         });
                         // Remove from scan list and if both lists are done return the completed network map
                         lqiScanList.delete(parent);

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -332,9 +332,13 @@ class Zigbee {
                 const friendlyDevice = settings.getDevice(device.ieeeAddr);
                 const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
                 const deviceType = utils.correctDeviceType(device);
-                let scanfailed = [];
-                if (lqiScanList.has(device.ieeeAddr)) {scanfailed.push('lqi')};
-                if (rtgScanList.has(device.ieeeAddr)) {scanfailed.push('rtg')};
+                const scanfailed = [];
+                if (lqiScanList.has(device.ieeeAddr)) {
+                    scanfailed.push('lqi')
+                }
+                if (rtgScanList.has(device.ieeeAddr)) {
+                    scanfailed.push('rtg')
+                }
                 networkMap.nodes.push({ieeeAddr: device.ieeeAddr, friendlyName: friendlyName, type: deviceType,
                     nwkAddr: device.nwkAddr, manufName: device.manufName, modelId: device.modelId,
                     status: device.status, scanfailed: scanfailed});
@@ -358,7 +362,7 @@ class Zigbee {
                             // only include active relationships
                             if (neighbor.relationship <= 3) {
                                 // lqi is measured at receiver so link is from neighbor (source) to scanned router
-                                const key =  neighbor.nwkAddr + '|' + targetNwkAddr;
+                                const key = neighbor.nwkAddr + '|' + targetNwkAddr;
                                 linkMap.push({
                                     key: key, sourceIeeeAddr: neighbor.extAddr, targetIeeeAddr: targetIeeeAddr,
                                     sourceNwkAddr: neighbor.nwkAddr, lqi: neighbor.lqi, depth: neighbor.depth,
@@ -424,7 +428,7 @@ class Zigbee {
             lqiScanList.add(dev.ieeeAddr);
             this.queue.push(dev.ieeeAddr, (queueCallback) => {
                 this.shepherd.controller.request('ZDO', 'mgmtLqiReq', {dstaddr: dev.nwkAddr, startindex: 0},
-                    (error, rsp, ieeeAddr) => {
+                    (error, rsp, ieeeAddr, nwkAddr) => {
                         processLqiResponse(error, rsp, dev.ieeeAddr, dev.nwkAddr);
                         queueCallback(error);
                     });
@@ -432,7 +436,7 @@ class Zigbee {
             rtgScanList.add(dev.ieeeAddr);
             this.queue.push(dev.ieeeAddr, (queueCallback) => {
                 this.shepherd.controller.request('ZDO', 'mgmtRtgReq', {dstaddr: dev.nwkAddr, startindex: 0},
-                    (error, rsp, ieeeAddr) => {
+                    (error, rsp, ieeeAddr, nwkAddr) => {
                         processRtgResponse(error, rsp, dev.ieeeAddr, dev.nwkAddr);
                         queueCallback(error);
                     });


### PR DESCRIPTION
Fixes for a couple of issues with the network map:

Any failed device scans are now recorded in the topology structure so can be shown on the map. This is just some text next to the device type but I'm open to alternative ideas. To enable this the topology data structure has been changed to a graph structure including both nodes and links (the failed scans are recorded against the nodes).

Greater care taken with getting the directionality of the links correct. lqi scans are done on receiving nodes which are endpoints for links. Route scans are from source nodes, i.e. start of links. Use consistent source/target variable naming in the scan code to keep track of which is which.

The code for device friendly name and device type are moved from networkMap.js to zigbee.js so they can be included in the elements for device nodes in the topology structure.

A side-effect of these code changes is that the 'raw' network map is much richer having both nodes (devices) and link information so it should now be possible to regenerate the graphviz externally to zigbee2mqtt if required or use an alternative graphing tool if desired. e.g. D3 https://github.com/d3/d3-force

Addresses the issues mentioned in my last post to #652