### PR TITLE
Add support for TRADFRI bulb E27 WS clear 806lm

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -642,6 +642,7 @@ const mapping = {
     'YRD426NRSC': [configurations.lock, configurations.sensor_battery],
     'E1743': [configurations.sensor_click, configurations.sensor_battery],
     'LED1732G11': [configurations.light_brightness_colortemp],
+    'LED1736G9': [configurations.light_brightness_colortemp],
     'RB 265': [configurations.light_brightness],
     '9290019758': [
         configurations.binary_sensor_occupancy, configurations.sensor_temperature,


### PR DESCRIPTION
New IKEA bulb.