### PR TITLE
feat: create environment variable for the config file

### DIFF
--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -1,6 +1,6 @@
 const data = require('./data');
 const utils = require('./utils');
-const file = data.joinPath('configuration.yaml');
+const file = process.env.ZIGBEE2MQTT_CONFIG || data.joinPath('configuration.yaml');
 const objectAssignDeep = require(`object-assign-deep`);
 const path = require('path');
 const yaml = require('./yaml');


### PR DESCRIPTION
Introduces an environment variable for the configuration.yaml location.

Since the devices and groups can be split off this can be used to build the configuration into a Docker image since it doesn't require writing to.

For example:
```yaml
# Home Assistant integration (MQTT discovery)
homeassistant: false

# allow new devices to join
permit_join: true

# MQTT settings
mqtt:
  # MQTT base topic for zigbee2mqtt MQTT messages
  base_topic: zigbee2mqtt
  # MQTT server URL
  server: "mqtt://localhost"
  # MQTT server authentication, uncomment if required:
  # user: my_user
  # password: my_password

# Serial settings
serial:
  # Location of CC2531 USB sniffer
  port: /dev/ttyACM0

# Map devices to persistent /data directory
devices: /data/devices.yaml
groups: /data/groups.yaml

advanced:
  log_output: ["console"]
```

This still persists the devices and groups to a volume but the configuration can be built into the image since it doesn't require changing.

I need this for to be able to use a Kubernetes configmap for the configuration. Kubernetes makes the folder where the configmap is mounted to read-only. In the current scenario this means that the whole /data directory becomes read-only. Zigbee2Mqtt tries to write the state.json to there so that results in an error.
This env var allows the configuration to exists in /config and keep the /data directory writable.
