### PR TITLE
add support for Mueller Licht 44435 Tint LED Stripe

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -635,6 +635,7 @@ const mapping = {
     'AC0251100NJ': [cfg.sensor_action, cfg.sensor_battery],
     '71831': [cfg.light_brightness_colortemp],
     '404000/404005/404012': [cfg.light_brightness_colortemp_colorxy],
+    '44435': [cfg.light_brightness_colortemp_colorxy],
     '404006/404008/404004': [cfg.light_brightness_colortemp],
     'MLI-404011': [cfg.sensor_action],
     'GL-S-003Z': [cfg.light_brightness_colorxy_white],


### PR DESCRIPTION
This adds suport for a pretty generic LED Stripe sold in germany.