### PR TITLE
Group device staying off when already off

### DIFF
--- a/lib/extension/groups.js
+++ b/lib/extension/groups.js
@@ -75,7 +75,7 @@ class Groups extends BaseExtension {
         const payload = {};
 
         properties.forEach((prop) => {
-            if (data.to.hasOwnProperty(prop) && (!data.from || data.from[prop] != data.to[prop])) {
+            if (data.to.hasOwnProperty(prop)) {
                 payload[prop] = data.to[prop];
             }
         });

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -389,8 +389,8 @@ describe('Groups', () => {
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledTimes(3);
         expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", '{"state":"OFF"}', {"retain": false, qos: 0}, expect.any(Function));
-        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb", '{"state":"OFF\","brightness":50,"color_temp":370,"linkquality":99}', {"retain": true, qos: 0}, expect.any(Function));
-        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/group_1", '{"state":"OFF"}', {"retain": false, qos: 0}, expect.any(Function));
+        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb", '{"state":"OFF","brightness":50,"color_temp":370,"linkquality":99}', {"retain": true, qos: 0}, expect.any(Function));
+        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/group_1", '{"state":"OFF","brightness":50,"color_temp":370}', {"retain": false, qos: 0}, expect.any(Function));
     });
 
     it('Should publish state change off even when missing current state', async () => {


### PR DESCRIPTION
Currently, only properties that have not changed are added to the payload, but since these properties could be different between member devices, they should all be included in the payload. Otherwise, devices will stay off (since `state` gets excluded from the payload, they will not know to change their state when the group changes)

Also related to #764 