### PR TITLE
Allow a device to be configured even if the interview process fails

### DIFF
--- a/lib/extension/deviceConfigure.js
+++ b/lib/extension/deviceConfigure.js
@@ -24,7 +24,7 @@ class DeviceConfigure extends BaseExtension {
             return false;
         }
 
-        if (device.interviewing === true || device.interviewCompleted === false) {
+        if (device.interviewing === true) {
             return false;
         }
 

--- a/test/deviceConfigure.test.js
+++ b/test/deviceConfigure.test.js
@@ -89,7 +89,7 @@ describe('Device receive', () => {
         device.interviewing = false;
     });
 
-    it('Should not configure when not interviewCompleted', async () => {
+    it('Should configure when not interviewCompleted', async () => {
         const device = zigbeeHerdsman.devices.remote;
         delete device.meta.configured;
         device.interviewCompleted = false;
@@ -98,7 +98,7 @@ describe('Device receive', () => {
         const payload = {data: {zclVersion: 1}, cluster: 'genBasic', device, endpoint, type: 'attributeReport', linkquality: 10};
         await zigbeeHerdsman.events.message(payload);
         await flushPromises();
-        expectRemoteNotConfigured();
+        expectRemoteConfigured();
         device.interviewCompleted = true;
     });
 


### PR DESCRIPTION
A certain device (Visonic MCT-340 E) is failing to complete its interview, but still pairs to the network and sends updates. Since the interview is never completed, the device is not getting configured; this allows devices to be configured even if interviewing fails.

More info and discussion in #2148.