### PR TITLE
Update availability_blacklist and availability_whitelist to allow for friendly names

### DIFF
--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -37,13 +37,18 @@ class DeviceAvailability extends BaseExtension {
     }
 
     isAllowed(device) {
+        const ieeeAddr = device.ieeeAddr;
+
+        const deviceSettings = settings.getDevice(ieeeAddr);
+        const name = deviceSettings ? deviceSettings.friendly_name : null;
+
         // Whitelist is not empty and device is in it, enable availability
         if (this.whitelist.length > 0) {
-            return this.whitelist.includes(device.ieeeAddr);
+            return this.whitelist.includes(ieeeAddr) || (name && this.whitelist.includes(name));
         }
 
         // Device is on blacklist, disable availability
-        if (this.blacklist.includes(device.ieeeAddr)) {
+        if (this.blacklist.includes(ieeeAddr) || (name && this.blacklist.includes(name))) {
             return false;
         }
 

--- a/test/deviceAvailability.test.js
+++ b/test/deviceAvailability.test.js
@@ -197,9 +197,23 @@ describe('Device availability', () => {
         expect(MQTT.publish.mock.calls.find((c) => c[0].includes('availability'))).toBeUndefined();
     });
 
-    it('Should not ping blacklisted devices', async () => {
+    it('Should not ping devices blacklisted by friendly name', async () => {
         const device = zigbeeHerdsman.devices.bulb_color;
-        settings.set(['advanced', 'availability_blacklist'], [device.ieeeAddr])
+        settings.set(['advanced', 'availability_blacklist'], ['bulb_color'])
+        await controller.stop();
+        await flushPromises();
+        controller = new Controller();
+        await controller.start();
+        await flushPromises();
+        device.ping.mockClear();
+        jest.advanceTimersByTime(11 * 1000);
+        await flushPromises();
+        expect(device.ping).toHaveBeenCalledTimes(0);
+    });
+
+    it('Should not ping devices blacklisted by IEEE address', async () => {
+        const device = zigbeeHerdsman.devices.bulb_color;
+        settings.set(['advanced', 'availability_blacklist'], [device.ieeeAddr]);
         await controller.stop();
         await flushPromises();
         controller = new Controller();
@@ -224,9 +238,23 @@ describe('Device availability', () => {
         expect(device.ping).toHaveBeenCalledTimes(1);
     });
 
-    it('Should ping whitelisted devices if availability_whitelist is set', async () => {
+    it('Should ping devices whitelisted by friendly name if availability_whitelist is set', async () => {
         const device = zigbeeHerdsman.devices.bulb_color;
-        settings.set(['advanced', 'availability_whitelist'], [device.ieeeAddr])
+        settings.set(['advanced', 'availability_whitelist'], ['bulb_color']);
+        await controller.stop();
+        await flushPromises();
+        controller = new Controller();
+        await controller.start();
+        await flushPromises();
+        device.ping.mockClear();
+        jest.advanceTimersByTime(11 * 1000);
+        await flushPromises();
+        expect(device.ping).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should ping devices whitelisted by IEEE address if availability_whitelist is set', async () => {
+        const device = zigbeeHerdsman.devices.bulb_color;
+        settings.set(['advanced', 'availability_whitelist'], [device.ieeeAddr]);
         await controller.stop();
         await flushPromises();
         controller = new Controller();


### PR DESCRIPTION
The documentation currently suggests that the `availability_blacklist` and `availability_whitelist` arrays should contain device friendly names: https://www.zigbee2mqtt.io/information/configuration.html. However, this doesn't currently work.

This PR allows the configuration to be friendly names and/or IEEE addresses.