### PR TITLE
Add support for battery percentage on Iris 3326-L motion sensor

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -537,7 +537,7 @@ const mapping = {
     'AV2010/22': [cfg.binary_sensor_occupancy, cfg.sensor_battery],
     '3210-L': [cfg.switch, cfg.sensor_power],
     '3320-L': [cfg.binary_sensor_contact, cfg.sensor_temperature, cfg.sensor_battery],
-    '3326-L': [cfg.binary_sensor_occupancy, cfg.sensor_temperature],
+    '3326-L': [cfg.binary_sensor_occupancy, cfg.sensor_temperature, cfg.sensor_battery],
     '7299355PH': [cfg.light_brightness_colorxy],
     '45857GE': [cfg.light_brightness],
     'A6121': [cfg.sensor_lock],


### PR DESCRIPTION
Along with https://github.com/Koenkk/zigbee-herdsman-converters/pull/697, this PR adds battery level reporting to HA for the Iris 3326-L motion sensor.