### PR TITLE
Added support for accepting hex color on deviceName/set/color MQTT topic

### DIFF
--- a/lib/extension/entityPublish.js
+++ b/lib/extension/entityPublish.js
@@ -92,10 +92,6 @@ class EntityPublish extends BaseExtension {
         let json = {};
         if (topic.hasOwnProperty('attribute') && topic.attribute) {
             json[topic.attribute] = message;
-            // If this is the color attribute and it starts with '#', assume it's hex
-            if (topic.attribute == 'color' && message[0] == '#') {
-                json = {color: {hex: message}};
-            }
         } else {
             try {
                 json = JSON.parse(message);

--- a/lib/extension/entityPublish.js
+++ b/lib/extension/entityPublish.js
@@ -92,6 +92,10 @@ class EntityPublish extends BaseExtension {
         let json = {};
         if (topic.hasOwnProperty('attribute') && topic.attribute) {
             json[topic.attribute] = message;
+            // If this is the color attribute and it starts with '#', assume it's hex
+            if (topic.attribute == 'color' && message[0] == '#') {
+                json = {color: {hex: message}};
+            }
         } else {
             try {
                 json = JSON.parse(message);

--- a/test/entityPublish.test.js
+++ b/test/entityPublish.test.js
@@ -458,6 +458,18 @@ describe('Entity publish', () => {
         expect(endpoint.command).toHaveBeenCalledWith("genOnOff", "on", {}, {});
     });
 
+    it('Should parse set with color attribute topic', async () => {
+        const device = zigbeeHerdsman.devices.bulb_color;
+        const endpoint = device.getEndpoint(1);
+        await MQTT.events.message('zigbee2mqtt/bulb_color/set/color', '#64C80A');
+        await flushPromises();
+        expect(endpoint.command).toHaveBeenCalledTimes(1);
+        expect(endpoint.command).toHaveBeenCalledWith("lightingColorCtrl", "moveToColor", {colorx: 17806, colory: 43155, transtime: 0}, {});
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
+        expect(MQTT.publish.mock.calls[0][0]).toStrictEqual('zigbee2mqtt/bulb_color');
+        expect(JSON.parse(MQTT.publish.mock.calls[0][1])).toStrictEqual({color_temp: 156, color: {x: 0.2717, y: 0.6585}});
+    });
+
     it('Should parse set with ieeeAddr topic', async () => {
         const device = zigbeeHerdsman.devices.bulb_color;
         const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Does what it says on the tin: makes it so you can simply write a hex color to friendlyName/set/color and it will convert it for you.

I figured this was needed because:
- /set/color is unusable as-is (the "color" attribute requires a JSON payload, which cannot be parsed through /set/)
- Most MQTT remote control tools (e.g. every single Android app) expects to be able to set color like this

Tested on my own setup, and I can now correctly set the color using most MQTT Android apps. 👍

I'd love to be able to also add a {"hex":"#AABBCC"} attribute to the "color" attribute published over MQTT (so these same apps can correctly read a hex color from the payload), but for the life of me can't figure out where in the source this is being set... 😕
If somebody can point me in the right direction, I'll happily add this as well and either make another pull request or update this one!
