### PR TITLE
temp_step attribute for climate entities

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -377,7 +377,7 @@ const cfg = {
     },
 
     // Thermostat/HVAC
-    'thermostat': (minTemp=7, maxTemp=30, temperatureStateProperty='occupied_heating_setpoint') => {
+    'thermostat': (minTemp=7, maxTemp=30, temperatureStateProperty='occupied_heating_setpoint', tempStep=1) => {
         return {
             type: 'climate',
             object_id: 'climate',
@@ -394,6 +394,7 @@ const cfg = {
                 temperature_state_topic: true,
                 temperature_state_template: `{{ value_json.${temperatureStateProperty} }}`,
                 temperature_command_topic: temperatureStateProperty,
+                temp_step: tempStep,
             },
         };
     },
@@ -647,7 +648,7 @@ const mapping = {
     '4090130P7': [cfg.light_brightness_colortemp_colorxy],
     '100.110.39': [cfg.light_brightness_colortemp_colorxy],
     'TI0001': [switchWithPostfix('left'), switchWithPostfix('right')],
-    'SPZB0001': [cfg.thermostat(5, 30, 'current_heating_setpoint'), cfg.sensor_battery],
+    'SPZB0001': [cfg.thermostat(5, 30, 'current_heating_setpoint', 0.5), cfg.sensor_battery],
     'HS3CG': [cfg.binary_sensor_gas],
     '81825': [cfg.sensor_action],
     'Z809AF': [cfg.switch, cfg.sensor_power],


### PR DESCRIPTION
Some thermostats like the Eurotronic Spirit Zigbee are able to handle temperature steps. For example the Eurotronic Spirit Zigbee does 0.5 steps if you click on the hardware buttons. To handle the same behavior in Home Assistant it is necessary to add the temp_step attribute for discovery payload.

Default value is set to 1 (same behavior as before). For Eurotronic Spirit Zigbee the temp step is set to 0.5.
![image](https://user-images.githubusercontent.com/18382402/70759575-26db2100-1d47-11ea-8938-e3a1a15ea9da.png)
