### PR TITLE
Fix commit hash output in version info

### DIFF
--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -91,7 +91,7 @@ function getZigbee2mqttVersion(callback) {
 
         if (err) {
             try {
-                commitHash = require('../.hash.json').hash;
+                commitHash = require('../../.hash.json').hash;
             } catch (error) {
                 commitHash = 'unknown';
             }


### PR DESCRIPTION
The path each Dockerfile writes `.hash.js` differs from where `lib/util/utils.js` expects to find it.

I've chosen to update the `utils.js` side of this, but it could just as easily be the Dockerfiles that are wrong if there is something else that generates this file too for non-docker use.