### PR TITLE
Remove caching for `to_side` and `from_side`.

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -11,7 +11,7 @@ const dontCacheProperties = [
     'action', 'button', 'button_left', 'button_right', 'click', 'forgotten', 'keyerror',
     'step_size', 'transition_time', 'action_color_temperature', 'action_color',
     'action_group', 'group_list', 'group_capacity', 'no_occupancy_since',
-    'step_mode', 'transition_time', 'duration', 'elapsed',
+    'step_mode', 'transition_time', 'duration', 'elapsed', 'from_side', 'to_side',
 ];
 
 class State extends events.EventEmitter {


### PR DESCRIPTION
As discussed in https://github.com/Koenkk/zigbee-shepherd-converters/issues/641, remove caching for `from_side` and `to_side` attributes, as they are only valid during a `flip90` action.
`side` is the cached attribute indicating which side is showing 'up'