### PR TITLE
Support Hue white ambiance E26 with Bluetooth

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -752,6 +752,7 @@ const mapping = {
     '45853GE': [configurations.switch, configurations.sensor_power],
     '50064': [configurations.light_brightness_colortemp],
     '9290011998B': [configurations.light_brightness_colortemp],
+    '9290022167': [configurations.light_brightness_colortemp],
     '4096730U7': [configurations.light_brightness_colortemp],
     'RB 278 T': [configurations.light_brightness],
     '3315-G': [


### PR DESCRIPTION
Support new Philips Hue bulb that has Bluetooth in addition to Zigbee.  We don't care about the BT, but it's a new device with a new model ID, so here we are.