### PR TITLE
add samsung 2018 water sensor

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -694,6 +694,10 @@ const mapping = {
     'HGZB-01A/02A': [configurations.switch],
     'MCT-350 SMA': [configurations.binary_sensor_contact],
     '3310-S': [configurations.sensor_temperature, configurations.sensor_battery],
+    'IM6001-WLP01': [
+        configurations.sensor_temperature, configurations.binary_sensor_water_leak,
+        configurations.sensor_battery,
+    ],
     '3315-S': [
         configurations.sensor_temperature, configurations.binary_sensor_water_leak,
         configurations.sensor_battery,


### PR DESCRIPTION
fix for https://github.com/Koenkk/zigbee2mqtt/issues/663 which will add samsung 2018 water sensor, requires https://github.com/Koenkk/zigbee-shepherd-converters/pull/556 be merged too