### PR TITLE
Store last_seen in state.json

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -246,6 +246,10 @@ class Controller {
             return;
         }
 
+        if (entity.type === 'device' && settings.get().advanced.last_seen !== 'disable' && entity.device.lastSeen) {
+            payload.last_seen = utils.formatDate(entity.device.lastSeen, settings.get().advanced.last_seen);
+        }
+
         let messagePayload = {...payload};
         const currentState = this.state.exists(entity.settings.ID) ? this.state.get(entity.settings.ID) : {};
         const newState = objectAssignDeep.noMutate(currentState, payload);
@@ -272,10 +276,6 @@ class Controller {
 
             messagePayload.device = {friendlyName: entity.name};
             attributes.forEach((a) => messagePayload.device[a] = device[a]);
-        }
-
-        if (entity.type === 'device' && settings.get().advanced.last_seen !== 'disable') {
-            messagePayload.last_seen = utils.formatDate(entity.device.lastSeen, settings.get().advanced.last_seen);
         }
 
         if (Object.entries(messagePayload).length) {


### PR DESCRIPTION
This PR fixes #2175 based on @Koenkk's recommendations. Note that I had to add a null check also, because `entity.device.lastSeen` is `null` when zigbee2mqtt first starts up, before it receives any messages.