### PR TITLE
Add GL-S-005Z RGBW GU5.3 (MR16)

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -641,6 +641,7 @@ const mapping = {
     '404006/404008/404004': [cfg.light_brightness_colortemp],
     'MLI-404011': [cfg.sensor_action],
     'GL-S-003Z': [cfg.light_brightness_colorxy_white],
+    'GL-S-005Z': [cfg.light_brightness_colortemp_colorxy],
     'HS1DS-E': [cfg.binary_sensor_contact],
     'SP600': [cfg.switch, cfg.sensor_power],
     '1613V': [cfg.switch, cfg.sensor_power],


### PR DESCRIPTION
Same bulb as GL-S-003Z with identical features, but different socket. 
I'm not sure why the flags differ, but I had to change it. Now I can successfully switch RGB, white-temperature and brightness in Home Assistant.