### PR TITLE
Support Aqara S2 Lock Pro

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -797,6 +797,9 @@ const mapping = {
     'ZNMS12LM': [
         configurations.sensor_action, configurations.binary_sensor_lock, configurations.binary_sensor_lock_reverse,
     ],
+    'ZNMS13LM': [
+        configurations.sensor_action, configurations.binary_sensor_lock, configurations.binary_sensor_lock_reverse,
+    ],
     '12050': [configurations.switch, configurations.sensor_power],
     'ROB_200-004-0': [configurations.light_brightness],
     'RH3040': [configurations.sensor_battery, configurations.binary_sensor_occupancy],

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -39,7 +39,7 @@ function flatten(arr) {
 }
 
 const forceEndDevice = flatten(
-    ['QBKG03LM', 'QBKG04LM']
+    ['QBKG03LM', 'QBKG04LM', 'ZNMS13LM']
         .map((model) => zigbeeShepherdConverters.devices.find((d) => d.model === model))
         .map((mappedModel) => mappedModel.zigbeeModel));
 


### PR DESCRIPTION
Add support for Aqara S2 Lock Pro (ZNMS13LM) , this needs https://github.com/Koenkk/zigbee-shepherd-converters/pull/567  to be merged.