### PR TITLE
Added support for Stelpro Ki & Stelpro Maestro

### DIFF
--- a/lib/extension/deviceConfigure.js
+++ b/lib/extension/deviceConfigure.js
@@ -13,7 +13,7 @@ class DeviceConfigure extends BaseExtension {
     }
 
     shouldConfigure(device, mappedDevice) {
-        if (!device) {
+        if (!device || !mappedDevice) {
             return false;
         }
 

--- a/lib/extension/deviceConfigure.js
+++ b/lib/extension/deviceConfigure.js
@@ -17,7 +17,7 @@ class DeviceConfigure extends BaseExtension {
             return false;
         }
 
-        if (device.meta.hasOwnProperty('configured') && device.meta.configured === mappedDevice.meta.configureKey) {
+        if (device.meta && device.meta.hasOwnProperty('configured') && device.meta.configured === mappedDevice.meta.configureKey) {
             return false;
         }
 

--- a/lib/extension/deviceConfigure.js
+++ b/lib/extension/deviceConfigure.js
@@ -17,7 +17,9 @@ class DeviceConfigure extends BaseExtension {
             return false;
         }
 
-        if (device.meta && device.meta.hasOwnProperty('configured') && device.meta.configured === mappedDevice.meta.configureKey) {
+        if (device.meta &&
+            device.meta.hasOwnProperty('configured') &&
+            device.meta.configured === mappedDevice.meta.configureKey) {
             return false;
         }
 

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -415,6 +415,7 @@ const cfg = {
                 temperature_state_template: `{{ value_json.${temperatureStateProperty} }}`,
                 temperature_command_topic: temperatureStateProperty,
                 temp_step: tempStep,
+                action_topic: 'operation',
             },
         };
     },

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -418,6 +418,18 @@ const cfg = {
             },
         };
     },
+    'keypad_lockout': {
+        type: 'lock',
+        object_id: 'keypad_lock',
+        discovery_payload: {
+            state_topic: false,
+            command_topic: true,
+            command_topic_postfix: 'keypad_lockout',
+            payload_unlock: '0',
+            payload_lock: '1',
+            value_template: '{{ value_json.keypad_lockout }}',
+        },
+    },
 
     // Fan
     'fan': {
@@ -1075,6 +1087,7 @@ const mapping = {
     '067771': [cfg.switch],
     '064873': [cfg.sensor_action],
     'K3004C': [cfg.switch],
+    'STZB402': [cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5), cfg.sensor_temperature, cfg.keypad_lockout],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -415,7 +415,8 @@ const cfg = {
                 temperature_state_template: `{{ value_json.${temperatureStateProperty} }}`,
                 temperature_command_topic: temperatureStateProperty,
                 temp_step: tempStep,
-                action_topic: 'operation',
+                action_topic: true,
+                action_template: '{{ value_json.operation }}',
             },
         };
     },
@@ -1269,6 +1270,10 @@ class HomeAssistant extends BaseExtension {
 
             if (payload.speed_command_topic) {
                 payload.speed_command_topic = `${stateTopic}/set/fan_mode`;
+            }
+
+            if (payload.action_topic) {
+                payload.action_topic = stateTopic;
             }
 
             // Override configuration with user settings.

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -419,6 +419,15 @@ const cfg = {
             },
         };
     },
+    'thermostat_temperature': {
+        type: 'sensor',
+        object_id: 'temperature',
+        discovery_payload: {
+            unit_of_measurement: '°C',
+            device_class: 'temperature',
+            value_template: '{{ value_json.local_temperature }}',
+        },
+    },
     'keypad_lockout': {
         type: 'lock',
         object_id: 'keypad_lock',
@@ -1088,7 +1097,7 @@ const mapping = {
     '067771': [cfg.switch],
     '064873': [cfg.sensor_action],
     'K3004C': [cfg.switch],
-    'STZB402': [cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5), cfg.sensor_temperature, cfg.keypad_lockout],
+    'STZB402': [cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5), cfg.thermostat_temperature, cfg.keypad_lockout],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1098,6 +1098,7 @@ const mapping = {
     '064873': [cfg.sensor_action],
     'K3004C': [cfg.switch],
     'STZB402': [cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5), cfg.thermostat_temperature, cfg.keypad_lockout],
+    'SMT402': [cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5), cfg.thermostat_temperature, cfg.keypad_lockout],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1097,8 +1097,16 @@ const mapping = {
     '067771': [cfg.switch],
     '064873': [cfg.sensor_action],
     'K3004C': [cfg.switch],
-    'STZB402': [cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5), cfg.thermostat_temperature, cfg.keypad_lockout],
-    'SMT402': [cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5), cfg.thermostat_temperature, cfg.keypad_lockout],
+    'STZB402': [
+        cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5),
+        cfg.thermostat_temperature,
+        cfg.keypad_lockout,
+    ],
+    'SMT402': [
+        cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5),
+        cfg.thermostat_temperature,
+        cfg.keypad_lockout,
+    ],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -423,7 +423,7 @@ const cfg = {
         type: 'lock',
         object_id: 'keypad_lock',
         discovery_payload: {
-            state_topic: false,
+            state_topic: true,
             command_topic: true,
             command_topic_postfix: 'keypad_lockout',
             payload_unlock: '0',

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -154,6 +154,15 @@ const cfg = {
             value_template: '{{ value_json.temperature }}',
         },
     },
+    'sensor_local_temperature': {
+        type: 'sensor',
+        object_id: 'local_temperature',
+        discovery_payload: {
+            unit_of_measurement: '°C',
+            device_class: 'temperature',
+            value_template: '{{ value_json.local_temperature }}',
+        },
+    },
     'sensor_pressure': {
         type: 'sensor',
         object_id: 'pressure',
@@ -395,6 +404,18 @@ const cfg = {
             value_template: '{{ value_json.state }}',
         },
     },
+    'lock_keypad_lockout': {
+        type: 'lock',
+        object_id: 'keypad_lock',
+        discovery_payload: {
+            state_topic: true,
+            command_topic: true,
+            command_topic_postfix: 'keypad_lockout',
+            payload_unlock: '0',
+            payload_lock: '1',
+            value_template: '{{ value_json.keypad_lockout }}',
+        },
+    },
 
     // Thermostat/HVAC
     'thermostat': (minTemp=7, maxTemp=30, temperatureStateProperty='occupied_heating_setpoint', tempStep=1) => {
@@ -419,27 +440,6 @@ const cfg = {
                 action_template: '{{ value_json.operation }}',
             },
         };
-    },
-    'thermostat_temperature': {
-        type: 'sensor',
-        object_id: 'temperature',
-        discovery_payload: {
-            unit_of_measurement: '°C',
-            device_class: 'temperature',
-            value_template: '{{ value_json.local_temperature }}',
-        },
-    },
-    'keypad_lockout': {
-        type: 'lock',
-        object_id: 'keypad_lock',
-        discovery_payload: {
-            state_topic: true,
-            command_topic: true,
-            command_topic_postfix: 'keypad_lockout',
-            payload_unlock: '0',
-            payload_lock: '1',
-            value_template: '{{ value_json.keypad_lockout }}',
-        },
     },
 
     // Fan
@@ -1100,13 +1100,13 @@ const mapping = {
     'K3004C': [cfg.switch],
     'STZB402': [
         cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5),
-        cfg.thermostat_temperature,
-        cfg.keypad_lockout,
+        cfg.sensor_local_temperature,
+        cfg.lock_keypad_lockout,
     ],
     'SMT402': [
         cfg.thermostat(5, 30, 'occupied_heating_setpoint', 0.5),
-        cfg.thermostat_temperature,
-        cfg.keypad_lockout,
+        cfg.sensor_local_temperature,
+        cfg.lock_keypad_lockout,
     ],
 };
 


### PR DESCRIPTION
Support for Stelpro Ki & Stelpro Maestro

* Support thermostat operations
* Support locking of the keypad (discovered as a `lock` by HomeAssistant)
* Operation status
* Display of outdoor temperature

Dependency on this PR: https://github.com/Koenkk/zigbee-herdsman-converters/pull/853 which needs to be completed before completing this one.