### PR TITLE
Improve support for Centralite 4257050-ZHAC dimmable plug

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -535,7 +535,7 @@ const mapping = {
     '50043': [cfg.switch],
     '50045': [cfg.light_brightness],
     'AV2010/22': [cfg.binary_sensor_occupancy, cfg.sensor_battery],
-    '3210-L': [cfg.switch, cfg.sensor_power],
+    '3210-L': [cfg.switch, cfg.sensor_power, cfg.sensor_current, cfg.sensor_voltage],
     '3320-L': [cfg.binary_sensor_contact, cfg.sensor_temperature, cfg.sensor_battery],
     '3326-L': [cfg.binary_sensor_occupancy, cfg.sensor_temperature, cfg.sensor_battery],
     '7299355PH': [cfg.light_brightness_colorxy],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -558,7 +558,7 @@ const mapping = {
     'MG-AUWS01': [switchWithPostfix('left'), switchWithPostfix('right')],
     '9290002579A': [cfg.light_brightness_colortemp_colorxy],
     '4256251-RZHAC': [cfg.switch, cfg.sensor_power],
-    '4257050-ZHAC': [cfg.switch, cfg.sensor_power, cfg.sensor_current, cfg.sensor_voltage],
+    '4257050-ZHAC': [cfg.light_brightness, cfg.sensor_power, cfg.sensor_current, cfg.sensor_voltage],
     'STS-PRS-251': [cfg.binary_sensor_presence, cfg.sensor_battery],
     '4058075816794': [cfg.light_brightness_colortemp],
     '4052899926158': [cfg.light_brightness],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -558,6 +558,7 @@ const mapping = {
     'MG-AUWS01': [switchWithPostfix('left'), switchWithPostfix('right')],
     '9290002579A': [cfg.light_brightness_colortemp_colorxy],
     '4256251-RZHAC': [cfg.switch, cfg.sensor_power],
+    '4257050-ZHAC': [cfg.switch, cfg.sensor_power, cfg.sensor_current, cfg.sensor_voltage],
     'STS-PRS-251': [cfg.binary_sensor_presence, cfg.sensor_battery],
     '4058075816794': [cfg.light_brightness_colortemp],
     '4052899926158': [cfg.light_brightness],


### PR DESCRIPTION
This PR adds HA sensors for the Centralite 4257050-ZHAC dimmable plug.

Note that https://github.com/Koenkk/zigbee-herdsman-converters/pull/705 is a prerequisite.