### PR TITLE
Added <operation>_failed logging

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -279,6 +279,8 @@ class BridgeConfig extends BaseExtension {
 
         if (!entity) {
             logger.error(`Cannot ${lookup[action][2]}, device '${message}' does not exist`);
+
+            this.mqtt.log(`device_${lookup[action][0]}_failed`, message);
             return;
         }
 
@@ -306,6 +308,8 @@ class BridgeConfig extends BaseExtension {
             logger.error(`Failed to ${lookup[action][2]} ${entity.settings.friendlyName} (${error})`);
             // eslint-disable-next-line
             logger.error(`See https://www.zigbee2mqtt.io/information/mqtt_topics_and_message_structure.html#zigbee2mqttbridgeconfigremove for more info`);
+
+            this.mqtt.log(`device_${lookup[action][0]}_failed`, message);
         }
 
         if (action === 'ban') {

--- a/lib/extension/deviceBind.js
+++ b/lib/extension/deviceBind.js
@@ -63,6 +63,10 @@ class DeviceBind extends BaseExtension {
                         `Failed to ${type} cluster '${cluster}' from '${sourceName}' to ` +
                         `'${targetName}' (${error})`,
                     );
+                    this.mqtt.log(
+                        `device_${type}_failed`,
+                        {from: sourceName, to: targetName, cluster},
+                    );
                 }
             }
         }

--- a/lib/extension/groups.js
+++ b/lib/extension/groups.js
@@ -142,6 +142,9 @@ class Groups extends BaseExtension {
 
             if (!group || group.type !== 'group') {
                 logger.error(`Group '${topicMatch[1]}' does not exist`);
+                this.mqtt.log(
+                    `device_group_${type}_failed`,
+                    {friendly_name: message, group: topicMatch[1], error: 'group doesn\'t exists'});
                 return;
             }
         } else if (topic.match(topicRegexRemoveAll)) {
@@ -153,6 +156,9 @@ class Groups extends BaseExtension {
         const entity = this.zigbee.resolveEntity(message);
         if (!entity || !entity.type === 'device') {
             logger.error(`Device '${message}' does not exist`);
+            this.mqtt.log(
+                `device_group_${type}_failed`,
+                {friendly_name: message, group: topicMatch[1], error: 'entity doesn\'t exists'});
             return;
         }
 

--- a/test/bridgeConfig.test.js
+++ b/test/bridgeConfig.test.js
@@ -368,8 +368,9 @@ describe('Bridge config', () => {
         MQTT.events.message('zigbee2mqtt/bridge/config/remove', 'bulb_color');
         await flushPromises();
         expect(device.removeFromNetwork).toHaveBeenCalledTimes(1);
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(settings.getDevice('bulb_color')).toStrictEqual({"ID": "0x000b57fffec6a5b3", "friendlyName": "bulb_color", "friendly_name": "bulb_color", "retain": false})
-        expect(MQTT.publish).toHaveBeenCalledTimes(0);
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
     });
 
     it('Should handle when ban fails', async () => {
@@ -381,8 +382,9 @@ describe('Bridge config', () => {
         MQTT.events.message('zigbee2mqtt/bridge/config/ban', 'bulb_color');
         await flushPromises();
         expect(device.removeFromNetwork).toHaveBeenCalledTimes(1);
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(settings.getDevice('bulb_color')).toStrictEqual({"ID": "0x000b57fffec6a5b3", "friendlyName": "bulb_color", "friendly_name": "bulb_color", "retain": false})
-        expect(MQTT.publish).toHaveBeenCalledTimes(0);
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
     });
 
     it('Should allow to touchlink factory reset (OK)', async () => {


### PR DESCRIPTION
for external tools (like Zigbee2MqttAssistant), this will allow the tool to know when an operation is failed.
https://github.com/Koenkk/zigbee2mqtt/issues/2223

Added the following:
* `bridge/bind/<device>` & `bridge/unbind/<device>` can now produce the following logs:
  * `device_bind`
  * `device_bind_failed` 🆕
  * `device_unbind`
  * `device_unbind_failed` 🆕
* `bridge/config/remove`, `bridge/config/force_remove` & `bridge/config/ban` can now produce the following logs:
  * `device_remove`
  * `device_remove_failed` 🆕
  * `device_force_remove`
  * `device_force_remove_failed` 🆕
  * `device_ban`
  * `device_ban_failed` 🆕
* `bridge/group/<group>/(remove|add|remove_all)` commands:
  * `device_group_add`
  * `device_group_add_failed` 🆕
  * `device_group_remove`
  * `device_group_remove_failed` 🆕
  * `device_group_remove_all`
  * `device_group_remove_all_failed` 🆕

TODO:
* [x] Update documentation