### PR TITLE
Do not use c.key.includes() for for cases where c.key is a string. 

### DIFF
--- a/lib/extension/entityPublish.js
+++ b/lib/extension/entityPublish.js
@@ -143,7 +143,7 @@ class EntityPublish extends BaseExtension {
                 }
             }
 
-            const converter = converters.find((c) => c.key.includes(key));
+            const converter = converters.find((c) => (typeof c.key === 'string' ? c.key == key : c.key.includes(key)));
 
             if (usedConverters.includes(converter)) {
                 // Use a converter only once (e.g. light_onoff_brightness converters can convert state and brightness)


### PR DESCRIPTION
This PR together with Koenkk/zigbee-herdsman-converters#850 should fix #2359

Will be AFK till next year, so will not be able to follow up on this for a few days.