### PR TITLE
Return false when mappedDevice is falsy

### DIFF
--- a/lib/extension/deviceReport.js
+++ b/lib/extension/deviceReport.js
@@ -97,7 +97,7 @@ class DeviceReport extends BaseExtension {
     }
 
     shouldSetupReporting(mappedDevice, device, messageType) {
-        if (!device) return false;
+        if (!device || !mappedDevice) return false;
 
         // Handle messages of type endDeviceAnnce and devIncoming.
         // This message is typically send when a device comes online after being powered off


### PR DESCRIPTION
Line 112 is raising vendor of undefined when having devices that are not mapped in your network, so I figured we might just return false on it as well. Feel free to adjust the logic if you prefer 👍 

https://github.com/hanswilw/zigbee2mqtt/blob/24b904adb191c4df7111d589981bb6ae2517f832/lib/extension/deviceReport.js#L112