### PR TITLE
Add support for Ecosmart-ZBT-A19-CCT-Bulb (A9A19A60WESDZ02) to Home Assistant

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -466,6 +466,7 @@ const mapping = {
     'SWITCH EDP RE:DY': [cfg.switch],
     'CC2530.ROUTER': [cfg.binary_sensor_router],
     'AA70155': [cfg.light_brightness_colortemp],
+    'A9A19A60WESDZ02': [cfg.light_brightness_colortemp],
     '4058075816718': [cfg.light_brightness_colortemp_colorxy],
     'AA69697': [cfg.light_brightness_colortemp_colorxy],
     'HALIGHTDIMWWE27': [cfg.light_brightness],


### PR DESCRIPTION
Adds support for Ecosmart-ZBT-A19-CCT-Bulb (A9A19A60WESDZ02) to Home Assistant

@qosmio 's PR #2562 was closed due to rebase issues.  This is just the changes to add the Ecosmart bulb to homeassistant.js