### PR TITLE
Use correct Home Assistant configuration for GL-S-007Z

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -609,7 +609,7 @@ const mapping = {
     'D1821': [cfg.light_brightness_colortemp_colorxy],
     'ZNCLDJ11LM': [cfg.cover_position, cfg.sensor_cover],
     'LTFY004': [cfg.light_brightness_colorxy],
-    'GL-S-007Z': [cfg.light_brightness_colorxy_white],
+    'GL-S-007Z': [cfg.light_brightness_colortemp_colorxy],
     '3325-S': [cfg.sensor_temperature, cfg.binary_sensor_occupancy],
     '4713407': [cfg.light_brightness],
     '464800': [cfg.light_brightness_colortemp],


### PR DESCRIPTION
This PR changes the Gledopto `GL-S-007Z` to use color temperature instead, as this bulb supports adjusting color temperature and not just brightness.

I think this fixes #2447 (I don't think we shouldn't be using `white_value`, we should instead be using `color_temp` to control the white LEDs).