### PR TITLE
IKEA TRADFRI E1810

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -611,7 +611,7 @@ const mapping = {
     'D1532': [configurations.light_brightness],
     'AV2010/32': [],
     'HGZB-07A': [configurations.light_brightness_colortemp_colorxy],
-    'E1524': [configurations.sensor_action, configurations.sensor_battery],
+    'E1524/E1810': [configurations.sensor_action, configurations.sensor_battery],
     'GL-C-006/GL-C-009': [configurations.light_brightness_colortemp],
     '100.424.11': [configurations.light_brightness_colortemp],
     'AC0251100NJ': [configurations.sensor_action, configurations.sensor_battery],


### PR DESCRIPTION
Add the IKEA E1810, which appears to be a replacement for the E1524. Functionally, they appear to
work identically, the only difference I can see is front finish is matte rather than glossy, and
the internals behind the battery cover are slightly different.

**NOTE: While I know the E1810 pairs and works just fine using `zigbeeModel: ['TRADFRI remote control']`, I have NOT verified these PRs actually work yet!**