### PR TITLE
availability_whitelist

### DIFF
--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -27,6 +27,7 @@ class DeviceAvailability extends BaseExtension {
         this.blacklist = settings.get().advanced.availability_blacklist.map((e) => {
             return settings.getEntity(e).ID;
         });
+
         // Initialize whitelist
         this.whitelist = settings.get().advanced.availability_whitelist.map((e) => {
             return settings.getEntity(e).ID;
@@ -34,26 +35,23 @@ class DeviceAvailability extends BaseExtension {
     }
 
     isPingable(device) {
+        // Whitelist is not empty and device is in it, enable availability
+        if (this.whitelist.length > 0) {
+            return this.whitelist.includes(device.ieeeAddr);
+        }
+
         // Device is on blacklist, disable availability
         if (this.blacklist.includes(device.ieeeAddr)) {
             return false;
         }
+
         // Device is on forcedPingable-list, enable availability
         if (forcedPingable.find((d) => d.zigbeeModel.includes(device.modelID))) {
             return true;
         }
-        // If availability_whitelist is set
-        if (settings.get().advanced.availability_whitelist.length > 0) {
-            // Check if device is found on availability_whitelist, if so enable availability
-            if (this.whitelist.includes(device.ieeeAddr)) {
-                return true;
-            } else { // If device is not found on whitelist, disable availability
-                return false;
-            }
-        } else { // If availability_whitelist is not set, enable availability on ZR and disable on ZEDs
-            const result = utils.isRouter(device) && !utils.isBatteryPowered(device);
-            return result;
-        }
+
+        const result = utils.isRouter(device) && !utils.isBatteryPowered(device);
+        return result;
     }
 
     getAllPingableDevices() {

--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -27,19 +27,33 @@ class DeviceAvailability extends BaseExtension {
         this.blacklist = settings.get().advanced.availability_blacklist.map((e) => {
             return settings.getEntity(e).ID;
         });
+        // Initialize whitelist
+        this.whitelist = settings.get().advanced.availability_whitelist.map((e) => {
+            return settings.getEntity(e).ID;
+        });
     }
 
     isPingable(device) {
+        // Device is on blacklist, disable availability
         if (this.blacklist.includes(device.ieeeAddr)) {
             return false;
         }
-
+        // Device is on forcedPingable-list, enable availability
         if (forcedPingable.find((d) => d.zigbeeModel.includes(device.modelID))) {
             return true;
         }
-
-        const result = utils.isRouter(device) && !utils.isBatteryPowered(device);
-        return result;
+        // If availability_whitelist is set
+        if (settings.get().advanced.availability_whitelist.length > 0) {
+            // Check if device is found on availability_whitelist, if so enable availability
+            if (this.whitelist.includes(device.ieeeAddr)) {
+                return true;
+            } else { // If device is not found on whitelist, disable availability
+                return false;
+            }
+        } else { // If availability_whitelist is not set, enable availability on ZR and disable on ZEDs
+            const result = utils.isRouter(device) && !utils.isBatteryPowered(device);
+            return result;
+        }
     }
 
     getAllPingableDevices() {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -54,6 +54,7 @@ const defaults = {
         // Availability timeout in seconds, disabled by default.
         availability_timeout: 0,
         availability_blacklist: [],
+        availability_whitelist: [],
 
         /**
          * Home Assistant requires ALL attributes to be present in ALL MQTT messages send by the device.
@@ -155,6 +156,7 @@ const schema = {
                 elapsed: {type: 'boolean'},
                 availability_timeout: {type: 'number', minimum: 0},
                 availability_blacklist: {type: 'array', items: {type: 'string'}},
+                availability_whitelist: {type: 'array', items: {type: 'string'}},
                 report: {type: 'boolean'},
                 homeassistant_discovery_topic: {type: 'string'},
                 homeassistant_status_topic: {type: 'string'},

--- a/test/deviceAvailability.test.js
+++ b/test/deviceAvailability.test.js
@@ -260,7 +260,6 @@ describe('Device availability', () => {
         expect(device.ping).toHaveBeenCalledTimes(0);
     });    
 
-
     it('Should not read when device has no modelID and reconnects', async () => {
         const device = zigbeeHerdsman.devices.nomodel;
         getExtension().state[device.ieeeAddr] = true;

--- a/test/deviceAvailability.test.js
+++ b/test/deviceAvailability.test.js
@@ -231,6 +231,36 @@ describe('Device availability', () => {
         expect(device.ping).toHaveBeenCalledTimes(1);
     });
 
+    it('Should ping whitelisted devices if availability_whitelist is set', async () => {
+        const device = zigbeeHerdsman.devices.bulb_color;
+        settings.set(['advanced', 'availability_whitelist'], [device.ieeeAddr])
+        await controller.stop();
+        await flushPromises();
+        controller = new Controller();
+        await controller.start();
+        await flushPromises();
+        device.ping.mockClear();
+        jest.advanceTimersByTime(11 * 1000);
+        await flushPromises();
+        expect(device.ping).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should not ping non-whitelisted devices if availability_whitelist is set', async () => {
+        const device = zigbeeHerdsman.devices.bulb;
+        getExtension().state[device.ieeeAddr] = false;
+        settings.set(['advanced', 'availability_whitelist'], [device.ieeeAddr])
+        await controller.stop();
+        await flushPromises();
+        controller = new Controller();
+        await controller.start();
+        await flushPromises();
+        device.ping.mockClear();
+        jest.advanceTimersByTime(11 * 1000);
+        await flushPromises();
+        expect(device.ping).toHaveBeenCalledTimes(0);
+    });    
+
+
     it('Should not read when device has no modelID and reconnects', async () => {
         const device = zigbeeHerdsman.devices.nomodel;
         getExtension().state[device.ieeeAddr] = true;


### PR DESCRIPTION
As requested at https://github.com/Koenkk/zigbee2mqtt/issues/2204

Tested with my environment

With
```
  availability_timeout: 120
  availability_whitelist: ['0x00124b001d3ab1b9','0x001788010278b40a']
```
in configuration.yaml

I get this behaviour as wanted:
```
zigbee2mqtt:debug 2019-11-22 14:08:09: Received Zigbee message from '0x00124b001d3ab1b9', type 'readResponse', cluster 'genBasic', data '{"zclVersion":1}' from endpoint 11 with groupID 0
zigbee2mqtt:debug 2019-11-22 14:08:09: Successfully pinged '0x00124b001d3ab1b9'
...
zigbee2mqtt:info  2019-11-22 14:08:19: MQTT publish: topic 'zigbee/0x001788010278b40a/availability', payload 'offline'
zigbee2mqtt:error 2019-11-22 14:08:19: Failed to ping '0x001788010278b40a'
...
zigbee2mqtt:debug 2019-11-22 14:18:11: Successfully pinged '0x00124b001d3ab1b9'
zigbee2mqtt:debug 2019-11-22 14:18:49: Failed to ping '0x001788010278b40a'
```
Hope I did not break anything else while at it.

Closes #2204 