### PR TITLE
Add support for Osram Smart+ GU10 PAR16 AC08560

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -496,6 +496,7 @@ const mapping = {
     'FB56+ZSW05HG1.2': [configurations.switch],
     '72922-A': [configurations.switch],
     'AC03642': [configurations.light_brightness_colortemp],
+    'AC08560': [configurations.light_brightness],
     'DNCKATSW002': [switchWithPostfix('left'), switchWithPostfix('right')],
     'DNCKATSW003': [switchWithPostfix('left'), switchWithPostfix('right'), switchWithPostfix('center')],
     'DNCKATSW004': [


### PR DESCRIPTION
Add support for the Osram Smart+ GU10 PAR16 AC08560