### PR TITLE
Add device specific configuration option: debounceIndexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ data/log
 data-backup/
 data/coordinator_backup.json
 data/.storage
+
+# MacOS indexing file
+.DS_Store

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -16,7 +16,7 @@ class DeviceReceive extends BaseExtension {
         this.coordinator = this.zigbee.getDevicesByType('Coordinator')[0];
     }
 
-    publishDebounce(ieeeAddr, payload, time) {
+    publishDebounce(ieeeAddr, payload, time, indexes) {
         if (!this.debouncers[ieeeAddr]) {
             this.debouncers[ieeeAddr] = {
                 payload: {},
@@ -27,8 +27,31 @@ class DeviceReceive extends BaseExtension {
             };
         }
 
+        if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, indexes)) {
+            // publish previous payload immediately
+            this.debouncers[ieeeAddr].publish.flush();
+        }
+
+        // extend debounced payload with current
         this.debouncers[ieeeAddr].payload = {...this.debouncers[ieeeAddr].payload, ...payload};
         this.debouncers[ieeeAddr].publish();
+    }
+
+    // if indexes are specified (Array of strings)
+    // then all newPayload values with key present in indexes
+    // should equal or be undefined in oldPayload
+    // otherwise payload is conflicted
+    isPayloadConflicted(newPayload, oldPayload, indexes) {
+        let result = false;
+        Object.keys(oldPayload)
+            .filter((key) => (indexes || []).includes(key))
+            .forEach((key) => {
+                if (typeof newPayload[key] !== 'undefined' && newPayload[key] !== oldPayload[key]) {
+                    result = true;
+                }
+            });
+
+        return result;
     }
 
     canHandleEvent(type, data, mappedDevice) {
@@ -117,7 +140,12 @@ class DeviceReceive extends BaseExtension {
 
             // Check if we have to debounce
             if (settingsDevice && settingsDevice.hasOwnProperty('debounce')) {
-                this.publishDebounce(data.device.ieeeAddr, payload, settingsDevice.debounce);
+                this.publishDebounce(
+                    data.device.ieeeAddr,
+                    payload,
+                    settingsDevice.debounce,
+                    settingsDevice.debounceIndexes,
+                );
             } else {
                 this.publishEntityState(data.device.ieeeAddr, payload);
 

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -16,7 +16,7 @@ class DeviceReceive extends BaseExtension {
         this.coordinator = this.zigbee.getDevicesByType('Coordinator')[0];
     }
 
-    publishDebounce(ieeeAddr, payload, time, indexes) {
+    publishDebounce(ieeeAddr, payload, time, debounce_ignore) {
         if (!this.debouncers[ieeeAddr]) {
             this.debouncers[ieeeAddr] = {
                 payload: {},
@@ -27,7 +27,7 @@ class DeviceReceive extends BaseExtension {
             };
         }
 
-        if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, indexes)) {
+        if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, debounce_ignore)) {
             // publish previous payload immediately
             this.debouncers[ieeeAddr].publish.flush();
         }
@@ -37,14 +37,14 @@ class DeviceReceive extends BaseExtension {
         this.debouncers[ieeeAddr].publish();
     }
 
-    // if indexes are specified (Array of strings)
-    // then all newPayload values with key present in indexes
+    // if debounce_ignore are specified (Array of strings)
+    // then all newPayload values with key present in debounce_ignore
     // should equal or be undefined in oldPayload
     // otherwise payload is conflicted
-    isPayloadConflicted(newPayload, oldPayload, indexes) {
+    isPayloadConflicted(newPayload, oldPayload, debounce_ignore) {
         let result = false;
         Object.keys(oldPayload)
-            .filter((key) => (indexes || []).includes(key))
+            .filter((key) => (debounce_ignore || []).includes(key))
             .forEach((key) => {
                 if (typeof newPayload[key] !== 'undefined' && newPayload[key] !== oldPayload[key]) {
                     result = true;
@@ -144,7 +144,7 @@ class DeviceReceive extends BaseExtension {
                     data.device.ieeeAddr,
                     payload,
                     settingsDevice.debounce,
-                    settingsDevice.debounceIndexes,
+                    settingsDevice.debounce_ignore,
                 );
             } else {
                 this.publishEntityState(data.device.ieeeAddr, payload);

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -16,7 +16,7 @@ class DeviceReceive extends BaseExtension {
         this.coordinator = this.zigbee.getDevicesByType('Coordinator')[0];
     }
 
-    publishDebounce(ieeeAddr, payload, time, debounce_ignore) {
+    publishDebounce(ieeeAddr, payload, time, debounceIgnore) {
         if (!this.debouncers[ieeeAddr]) {
             this.debouncers[ieeeAddr] = {
                 payload: {},
@@ -27,7 +27,7 @@ class DeviceReceive extends BaseExtension {
             };
         }
 
-        if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, debounce_ignore)) {
+        if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, debounceIgnore)) {
             // publish previous payload immediately
             this.debouncers[ieeeAddr].publish.flush();
         }
@@ -41,10 +41,10 @@ class DeviceReceive extends BaseExtension {
     // then all newPayload values with key present in debounce_ignore
     // should equal or be undefined in oldPayload
     // otherwise payload is conflicted
-    isPayloadConflicted(newPayload, oldPayload, debounce_ignore) {
+    isPayloadConflicted(newPayload, oldPayload, debounceIgnore) {
         let result = false;
         Object.keys(oldPayload)
-            .filter((key) => (debounce_ignore || []).includes(key))
+            .filter((key) => (debounceIgnore || []).includes(key))
             .forEach((key) => {
                 if (typeof newPayload[key] !== 'undefined' && newPayload[key] !== oldPayload[key]) {
                     result = true;

--- a/test/deviceReceive.test.js
+++ b/test/deviceReceive.test.js
@@ -110,11 +110,11 @@ describe('Device receive', () => {
         expect(MQTT.publish.mock.calls[0][2]).toStrictEqual({"qos": 1, "retain": false});
     });
 
-    it('Should debounce messages only with the same payload values for provided indexes', async () => {
+    it('Should debounce messages only with the same payload values for provided debounce_ignore keys', async () => {
         jest.useFakeTimers();
         const device = zigbeeHerdsman.devices.WSDCGQ11LM;
         settings.set(['devices', device.ieeeAddr, 'debounce'], 0.1);
-        settings.set(['devices', device.ieeeAddr, 'debounceIndexes'], ['temperature']);
+        settings.set(['devices', device.ieeeAddr, 'debounce_ignore'], ['temperature']);
         const tempMsg = {data: {measuredValue: 8}, cluster: 'msTemperatureMeasurement', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 13};
         await zigbeeHerdsman.events.message(tempMsg);
         const pressureMsg = {data: {measuredValue: 2}, cluster: 'msPressureMeasurement', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 13};

--- a/test/deviceReceive.test.js
+++ b/test/deviceReceive.test.js
@@ -110,6 +110,29 @@ describe('Device receive', () => {
         expect(MQTT.publish.mock.calls[0][2]).toStrictEqual({"qos": 1, "retain": false});
     });
 
+    it('Should debounce messages only with the same payload values for provided indexes', async () => {
+        jest.useFakeTimers();
+        const device = zigbeeHerdsman.devices.WSDCGQ11LM;
+        settings.set(['devices', device.ieeeAddr, 'debounce'], 0.1);
+        settings.set(['devices', device.ieeeAddr, 'debounceIndexes'], ['temperature']);
+        const tempMsg = {data: {measuredValue: 8}, cluster: 'msTemperatureMeasurement', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 13};
+        await zigbeeHerdsman.events.message(tempMsg);
+        const pressureMsg = {data: {measuredValue: 2}, cluster: 'msPressureMeasurement', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 13};
+        await zigbeeHerdsman.events.message(pressureMsg);
+        const tempMsg2 = {data: {measuredValue: 7}, cluster: 'msTemperatureMeasurement', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 13};
+        await zigbeeHerdsman.events.message(tempMsg2);
+        const humidityMsg = {data: {measuredValue: 3}, cluster: 'msRelativeHumidity', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 13};
+        await zigbeeHerdsman.events.message(humidityMsg);
+        await flushPromises();
+        jest.advanceTimersByTime(50);
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
+        expect(JSON.parse(MQTT.publish.mock.calls[0][1])).toStrictEqual({temperature: 0.08, pressure: 2, linkquality: 13});
+        jest.runAllTimers();
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledTimes(2);
+        expect(JSON.parse(MQTT.publish.mock.calls[1][1])).toStrictEqual({temperature: 0.07, pressure: 2, humidity: 0.03, linkquality: 13});
+    });
+
     it('Should handle a zigbee message with 1 precision', async () => {
         const device = zigbeeHerdsman.devices.WSDCGQ11LM;
         settings.set(['devices', device.ieeeAddr, 'temperature_precision'], 1);


### PR DESCRIPTION
@Koenkk please take a look at this PR.
It's related to https://github.com/Koenkk/zigbee2mqtt/issues/2354

It allows to provide in configuration debounceIndexes (index keys of device specific payload) which unique values should never be omitted when debounce is set.

So for example if you have a device sending temperature, humidity & pressure and you set debounce to 1s & debounceIndexes: ['temperature', 'pressure'] then it will wait 1s to combine all values into one payload unless temperature or pressure value changes in the meantime.

If there is something missing in this implementation, let me know I'll add it.