### PR TITLE
Fix missing retain on add_group, allow specifying of groupID

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -204,8 +204,29 @@ class BridgeConfig extends BaseExtension {
     }
 
     addGroup(topic, message) {
-        const name = message;
-        const group = settings.addGroup(name);
+        let id = null;
+        let name = null;
+        try {
+            // json payload with id and friendly_name
+            const json = JSON.parse(message);
+            if (json.hasOwnProperty('id')) {
+                id = json.id;
+                name = `group_${id}`;
+            }
+            if (json.hasOwnProperty('friendly_name')) {
+                name = json.friendly_name;
+            }
+        } catch (e) {
+            // just friendly_name
+            name = message;
+        }
+
+        if (name == null) {
+            logger.error('Failed to add group, missing friendly_name!');
+            return;
+        }
+
+        const group = settings.addGroup(name, id);
         this.zigbee.createGroup(group.ID);
         logger.info(`Added group '${name}'`);
     }

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -483,7 +483,7 @@ function removeDevice(IDorName) {
     write();
 }
 
-function addGroup(name) {
+function addGroup(name, ID=null) {
     if (getGroup(name) || getDevice(name)) {
         throw new Error(`friendly_name '${name}' is already in use`);
     }
@@ -493,12 +493,21 @@ function addGroup(name) {
         settings.groups = {};
     }
 
-    let ID = '1';
-    while (settings.groups.hasOwnProperty(ID)) {
-        ID = (Number.parseInt(ID) + 1).toString();
+    if (ID == null) {
+        // look for free ID
+        ID = '1';
+        while (settings.groups.hasOwnProperty(ID)) {
+            ID = (Number.parseInt(ID) + 1).toString();
+        }
+    } else {
+        // ensure provided ID is not in use
+        ID = ID.toString();
+        if (settings.groups.hasOwnProperty(ID)) {
+            throw new Error(`group id '${ID}' is already in use`);
+        }
     }
 
-    settings.groups[ID] = {friendly_name: name};
+    settings.groups[ID] = {friendly_name: name, retain: false};
     write();
 
     return getGroup(ID);

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -338,6 +338,21 @@ describe('Settings', () => {
         const expected = {
             '1': {
                 friendly_name: 'test123',
+                retain: false,
+            },
+        };
+
+        expect(settings.get().groups).toStrictEqual(expected);
+    });
+
+    it('Should add groups with specific ID', () => {
+        write(configurationFile, {});
+
+        const added = settings.addGroup('test123', 123);
+        const expected = {
+            '123': {
+                friendly_name: 'test123',
+                retain: false,
             },
         };
 
@@ -354,6 +369,24 @@ describe('Settings', () => {
         const expected = {
             '1': {
                 friendly_name: 'test123',
+                retain: false,
+            },
+        };
+
+        expect(settings.get().groups).toStrictEqual(expected);
+    });
+
+    it('Should not add duplicate groups with specific ID', () => {
+        write(configurationFile, {});
+
+        settings.addGroup('test123', 123);
+        expect(() => {
+            settings.addGroup('test_id_123', 123);
+        }).toThrow(new Error("group id '123' is already in use"));
+        const expected = {
+            '123': {
+                friendly_name: 'test123',
+                retain: false,
             },
         };
 
@@ -375,6 +408,7 @@ describe('Settings', () => {
         const expected = {
             '1': {
                 friendly_name: 'test123',
+                retain: false,
                 devices: ['0x123'],
             },
         };


### PR DESCRIPTION
This PR fixes #2264, it also now accepts json input for add_group in the format of

```json
{
  "friendly_name": "my_group",
  "id": 123"
}
```

It is also possible to just provide and id, the friendly_name will then be `group_${id}` or just a friendly_name and the behavior will be the same as just sending the friendly_name as a string.

~~I still need to figure out how to get the tests to run so I can update them.~~ `npm run test` apparently ...