### PR TITLE
Some availability checks improvements

### DIFF
--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -94,9 +94,12 @@ class DeviceAvailability extends BaseExtension {
             clearTimeout(this.timers[device.ieeeAddr]);
         }
 
-        this.timers[device.ieeeAddr] = setTimeout(async () => {
-            await this.handleInterval(device);
-        }, utils.secondsToMilliseconds(this.availability_timeout));
+        const online = this.state.hasOwnProperty(device.ieeeAddr) && this.state[device.ieeeAddr];
+        if (online) {
+            this.timers[device.ieeeAddr] = setTimeout(async () => {
+                await this.handleInterval(device);
+            }, utils.secondsToMilliseconds(this.availability_timeout));
+        }
     }
 
     async stop() {

--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -64,7 +64,7 @@ class DeviceAvailability extends BaseExtension {
         this.zigbee.getClients().forEach((device) => this.publishAvailability(device, true));
 
         // Start timers for all devices
-        this.getAllPingableDevices().forEach((device) => this.setTimer(device));
+        this.getAllPingableDevices().forEach((device) => this.setTimer(device, true));
     }
 
     async handleInterval(device) {
@@ -89,16 +89,18 @@ class DeviceAvailability extends BaseExtension {
         }
     }
 
-    setTimer(device) {
+    setTimer(device, now = false) {
         if (this.timers[device.ieeeAddr]) {
             clearTimeout(this.timers[device.ieeeAddr]);
         }
 
         const online = this.state.hasOwnProperty(device.ieeeAddr) && this.state[device.ieeeAddr];
         if (online) {
+            const timeout = now ? 0 : this.availability_timeout;
+
             this.timers[device.ieeeAddr] = setTimeout(async () => {
                 await this.handleInterval(device);
-            }, utils.secondsToMilliseconds(this.availability_timeout));
+            }, utils.secondsToMilliseconds(timeout));
         }
     }
 

--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -20,6 +20,7 @@ class DeviceAvailability extends BaseExtension {
         super(zigbee, mqtt, state, publishEntityState);
 
         this.availability_timeout = settings.get().advanced.availability_timeout;
+        this.randomize_availability_timeout = settings.get().advanced.randomize_availability_timeout;
         this.timers = {};
         this.state = {};
 
@@ -96,7 +97,7 @@ class DeviceAvailability extends BaseExtension {
 
         const online = this.state.hasOwnProperty(device.ieeeAddr) && this.state[device.ieeeAddr];
         if (online) {
-            const timeout = now ? 0 : this.availability_timeout;
+            const timeout = now ? 0 : (this.availability_timeout + Math.random() * this.randomize_availability_timeout);
 
             this.timers[device.ieeeAddr] = setTimeout(async () => {
                 await this.handleInterval(device);

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -54,6 +54,14 @@ const defaults = {
 
         // Availability timeout in seconds, disabled by default.
         availability_timeout: 0,
+        /**
+         * If randomize_availability_timeout is different from 0, the
+         * availability_timeout value will be added a random number of seconds
+         * between 0 and randomize_availability_timeout. This is useful if
+         * there are many devices to ping and we don't want all of them to be
+         * pinged at the same time. Disabled by default.
+         */
+        randomize_availability_timeout: 0,
         availability_blacklist: [],
         availability_whitelist: [],
 
@@ -163,6 +171,7 @@ const schema = {
                 last_seen: {type: 'string', enum: ['disable', 'ISO_8601', 'ISO_8601_local', 'epoch']},
                 elapsed: {type: 'boolean'},
                 availability_timeout: {type: 'number', minimum: 0},
+                randomize_availability_timeout: {type: 'number', minimum: 0},
                 availability_blacklist: {type: 'array', items: {type: 'string'}},
                 availability_whitelist: {type: 'array', items: {type: 'string'}},
                 report: {type: 'boolean'},


### PR DESCRIPTION
* Do not set a timer to ping currently unavailable devices

  The documentation of availability_timeout says: "When enabled, devices
will be checked if they are still online.", so only online devices should be checked.

  This makes sense since unavailable devices will anyway announce themselves when they are
available again (at least my hue lights and innr plug do that), so it's only neccesary to ping online devices periodically to know when they become unavailable.

  Also, since I have many hue lights and they're usually unavailable (switched off), this reduces the zigbee traffic a lot, allowing other devices to behave better.

* Ping devices inmediately when starting
This improves the experience of using the availability status of devices since otherwise we have to wait for the timeout to happen once before we know which devices are available and which aren't.
With this patch, we know the status right after starting zigbee2mqtt and then the status is updated as usual.

* Add randomize_availability_timeout setting
We currently ping all the devices at the same time either at a start (with `this.getAllPingableDevices().forEach((device) => this.setTimer(device, true));` ) and later every `availability_timeout` seconds since the timer is the same for all devices.

  With this patch, we randomize the timeout every time the timer is set by adding a random number
from 0 to randomize_availability_timeout seconds.

  So for example, if availability_timeout is 60 and randomize_availability_timeout is 10, then each device is pinged every 60 to 70 seconds.

