### PR TITLE
fix: avoid creating the log/ directory when file output disabled

### DIFF
--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -32,9 +32,26 @@ const levelWithCompensatedLength = {
 /* istanbul ignore next */
 const timestampFormat = () => moment().format(settings.get().advanced.timestamp_format);
 
-// Create logger
-const transports = {
-    file: new winston.transports.File({
+// Setup default console logger
+const transportsToUse = [
+    new winston.transports.Console({
+        level,
+        silent: !output.includes('console'),
+        format: winston.format.combine(
+            winston.format.timestamp({format: timestampFormat}),
+            winston.format.printf(/* istanbul ignore next */(info) => {
+                const {timestamp, level, message} = info;
+                const prefix = colorizer.colorize(level, `zigbee2mqtt:${levelWithCompensatedLength[level]}`);
+                return `${prefix} ${timestamp.split('.')[0]}: ${message}`;
+            }),
+        ),
+    }),
+];
+
+// Add file logger when enabled
+// NOTE: the initiation of the logger, even when not added as transport tries to create the logging directory
+if (output.includes('file')) {
+    transportsToUse.push(new winston.transports.File({
         filename: path.join(directory, 'log.txt'),
         json: false,
         level,
@@ -47,27 +64,10 @@ const transports = {
                 return `${levelWithCompensatedLength[level]} ${timestamp.split('.')[0]}: ${message}`;
             }),
         ),
-    }),
-    console: new winston.transports.Console({
-        level,
-        silent: !output.includes('console'),
-        format: winston.format.combine(
-            winston.format.timestamp({format: timestampFormat}),
-            winston.format.printf(/* istanbul ignore next */(info) => {
-                const {timestamp, level, message} = info;
-                const prefix = colorizer.colorize(level, `zigbee2mqtt:${levelWithCompensatedLength[level]}`);
-                return `${prefix} ${timestamp.split('.')[0]}: ${message}`;
-            }),
-        ),
-    }),
-};
-
-// Create logger without transports
-const transportsToUse = [transports.console];
-if (output.includes('file')) {
-    transportsToUse.push(transports.file);
+    }));
 }
 
+// Create logger
 const logger = winston.createLogger({transports: transportsToUse});
 
 // Cleanup any old log directory.
@@ -90,10 +90,9 @@ function cleanup() {
 }
 
 logger.cleanup = cleanup;
-logger.getLevel = () => transports.console.level;
+logger.getLevel = () => transportsToUse[0].level;
 logger.setLevel = (level) => {
-    transports.console.level = level;
-    transports.file.level = level;
+    transportsToUse.forEach((transport) => transport.level = level);
 };
 
 // Print to user what logging is enabled


### PR DESCRIPTION
Refactored the code a to just instantiate the logger when configured to use.

On initiation of the file transport it tries to create the configured logging directory, not when adding it to the logger:

```console
fs.js:114
    throw err;
    ^

Error: ENOENT: no such file or directory, mkdir '/data/log/2019-12-13.07-41-50'
    at Object.mkdirSync (fs.js:757:3)
    at File._createLogDirIfNotExist (/zigbee2mqtt/node_modules/winston/lib/winston/transports/file.js:694:10)
    at new File (/zigbee2mqtt/node_modules/winston/lib/winston/transports/file.js:92:28)
    at Object.<anonymous> (/zigbee2mqtt/lib/util/logger.js:37:11)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
```

Now the transport gets created only when configured as output.