### PR TITLE
Update homeassistant.js for the automatic discovery of ZNCZ03LM

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -427,6 +427,7 @@ const mapping = {
     'SJCGQ11LM': [configurations.binary_sensor_water_leak, configurations.sensor_battery],
     'MFKZQ01LM': [configurations.sensor_action, configurations.sensor_battery],
     'ZNCZ02LM': [configurations.switch, configurations.sensor_power],
+    'ZNCZ03LM': [configurations.switch, configurations.sensor_power],
     'QBCZ11LM': [configurations.switch, configurations.sensor_power],
     'LED1545G12': [configurations.light_brightness_colortemp],
     'LED1623G12': [configurations.light_brightness],


### PR DESCRIPTION
Since ZNCZ03LM is added to zigbee-shepherd-converters in https://github.com/Koenkk/zigbee-shepherd-converters/pull/570, update homeassistant.js to allow this model auto-discovered by HA.