### PR TITLE
Support hard reset ZNP/Coordinator

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -18,6 +18,7 @@ class BridgeConfig {
         this.lastSeen = this.lastSeen.bind(this);
         this.elapsed = this.elapsed.bind(this);
         this.reset = this.reset.bind(this);
+        this.hardReset = this.hardReset.bind(this);
         this.logLevel = this.logLevel.bind(this);
         this.devices = this.devices.bind(this);
         this.groups = this.groups.bind(this);
@@ -35,6 +36,7 @@ class BridgeConfig {
             'last_seen': this.lastSeen,
             'elapsed': this.elapsed,
             'reset': this.reset,
+            'hard_reset': this.hardReset,
             'log_level': this.logLevel,
             'devices': this.devices,
             'groups': this.groups,
@@ -92,6 +94,16 @@ class BridgeConfig {
                 logger.error('Soft reset failed');
             } else {
                 logger.info('Soft resetted ZNP');
+            }
+        });
+    }
+
+    hardReset(topic, message) {
+        this.zigbee.hardReset((error) => {
+            if (error) {
+                logger.error('Hard reset failed');
+            } else {
+                logger.info('Hard resetted ZNP');
             }
         });
     }

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -148,7 +148,7 @@ class Zigbee {
     softReset(callback) {
         this.shepherd.reset('soft', callback);
     }
-    
+
     hardReset(callback) {
         this.shepherd.reset('hard', callback);
     }

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -148,6 +148,10 @@ class Zigbee {
     softReset(callback) {
         this.shepherd.reset('soft', callback);
     }
+    
+    hardReset(callback) {
+        this.shepherd.reset('hard', callback);
+    }
 
     stop(callback) {
         if (this.permitJoinTimer) {


### PR DESCRIPTION
Me and many other user sometimes must re-flash the Coordinator to fix network problem, it take time and hard for some user, so hard reset has been support.
So hard reset trigger the hardware reset (SoC resets), and clear NVRAM
```
zigbee2mqtt/bridge/config/reset
Hard reset the ZNP (CC2530/CC2531/CC2538/CC2652R1).
```
@Koenkk It is just Lint error for space, you can edit it