### PR TITLE
Do not publish a new optimistic group state if any devices within are

### DIFF
--- a/lib/extension/groups.js
+++ b/lib/extension/groups.js
@@ -90,7 +90,23 @@ class Groups extends BaseExtension {
             if (entity.type === 'device') {
                 for (const zigbeeGroup of zigbeeGroups) {
                     if (zigbeeGroup.hasMember(entity.endpoint)) {
-                        await this.publishEntityState(zigbeeGroup.groupID, payload, reason);
+                        let shouldGroupChange = true;
+
+                        if (payload.state && payload.state === 'OFF') {
+                            for (const member of zigbeeGroup.members) {
+                                const device = member.getDevice();
+                                if (this.state.exists(device.ieeeAddr)) {
+                                    const state = this.state.get(device.ieeeAddr);
+                                    if (state.state && state.state === 'ON') {
+                                        shouldGroupChange = false;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (shouldGroupChange) {
+                            await this.publishEntityState(zigbeeGroup.groupID, payload, reason);
+                        }
                     }
                 }
             } else {

--- a/test/stub/zigbeeHerdsman.js
+++ b/test/stub/zigbeeHerdsman.js
@@ -90,7 +90,7 @@ const returnDevices = [];
 
 const devices = {
     'coordinator': new Device('Coordinator', '0x00124b00120144ae', 0, 0, [new Endpoint(1, [], [])], false),
-    'bulb': new Device('Router', '0x000b57fffec6a5b2', 40369, 4476, [new Endpoint(1, [0,3,4,5,6,8,768,2821,4096], [5,25,32,4096])], true, "Mains (single phase)", "TRADFRI bulb E27 WS opal 980lm"),
+    'bulb': new Device('Router', '0x000b57fffec6a5b2', 40369, 4476, [new Endpoint(1, [0,3,4,5,6,8,768,2821,4096], [5,25,32,4096], '0x000b57fffec6a5b2')], true, "Mains (single phase)", "TRADFRI bulb E27 WS opal 980lm"),
     'bulb_color': new Device('Router', '0x000b57fffec6a5b3', 40399, 6535, [new Endpoint(1, [0,3,4,5,6,8,768,2821,4096], [5,25,32,4096], '0x000b57fffec6a5b3')], true, "Mains (single phase)", "LLC020"),
     'remote': new Device('EndDevice', '0x0017880104e45517', 6535, 4107, [new Endpoint(1, [0], [0,3,4,6,8,5]), new Endpoint(2, [0,1,3,15,64512], [25, 6])], true, "Battery", "RWL021"),
     'unsupported': new Device('EndDevice', '0x0017880104e45518', 6536, 0, [new Endpoint(1, [0], [0,3,4,6,8,5])], true, "Battery", "notSupportedModelID"),


### PR DESCRIPTION
Keeps an `optimistic` group reported as `ON` if one device within is switched `OFF`, but any others are still turned `ON`.

Related to #764 