### PR TITLE
Use penwidth instead of dotted/dashed lines

### DIFF
--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -121,8 +121,8 @@ class NetworkMap {
              */
             topology.links.filter((e) => (e.sourceIeeeAddr === device.ieeeAddr) || (e.SourceNwkAddr === device.nwkAddr))
                 .forEach((e) => {
-                    const lineStyle = (device.type=='EndDevice') ? 'style="dashed", '
-                        : (!e.routes.length) ? 'style="dotted", ' : '';
+                    const lineStyle = (device.type=='EndDevice') ? 'penwidth=1, '
+                        : (!e.routes.length) ? 'penwidth=0.5, ' : 'penwidth=2, ';
                     const lineWeight = (!e.routes.length) ? `weight=0, color="${colors.line.inactive}", `
                         : `weight=1, color="${colors.line.active}", `;
                     const textRoutes = e.routes.map((r) => `0x${r.toString(16)}`);


### PR DESCRIPTION
Address #1691 by using penwidth instead of dotted and dashed lines to represent types of connections. I'll also do a PR for the documentation.