### PR TITLE
Network map routes selectable by mqtt topic

### DIFF
--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -11,6 +11,7 @@ class NetworkMap {
 
         // Subscribe to topic.
         this.topic = `${settings.get().mqtt.base_topic}/bridge/networkmap`;
+        this.topicRoutes = `${settings.get().mqtt.base_topic}/bridge/networkmap/routes`;
 
         // Bind
         this.raw = this.raw.bind(this);
@@ -31,13 +32,15 @@ class NetworkMap {
 
     onMQTTConnected() {
         this.mqtt.subscribe(this.topic);
+        this.mqtt.subscribe(this.topicRoutes);
     }
 
     onMQTTMessage(topic, message) {
         message = message.toString();
-
-        if (topic === this.topic && this.supportedFormats.hasOwnProperty(message)) {
-            this.zigbee.networkScan((result)=> {
+        const includeRoutes = (topic === this.topicRoutes) ? 1: 0;
+        if ((topic === this.topic || topic === this.topicRoutes)
+            && this.supportedFormats.hasOwnProperty(message)) {
+            this.zigbee.networkScan(includeRoutes, (result)=> {
                 const converted = this.supportedFormats[message](this.zigbee, result);
                 this.mqtt.publish(`bridge/networkmap/${message}`, converted, {});
             });

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -308,8 +308,8 @@ class Zigbee {
         return (friendlyName ? friendlyName : ID);
     }
 
-    networkScan(callback) {
-        logger.info('Starting network scan...');
+    networkScan(includeRoutes, callback) {
+        logger.info(`Starting network scan includeRoutes='${includeRoutes}'...`);
         const lqiScanList = new Set();
         const rtgScanList = new Set();
         const linkMap = [];
@@ -374,7 +374,7 @@ class Zigbee {
                         });
                         // Remove from scan list and if both lists are done return the completed network map
                         lqiScanList.delete(targetIeeeAddr);
-                        if (lqiScanList.size === 0 && rtgScanList === 0) {
+                        if (lqiScanList.size === 0 && rtgScanList.size === 0) {
                             logger.info('Network scan completed');
                             collateMap();
                         } else {
@@ -436,14 +436,16 @@ class Zigbee {
                         queueCallback(error);
                     });
             });
-            rtgScanList.add(dev.ieeeAddr);
-            this.queue.push(dev.ieeeAddr, (queueCallback) => {
-                this.shepherd.controller.request('ZDO', 'mgmtRtgReq', {dstaddr: dev.nwkAddr, startindex: 0},
-                    (error, rsp, ieeeAddr, nwkAddr) => {
-                        processRtgResponse(error, rsp, dev.ieeeAddr, dev.nwkAddr);
-                        queueCallback(error);
-                    });
-            });
+            if (includeRoutes) {
+                rtgScanList.add(dev.ieeeAddr);
+                this.queue.push(dev.ieeeAddr, (queueCallback) => {
+                    this.shepherd.controller.request('ZDO', 'mgmtRtgReq', {dstaddr: dev.nwkAddr, startindex: 0},
+                        (error, rsp, ieeeAddr, nwkAddr) => {
+                            processRtgResponse(error, rsp, dev.ieeeAddr, dev.nwkAddr);
+                            queueCallback(error);
+                        });
+                });
+            }
         });
 
         // Wait for all device scans before forcing map with whatever results are already in


### PR DESCRIPTION
As per https://github.com/Koenkk/zigbee2mqtt/issues/1728#issuecomment-511187612 this change excludes routes from the network map by default, but publishing the 'raw' or 'graphviz' request instead to zigbee2mqtt/bridge/networkmap/routes will include routes in the resultant map.

Note: of course it doesn't just exclude the routes from the map, it also prevents the rtg requests being made over the zigbee network unless specifically requested by the /routes topic.

Also fixes a minor bug where if the last lqi scan finished after the last rtg scan it would wait for the timeout instead of returning the map immediately.