### PR TITLE
mqtt listener to rename last paired device.

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -185,7 +185,6 @@ class Controller {
         } else if (type === 'deviceJoined') {
             logger.info(`Device '${name}' joined`);
             this.mqtt.log('device_connected', {friendly_name: name});
-            this.state.lastPairedName = name;
         } else if (type === 'deviceInterview') {
             if (data.status === 'successful') {
                 logger.info(`Successfully interviewed '${name}', device has successfully been paired`);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -185,6 +185,7 @@ class Controller {
         } else if (type === 'deviceJoined') {
             logger.info(`Device '${name}' joined`);
             this.mqtt.log('device_connected', {friendly_name: name});
+            this.state.lastPairedName = name;
         } else if (type === 'deviceInterview') {
             if (data.status === 'successful') {
                 logger.info(`Successfully interviewed '${name}', device has successfully been paired`);

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -21,6 +21,7 @@ class BridgeConfig extends BaseExtension {
         this.devices = this.devices.bind(this);
         this.groups = this.groups.bind(this);
         this.rename = this.rename.bind(this);
+        this.renameLast = this.renameLast.bind(this);
         this.remove = this.remove.bind(this);
         this.forceRemove = this.forceRemove.bind(this);
         this.ban = this.ban.bind(this);
@@ -40,6 +41,7 @@ class BridgeConfig extends BaseExtension {
             'groups': this.groups,
             'devices/get': this.devices,
             'rename': this.rename,
+            'rename_last': this.renameLast,
             'remove': this.remove,
             'force_remove': this.forceRemove,
             'ban': this.ban,
@@ -200,6 +202,19 @@ class BridgeConfig extends BaseExtension {
             this.mqtt.log('device_renamed', {from: json.old, to: json.new});
         } catch (error) {
             logger.error(`Failed to rename - ${json.old} to ${json.new}`);
+        }
+    }
+
+    // rename last paired device
+    renameLast(topic, message) {
+        const newName = message;
+        const oldName = this.state.lastPairedName;
+        try {
+            settings.changeFriendlyName(oldName, newName);
+            logger.info(`Successfully renamed - ${oldName} to ${newName} `);
+            this.mqtt.log('device_renamed', {from: oldName, to: newName});
+        } catch (error) {
+            logger.error(`Failed to rename - ${oldName} to ${newName}`);
         }
     }
 

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -28,7 +28,9 @@ class BridgeConfig extends BaseExtension {
         this.deviceOptions = this.deviceOptions.bind(this);
         this.addGroup = this.addGroup.bind(this);
         this.removeGroup = this.removeGroup.bind(this);
-        this.whitelist= this.whitelist.bind(this);
+        this.whitelist = this.whitelist.bind(this);
+
+        this.lastJoinedDeviceName = null;
 
         // Set supported options
         this.supportedOptions = {
@@ -196,25 +198,25 @@ class BridgeConfig extends BaseExtension {
             return;
         }
 
-        try {
-            settings.changeFriendlyName(json.old, json.new);
-            logger.info(`Successfully renamed - ${json.old} to ${json.new} `);
-            this.mqtt.log('device_renamed', {from: json.old, to: json.new});
-        } catch (error) {
-            logger.error(`Failed to rename - ${json.old} to ${json.new}`);
-        }
+        this._renameInternal(json.old, json.new);
     }
 
-    // rename last paired device
     renameLast(topic, message) {
-        const newName = message;
-        const oldName = this.state.lastPairedName;
+        if (!this.lastJoinedDeviceName) {
+            logger.error(`Cannot rename last joined device, no device has joined during this session`);
+            return;
+        }
+
+        this._renameInternal(this.lastJoinedDeviceName, message);
+    }
+
+    _renameInternal(from, to) {
         try {
-            settings.changeFriendlyName(oldName, newName);
-            logger.info(`Successfully renamed - ${oldName} to ${newName} `);
-            this.mqtt.log('device_renamed', {from: oldName, to: newName});
+            settings.changeFriendlyName(from, to);
+            logger.info(`Successfully renamed - ${from} to ${to} `);
+            this.mqtt.log('device_renamed', {from, to});
         } catch (error) {
-            logger.error(`Failed to rename - ${oldName} to ${newName}`);
+            logger.error(`Failed to rename - ${from} to ${to}`);
         }
     }
 
@@ -340,6 +342,12 @@ class BridgeConfig extends BaseExtension {
         };
 
         await this.mqtt.publish(topic, JSON.stringify(payload), {retain: true, qos: 0});
+    }
+
+    onZigbeeEvent(type, data, mappedDevice, settingsDevice) {
+        if (type === 'deviceJoined') {
+            this.lastJoinedDeviceName = settingsDevice.friendlyName;
+        }
     }
 }
 

--- a/test/bridgeConfig.test.js
+++ b/test/bridgeConfig.test.js
@@ -201,6 +201,33 @@ describe('Bridge config', () => {
         expect(settings.getDevice('bulb_color2')).toStrictEqual(bulb_color2);
     });
 
+    it('Should allow to rename last joined device', async () => {
+        const device = zigbeeHerdsman.devices.bulb;
+        const payload = {device};
+        await zigbeeHerdsman.events.deviceJoined(payload);
+        await flushPromises();
+        expect(settings.getDevice('0x000b57fffec6a5b2').friendlyName).toStrictEqual('bulb');
+        MQTT.events.message('zigbee2mqtt/bridge/config/rename_last', 'bulb_new_name');
+        await flushPromises();
+        expect(settings.getDevice('0x000b57fffec6a5b2').friendlyName).toStrictEqual('bulb_new_name');
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'zigbee2mqtt/bridge/log',
+            JSON.stringify({type: 'device_renamed', message: {from: 'bulb', to: 'bulb_new_name'}}),
+            {qos: 0, retain: false},
+            expect.any(Function)
+        );
+    });
+
+    it('Shouldnt rename when no device has been joined', async () => {
+        controller = new Controller();
+        await controller.start();
+        await flushPromises();
+        expect(settings.getDevice('0x000b57fffec6a5b2').friendlyName).toStrictEqual('bulb');
+        MQTT.events.message('zigbee2mqtt/bridge/config/rename_last', 'bulb_new_name');
+        await flushPromises();
+        expect(settings.getDevice('0x000b57fffec6a5b2').friendlyName).toStrictEqual('bulb');
+    });
+
     it('Should allow to add groups', async () => {
         zigbeeHerdsman.createGroup.mockClear();
         MQTT.events.message('zigbee2mqtt/bridge/config/add_group', 'new_group');


### PR DESCRIPTION
Allow to rename last paired device without knowledge of its original name.

Send zigbee2mqtt/bridge/config/rename_last with payload containing new name and last paired device will be renamed.