### PR TITLE
Add device options to onEvent

### DIFF
--- a/lib/extension/deviceEvent.js
+++ b/lib/extension/deviceEvent.js
@@ -1,5 +1,6 @@
 const BaseExtension = require('./baseExtension');
 const zigbeeHerdsmanConverters = require('zigbee-herdsman-converters');
+const settings = require('../util/settings');
 
 class DeviceEvent extends BaseExtension {
     async onZigbeeStarted() {
@@ -10,7 +11,7 @@ class DeviceEvent extends BaseExtension {
 
     onZigbeeEvent(type, data, mappedDevice, settingsDevice) {
         if (data.device) {
-            this.callOnEvent(data.device, type, data, mappedDevice);
+            this.callOnEvent(data.device, type, data, mappedDevice, settingsDevice);
         }
     }
 
@@ -20,13 +21,16 @@ class DeviceEvent extends BaseExtension {
         }
     }
 
-    callOnEvent(device, type, data, mappedDevice) {
+    callOnEvent(device, type, data, mappedDevice, options) {
         if (!mappedDevice) {
             mappedDevice = zigbeeHerdsmanConverters.findByZigbeeModel(device.modelID);
         }
+        if (!options) {
+            options = {...settings.get().device_options, ...settings.getDevice(data.device.ieeeAddr)};
+        }
 
         if (mappedDevice && mappedDevice.onEvent) {
-            mappedDevice.onEvent(type, data, device);
+            mappedDevice.onEvent(type, data, device, options);
         }
     }
 }

--- a/lib/extension/deviceEvent.js
+++ b/lib/extension/deviceEvent.js
@@ -26,7 +26,7 @@ class DeviceEvent extends BaseExtension {
             mappedDevice = zigbeeHerdsmanConverters.findByZigbeeModel(device.modelID);
         }
         if (!options) {
-            options = {...settings.get().device_options, ...settings.getDevice(data.device.ieeeAddr)};
+            options = {...settings.get().device_options, ...settings.getDevice(device.ieeeAddr)};
         }
 
         if (mappedDevice && mappedDevice.onEvent) {


### PR DESCRIPTION
As the title says, it allows to get the device options in the "onEvent" function in converters.

The current use is to fetch the battery state only once every X times for wireless/battery powered devices (see https://github.com/Koenkk/zigbee2mqtt/issues/2399) and allow the modification.
Doing it less than at each deviceAnnounce saves battery.