### PR TITLE
Home Assistant discovery: allow to delete setting

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1057,6 +1057,8 @@ class HomeAssistant {
                     Object.keys(obj).forEach((key) => {
                         if (['number', 'string'].includes(typeof obj[key])) {
                             payload[key] = obj[key];
+                        } else if (typeof obj[key] === 'object' && obj[key] === null) {
+                            delete payload[key];
                         } else if (key === 'device' && typeof obj[key] === 'object') {
                             Object.keys(obj['device']).forEach((key) => {
                                 payload['device'][key] = obj['device'][key];

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1055,7 +1055,7 @@ class HomeAssistant {
             if (device.hasOwnProperty('homeassistant')) {
                 const add = (obj) => {
                     Object.keys(obj).forEach((key) => {
-                        if (['number', 'string'].includes(typeof obj[key])) {
+                        if (['number', 'string', 'boolean'].includes(typeof obj[key])) {
                             payload[key] = obj[key];
                         } else if (typeof obj[key] === 'object' && obj[key] === null) {
                             delete payload[key];


### PR DESCRIPTION
Home Assistant Discovery: Allows to delete a setting by setting it to ~~`false`~~ `null` in `configuration.yaml` in addition to being able to overwrite it. This is useful to e.g. remove a capability from a device as Home Assistant will throw an error if a topic setting is present in the discovery payload but empty.

Example for a cover that only supports lift but not tilt:  
```yaml
'0x001fee000000abcd':
  homeassistant:
    tilt_command_topic: null
    tilt_status_topic: null
```

I am completely open for other ways to achieve this ~~- just a proposal based on the syntax of `configurations` / `discovery_payload` in `homeassistant.js`~~...

Thanks!