### PR TITLE
Customizable timestamp

### DIFF
--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -15,7 +15,7 @@ const directory = settings.get().advanced.log_directory.replace('%TIMESTAMP%', t
 fx.mkdirSync(directory);
 
 // Determine the log level.
-const timestampFormat = () => moment().format(settings.get().advanced.timestamp_format);
+const level = settings.get().advanced.log_level;
 
 const levelWithCompensatedLength = {
     'info': 'info ',

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -24,7 +24,7 @@ const levelWithCompensatedLength = {
     'debug': 'debug',
 };
 
-const timestampFormat = () => moment().format('YYYY-MM-DD HH:mm:ss');
+const timestampFormat = () => moment().format(settings.get().advanced.timestamp_format);
 
 // Create logger
 const transports = {

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -15,7 +15,7 @@ const directory = settings.get().advanced.log_directory.replace('%TIMESTAMP%', t
 fx.mkdirSync(directory);
 
 // Determine the log level.
-const level = settings.get().advanced.log_level;
+const timestampFormat = () => moment().format(settings.get().advanced.timestamp_format);
 
 const levelWithCompensatedLength = {
     'info': 'info ',

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -104,7 +104,7 @@ const defaults = {
          * Configurable timestampFormat
          * https://github.com/Koenkk/zigbee2mqtt/commit/44db557a0c83f419d66755d14e460cd78bd6204e
          */
-        timestamp_format: 'YYYY-MM-DD HH:mm:ss',        
+        timestamp_format: 'YYYY-MM-DD HH:mm:ss',
     },
 };
 
@@ -158,7 +158,7 @@ const schema = {
                 report: {type: 'boolean'},
                 homeassistant_discovery_topic: {type: 'string'},
                 homeassistant_status_topic: {type: 'string'},
-                timestamp_format: {type: 'string'},                
+                timestamp_format: {type: 'string'},
             },
         },
         map_options: {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -99,6 +99,13 @@ const defaults = {
          * Home Assistant status topic
          */
         homeassistant_status_topic: 'hass/status',
+
+        /**
+         * Configurable timestampFormat
+         * https://github.com/Koenkk/zigbee2mqtt/commit/44db557a0c83f419d66755d14e460cd78bd6204e
+         */
+        timestamp_format: 'YYYY-MM-DD HH:mm:ss',
+
     },
 };
 
@@ -152,6 +159,7 @@ const schema = {
                 report: {type: 'boolean'},
                 homeassistant_discovery_topic: {type: 'string'},
                 homeassistant_status_topic: {type: 'string'},
+                timestamp_format: {type: 'string'},
             },
         },
         map_options: {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -99,6 +99,12 @@ const defaults = {
          * Home Assistant status topic
          */
         homeassistant_status_topic: 'hass/status',
+
+        /**
+         * Configurable timestampFormat
+         * https://github.com/Koenkk/zigbee2mqtt/commit/44db557a0c83f419d66755d14e460cd78bd6204e
+         */
+        timestamp_format: 'YYYY-MM-DD HH:mm:ss',        
     },
 };
 
@@ -152,6 +158,7 @@ const schema = {
                 report: {type: 'boolean'},
                 homeassistant_discovery_topic: {type: 'string'},
                 homeassistant_status_topic: {type: 'string'},
+                timestamp_format: {type: 'string'},                
             },
         },
         map_options: {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -99,13 +99,6 @@ const defaults = {
          * Home Assistant status topic
          */
         homeassistant_status_topic: 'hass/status',
-
-        /**
-         * Configurable timestampFormat
-         * https://github.com/Koenkk/zigbee2mqtt/commit/44db557a0c83f419d66755d14e460cd78bd6204e
-         */
-        timestamp_format: 'YYYY-MM-DD HH:mm:ss',
-
     },
 };
 
@@ -159,7 +152,6 @@ const schema = {
                 report: {type: 'boolean'},
                 homeassistant_discovery_topic: {type: 'string'},
                 homeassistant_status_topic: {type: 'string'},
-                timestamp_format: {type: 'string'},
             },
         },
         map_options: {


### PR DESCRIPTION
Added setting ```timestamp_format``` under advanced in continuation of commit https://github.com/Koenkk/zigbee2mqtt/commit/44db557a0c83f419d66755d14e460cd78bd6204e

If not set, it will default to ```YYYY-MM-DD HH:mm:ss``` formatting.

With different settings:
```timestamp_format: 'MMMM Do YYYY, h:mm:ss a'```
We will get:
```November 17th 2019, 6:50:57 pm: Starting zigbee2mqtt version 1.7.1+dev (commit #d2c4133)```

```
timestamp_format: 'YYYY-MM-DD HH-mm-ss'```
2019-11-17 18-53-49: Starting zigbee2mqtt version 1.7.1+dev (commit #d2c4133)
```

```
timestamp_format: 'YYYY-MM-DD [<]HH-mm-ss[>]'
2019-11-17 <18-56-31>: Starting zigbee2mqtt version 1.7.1+dev (commit #d2c4133)
```

Damn it was hard to make PR with two files... 🤕 