### PR TITLE
Add Hue White Ambiance GU10 with Bluetooth

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -505,6 +505,7 @@ const mapping = {
         configurations.binary_sensor_occupancy, configurations.sensor_temperature,
         configurations.sensor_illuminance, configurations.sensor_battery,
     ],
+    '929001953301': [configurations.light_brightness_colortemp],
     'GL-C-008': [configurations.light_brightness_colortemp_colorxy],
     'STSS-MULT-001': [configurations.binary_sensor_contact, configurations.sensor_battery],
     'E11-G23/E11-G33': [configurations.light_brightness],


### PR DESCRIPTION
Add support for Hue white ambiance GU10 with Bluetooth