### PR TITLE
add sensor_action config for WXKG12LM

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -388,7 +388,7 @@ const switchWithPostfix = (postfix) => {
 const mapping = {
     'WXKG01LM': [configurations.sensor_click, configurations.sensor_battery],
     'WXKG11LM': [configurations.sensor_click, configurations.sensor_battery],
-    'WXKG12LM': [configurations.sensor_click, configurations.sensor_battery],
+    'WXKG12LM': [configurations.sensor_click, configurations.sensor_battery, configurations.sensor_action],
     // BREAKING_IMPROVEMENT: only use sensor_click for WXKG03LM (action hold -> click hold)
     'WXKG03LM': [configurations.sensor_click, configurations.sensor_battery, configurations.sensor_action],
     'WXKG02LM': [configurations.sensor_click, configurations.sensor_battery],


### PR DESCRIPTION
Because WXKG12LM  has a  click and action sensor, the default map for home assistant config missing action sensor.

https://github.com/Koenkk/zigbee-shepherd-converters/blob/fe668b0c3a119e7c602a7188e5da1422d3f4b48c/converters/fromZigbee.js#L530-L545

