### PR TITLE
#1874: Fix logging of groupid's

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -133,7 +133,7 @@ class Controller {
         logger.debug(
             `Received zigbee message of type '${message.type}' with data '${JSON.stringify(message.data)}'` +
             (device ? ` of device '${device.modelId}' (${device.ieeeAddr})` : '') +
-            (message.groupid ? ` with groupID ${message.groupID}` : '') +
+            (message.groupid ? ` with groupID ${message.groupid}` : '') +
             (message.endpoints && message.endpoints.length ? ` of endpoint ${message.endpoints[0].epId}` : '')
         );
 


### PR DESCRIPTION
While trying to get my IKEA remote to work I kept getting 'undefined' groupID's. This fixes it.

I think there might be a better fix, where we ensure that the property is `groupId` so it follows the casing of other properties, but that is for now a bit beyond my capabilities.