### PR TITLE
Support for PP-WHT-US new sensors

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -680,8 +680,10 @@ const mapping = {
     ],
     'IM6001-BTP01': [configurations.sensor_click, configurations.sensor_temperature],
     'AV2010/34': [configurations.sensor_click],
-    'PP-WHT-US': [configurations.switch, configurations.sensor_power,
-        configurations.sensor_current, configurations.sensor_voltage],
+    'PP-WHT-US': [
+        configurations.switch, configurations.sensor_power,
+        configurations.sensor_current, configurations.sensor_voltage,
+    ],
     'CR701-YZ': [
         configurations.binary_sensor_battery_low, configurations.binary_sensor_carbon_monoxide,
         configurations.binary_sensor_gas,

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -165,9 +165,27 @@ const configurations = {
         type: 'sensor',
         object_id: 'power',
         discovery_payload: {
-            unit_of_measurement: 'Watt',
-            icon: 'mdi:flash',
+            unit_of_measurement: 'W',
+            icon: 'mdi:factory',
             value_template: '{{ value_json.power }}',
+        },
+    },
+    'sensor_current': {
+        type: 'sensor',
+        object_id: 'current',
+        discovery_payload: {
+            unit_of_measurement: 'A',
+            icon: 'mdi:power-plug',
+            value_template: '{{ value_json.current }}',
+        },
+    },
+    'sensor_voltage': {
+        type: 'sensor',
+        object_id: 'voltage',
+        discovery_payload: {
+            unit_of_measurement: 'V',
+            icon: 'mdi:flash',
+            value_template: '{{ value_json.voltage }}',
         },
     },
     'sensor_action': {
@@ -662,7 +680,8 @@ const mapping = {
     ],
     'IM6001-BTP01': [configurations.sensor_click, configurations.sensor_temperature],
     'AV2010/34': [configurations.sensor_click],
-    'PP-WHT-US': [configurations.switch, configurations.sensor_power],
+    'PP-WHT-US': [configurations.switch, configurations.sensor_power,
+        configurations.sensor_current, configurations.sensor_voltage],
     'CR701-YZ': [
         configurations.binary_sensor_battery_low, configurations.binary_sensor_carbon_monoxide,
         configurations.binary_sensor_gas,


### PR DESCRIPTION
In the existing power sensor I also changed the units from "Watt" to "W" consistent with other uses of abbreviated unit names.