### PR TITLE
Only post deviceAvailability updates if the status has changed.

### DIFF
--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -113,12 +113,14 @@ class DeviceAvailability extends BaseExtension {
             this.onReconnect(device);
         }
 
-        this.state[ieeeAddr] = available;
         const deviceSettings = settings.getDevice(ieeeAddr);
         const name = deviceSettings ? deviceSettings.friendly_name : ieeeAddr;
         const topic = `${name}/availability`;
         const payload = available ? 'online' : 'offline';
-        this.mqtt.publish(topic, payload, {retain: true, qos: 0});
+        if (this.state[ieeeAddr] !== available) {
+            this.state[ieeeAddr] = available;
+            this.mqtt.publish(topic, payload, {retain: true, qos: 0});
+        }
     }
 
     onZigbeeEvent(type, data, mappedDevice, settingsDevice) {

--- a/test/deviceAvailability.test.js
+++ b/test/deviceAvailability.test.js
@@ -54,7 +54,7 @@ describe('Device availability', () => {
         device.ping.mockImplementationOnce(() => {throw new Error('failed')});
         jest.advanceTimersByTime(11 * 1000);
         await flushPromises();
-        expect(MQTT.publish).toHaveBeenCalledTimes(2);
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenNthCalledWith(1,
             'zigbee2mqtt/bulb_color/availability',
           'offline',
@@ -68,8 +68,8 @@ describe('Device availability', () => {
         await flushPromises();
         expect(logger.debug).toHaveBeenCalledTimes(3);
         expect(logger.debug).toHaveBeenCalledWith("Failed to ping 'bulb_color'");
-        expect(MQTT.publish).toHaveBeenCalledTimes(4);
-        expect(MQTT.publish).toHaveBeenNthCalledWith(3,
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
+        expect(MQTT.publish).toHaveBeenNthCalledWith(1,
             'zigbee2mqtt/bulb_color/availability',
           'offline',
           { retain: true, qos: 0 },


### PR DESCRIPTION
This fixes #2296 so that the /availability MQTT message is only sent when the state has  change...
- offline -> online
- online -> offline