### PR TITLE
LLKZMK11LM Supports power, temperature and consumption

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -255,6 +255,15 @@ const cfg = {
             icon: 'mdi:view-array',
         },
     },
+    'sensor_consumption': {
+        type: 'sensor',
+        object_id: 'consumption',
+        discovery_payload: {
+            unit_of_measurement: 'kWh',
+            value_template: '{{ value_json.consumption }}',
+            icon: 'mdi:power-plug',
+        },
+    },
     'sensor_sensitivity': {
         type: 'sensor',
         object_id: 'sensitivity',
@@ -763,7 +772,7 @@ const mapping = {
     'BY 285 C': [cfg.light_brightness_colortemp_colorxy],
     'HS1RC-M': [cfg.sensor_action, cfg.sensor_battery],
     'SWO-WDS1PA': [cfg.binary_sensor_contact],
-    'LLKZMK11LM': [switchWithPostfix('l1'), switchWithPostfix('l2'), cfg.sensor_power, cfg.sensor_temperature],
+    'LLKZMK11LM': [switchWithPostfix('l1'), switchWithPostfix('l2'), cfg.sensor_power, cfg.sensor_temperature, cfg.sensor_consumption],
     'LVS-SM10ZW': [cfg.binary_sensor_contact, cfg.binary_sensor_battery_low],
     'HS2SK': [cfg.switch, cfg.sensor_power],
     '45853GE': [cfg.switch, cfg.sensor_power],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -261,7 +261,7 @@ const cfg = {
         discovery_payload: {
             unit_of_measurement: 'kWh',
             value_template: '{{ value_json.consumption }}',
-            icon: 'mdi:power-plug',
+            icon: 'mdi:flash',
         },
     },
     'sensor_sensitivity': {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -763,7 +763,7 @@ const mapping = {
     'BY 285 C': [cfg.light_brightness_colortemp_colorxy],
     'HS1RC-M': [cfg.sensor_action, cfg.sensor_battery],
     'SWO-WDS1PA': [cfg.binary_sensor_contact],
-    'LLKZMK11LM': [switchWithPostfix('l1'), switchWithPostfix('l2')],
+    'LLKZMK11LM': [switchWithPostfix('l1'), switchWithPostfix('l2'), cfg.sensor_power, cfg.sensor_temperature],
     'LVS-SM10ZW': [cfg.binary_sensor_contact, cfg.binary_sensor_battery_low],
     'HS2SK': [cfg.switch, cfg.sensor_power],
     '45853GE': [cfg.switch, cfg.sensor_power],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -772,7 +772,10 @@ const mapping = {
     'BY 285 C': [cfg.light_brightness_colortemp_colorxy],
     'HS1RC-M': [cfg.sensor_action, cfg.sensor_battery],
     'SWO-WDS1PA': [cfg.binary_sensor_contact],
-    'LLKZMK11LM': [switchWithPostfix('l1'), switchWithPostfix('l2'), cfg.sensor_power, cfg.sensor_temperature, cfg.sensor_consumption],
+    'LLKZMK11LM': [
+        switchWithPostfix('l1'), switchWithPostfix('l2'),
+        cfg.sensor_power, cfg.sensor_temperature, cfg.sensor_consumption,
+    ],
     'LVS-SM10ZW': [cfg.binary_sensor_contact, cfg.binary_sensor_battery_low],
     'HS2SK': [cfg.switch, cfg.sensor_power],
     '45853GE': [cfg.switch, cfg.sensor_power],


### PR DESCRIPTION
LLKZMK11LM already sends power, temperature and consumption in mqtt json.

```
info  2020-01-02 20:06:20: MQTT publish: topic 'zigbee2mqtt/front_outdoor_lights', payload '{"state_l1":"ON","linkquality":54,"state_l2":"OFF","power":35.1,"consumption":2.89,"temperature":33}'
```

Not sure in which units `consumption` is. Not adding right now.