### PR TITLE
Report Iris 3210-L power usage in its own sensor

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -533,7 +533,7 @@ const mapping = {
     '50043': [cfg.switch],
     '50045': [cfg.light_brightness],
     'AV2010/22': [cfg.binary_sensor_occupancy, cfg.sensor_battery],
-    '3210-L': [cfg.switch],
+    '3210-L': [cfg.switch, cfg.sensor_power],
     '3320-L': [cfg.binary_sensor_contact],
     '3326-L': [cfg.binary_sensor_occupancy, cfg.sensor_temperature],
     '7299355PH': [cfg.light_brightness_colorxy],


### PR DESCRIPTION
This enables power usage reporting in its own sensor for the Iris 3210-L smart plug. Related to https://github.com/Koenkk/zigbee-shepherd-converters/issues/671. Thanks!