### PR TITLE
Add support for Philips Hue white ambiance Aurelle rectangle panel light (3216231P5)

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -546,6 +546,7 @@ const mapping = {
     '50049': [configurations.light_brightness_colorxy],
     '915005733701': [configurations.light_brightness_colortemp_colorxy],
     'RB 285 C': [configurations.light_brightness_colortemp_colorxy],
+    '3216231P5': [configurations.light_brightness_colortemp],
     '3216331P5': [configurations.light_brightness_colortemp],
     'AC08562': [configurations.light_brightness],
     '900008-WW': [configurations.light_brightness],


### PR DESCRIPTION
Add support for Philips Hue white ambiance Aurelle rectangle panel light (3216231P5)