### PR TITLE
Add support for IKEA bulb LED1842G3

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -454,6 +454,7 @@ const mapping = {
     '9290012573A': [configurations.light_brightness_colortemp_colorxy],
     'LED1624G9': [configurations.light_brightness_colorxy],
     'LED1837R5': [configurations.light_brightness],
+    'LED1842G3': [configurations.light_brightness],
     '73742': [configurations.light_brightness_colortemp],
     '73740': [configurations.light_brightness_colortemp],
     '73739': [configurations.light_brightness_colortemp_colorxy],


### PR DESCRIPTION
As it is already in https://github.com/Koenkk/zigbee-shepherd-converters/commit/41df919aba78b70bc81be79f377bf471b7bb7827

I don't think there is any sorting going in on that list?