### PR TITLE
Added device_repower field to determine repowered devices.

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -23,6 +23,7 @@ const ExtensionDeviceBind = require('./extension/deviceBind');
 const ExtensionDeviceReport = require('./extension/deviceReport');
 const ExtensionLivolo = require('./extension/livolo');
 const ExtensionResponder = require('./extension/responder');
+const ExtensionDeviceRepower = require('./extension/deviceRepower');
 
 class Controller {
     constructor() {
@@ -47,6 +48,7 @@ class Controller {
             new ExtensionBridgeConfig(this.zigbee, this.mqtt, this.state, this.publishEntityState),
             new ExtensionGroups(this.zigbee, this.mqtt, this.state, this.publishEntityState),
             new ExtensionDeviceBind(this.zigbee, this.mqtt, this.state, this.publishEntityState),
+            new ExtensionResponder(this.zigbee, this.mqtt, this.state, this.publishEntityState),
             new ExtensionResponder(this.zigbee, this.mqtt, this.state, this.publishEntityState),
         ];
 
@@ -77,6 +79,12 @@ class Controller {
         if (settings.get().experimental.livolo) {
             // https://github.com/Koenkk/zigbee2mqtt/issues/592
             this.extensions.push(new ExtensionLivolo(
+                this.zigbee, this.mqtt, this.state, this.publishEntityState
+            ));
+        }
+        
+        if (settings.get().experimental.device_repower) {
+            this.extensions.push(new ExtensionDeviceRepower(
                 this.zigbee, this.mqtt, this.state, this.publishEntityState
             ));
         }

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -82,7 +82,7 @@ class Controller {
                 this.zigbee, this.mqtt, this.state, this.publishEntityState
             ));
         }
-        
+
         if (settings.get().experimental.device_repower) {
             this.extensions.push(new ExtensionDeviceRepower(
                 this.zigbee, this.mqtt, this.state, this.publishEntityState

--- a/lib/extension/deviceRepower.js
+++ b/lib/extension/deviceRepower.js
@@ -4,31 +4,30 @@ const settings = require('../util/settings');
  * This extensions inform about repowered devices (endDeviceAnnce).
  */
 class ExtensionDeviceRepower {
-    
     constructor(zigbee, mqtt, state, publishEntityState) {
         this.zigbee = zigbee;
         this.mqtt = mqtt;
         this.state = state;
         this.publishEntityState = publishEntityState;
     }
-    
+
     onZigbeeStarted() {}
-    
+
     onMQTTConnected() {}
-    
+
     onZigbeeMessage(message, device, mappedDevice) {
         if (message.type == 'endDeviceAnnce') {
             const settingsDevice = settings.getDevice(device.ieeeAddr);
-            this.mqtt.publish("bridge/device_repower", settingsDevice.friendly_name, {retain: false, qos: 2});
+            this.mqtt.publish('bridge/device_repower', settingsDevice.friendly_name, {retain: false, qos: 2});
 
             return;
         }
     }
-    
+
     onMQTTMessage(topic, message) {
         return false;
     }
-    
+
     stop() {}
 }
 

--- a/lib/extension/deviceRepower.js
+++ b/lib/extension/deviceRepower.js
@@ -1,0 +1,35 @@
+const settings = require('../util/settings');
+
+/**
+ * This extensions inform about repowered devices (endDeviceAnnce).
+ */
+class ExtensionDeviceRepower {
+    
+    constructor(zigbee, mqtt, state, publishEntityState) {
+        this.zigbee = zigbee;
+        this.mqtt = mqtt;
+        this.state = state;
+        this.publishEntityState = publishEntityState;
+    }
+    
+    onZigbeeStarted() {}
+    
+    onMQTTConnected() {}
+    
+    onZigbeeMessage(message, device, mappedDevice) {
+        if (message.type == 'endDeviceAnnce') {
+            const settingsDevice = settings.getDevice(device.ieeeAddr);
+            this.mqtt.publish("bridge/device_repower", settingsDevice.friendly_name, {retain: false, qos: 2});
+
+            return;
+        }
+    }
+    
+    onMQTTMessage(topic, message) {
+        return false;
+    }
+    
+    stop() {}
+}
+
+module.exports = ExtensionDeviceRepower;

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -42,6 +42,7 @@ const defaults = {
         livolo: false,
         // json or attribute
         output: 'json',
+        device_repower: false,
     },
     advanced: {
         log_directory: path.join(data.getPath(), 'log', '%TIMESTAMP%'),


### PR DESCRIPTION
The feature can be enabled via configuration.

```
experimental:
  device_repower: true
```

It shows repowered devices under zigbee2mqtt/bridge/device_repower

I use this extension to turn devices on / off after short mains power cut (via push button switch).