### PR TITLE
Add support for the EcoSmart D1533 to HA

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -628,6 +628,7 @@ const mapping = {
     'HGZB-20-DE': [cfg.switch],
     'D1531': [cfg.light_brightness],
     'D1532': [cfg.light_brightness],
+    'D1533': [cfg.light_brightness],
     'AV2010/32': [],
     'HGZB-07A': [cfg.light_brightness_colortemp_colorxy],
     'E1524/E1810': [cfg.sensor_action, cfg.sensor_battery],


### PR DESCRIPTION
Adds support for the EcoSmart D1533 to Home Assistant, which is a PAR20 bright white bulb. Supports light on/off, and brightness.

A companion to https://github.com/Koenkk/zigbee-herdsman-converters/pull/830.