### PR TITLE
WIP - Add "components" in devices response

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -4,7 +4,6 @@ const zigbeeHerdsmanConverters = require('zigbee-herdsman-converters');
 const utils = require('../util/utils');
 const assert = require('assert');
 const BaseExtension = require('./baseExtension');
-const hassExtension = require('./homeassistant');
 
 const configRegex =
     new RegExp(`${settings.get().mqtt.base_topic}/bridge/config/((?:\\w+/get)|(?:\\w+/factory_reset)|(?:\\w+))`);
@@ -150,8 +149,6 @@ class BridgeConfig extends BaseExtension {
             if (device.type !== 'Coordinator') {
                 const mappedDevice = zigbeeHerdsmanConverters.findByZigbeeModel(device.modelID);
                 const friendlyDevice = settings.getDevice(device.ieeeAddr);
-                const components = hassExtension.getComponents(device);
-
                 payload.model = mappedDevice ? mappedDevice.model : device.modelID;
                 payload.friendly_name = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
                 payload.manufacturerID = device.manufacturerID;
@@ -162,13 +159,11 @@ class BridgeConfig extends BaseExtension {
                 payload.softwareBuildID = device.softwareBuildID;
                 payload.dateCode = device.dateCode;
                 payload.lastSeen = device.lastSeen;
-                payload.components = components;
             } else {
                 payload.friendly_name = 'Coordinator';
                 payload.softwareBuildID = coordinator.type;
                 payload.dateCode = coordinator.meta.revision.toString();
                 payload.lastSeen = Date.now();
-                payload.components = 'coordinator';
             }
 
             return payload;

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -4,6 +4,7 @@ const zigbeeHerdsmanConverters = require('zigbee-herdsman-converters');
 const utils = require('../util/utils');
 const assert = require('assert');
 const BaseExtension = require('./baseExtension');
+const hassExtension = require('./homeassistant');
 
 const configRegex =
     new RegExp(`${settings.get().mqtt.base_topic}/bridge/config/((?:\\w+/get)|(?:\\w+/factory_reset)|(?:\\w+))`);
@@ -149,6 +150,8 @@ class BridgeConfig extends BaseExtension {
             if (device.type !== 'Coordinator') {
                 const mappedDevice = zigbeeHerdsmanConverters.findByZigbeeModel(device.modelID);
                 const friendlyDevice = settings.getDevice(device.ieeeAddr);
+                const components = hassExtension.getComponents(device);
+
                 payload.model = mappedDevice ? mappedDevice.model : device.modelID;
                 payload.friendly_name = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
                 payload.manufacturerID = device.manufacturerID;
@@ -159,11 +162,13 @@ class BridgeConfig extends BaseExtension {
                 payload.softwareBuildID = device.softwareBuildID;
                 payload.dateCode = device.dateCode;
                 payload.lastSeen = device.lastSeen;
+                payload.components = components;
             } else {
                 payload.friendly_name = 'Coordinator';
                 payload.softwareBuildID = coordinator.type;
                 payload.dateCode = coordinator.meta.revision.toString();
                 payload.lastSeen = Date.now();
+                payload.components = 'coordinator';
             }
 
             return payload;

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1149,8 +1149,28 @@ class HomeAssistant extends BaseExtension {
         }
     }
 
+    static getComponents(entity) {
+        if (!entity) {
+            return [];
+        }
+        const model = entity.modelID;
+        if (!model) {
+            return [];
+        }
+        const mappedModel = mapping[model];
+        if (!mappedModel) {
+            return [];
+        }
+
+        const result = mappedModel.map((config) => {
+            return config.object_id;
+        });
+
+        return result;
+    }
+
     discover(entityID, mappedModel, force=false) {
-        // Check if already discoverd and check if there are configs.
+        // Check if already discovered and check if there are configs.
         const discover = force || !this.discovered[entityID];
         if (!discover) {
             return;

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -4,6 +4,9 @@ const logger = require('../util/logger');
 const zigbee2mqttVersion = require('../../package.json').version;
 const BaseExtension = require('./baseExtension');
 
+const topicRegex =
+    new RegExp(`${settings.get().mqtt.base_topic}/bridge/homeassistant/(\\w+)`);
+
 const cfg = {
     // Binary sensor
     'binary_sensor_occupancy': {
@@ -1135,21 +1138,23 @@ class HomeAssistant extends BaseExtension {
 
         this.discoveryTopic = settings.get().advanced.homeassistant_discovery_topic;
         this.statusTopic = settings.get().advanced.homeassistant_status_topic;
+
+        this.mqttCommands = {
+            'get_components': this.mqttGetComponents.bind(this),
+            'refresh_discovery': this.refreshDiscovery.bind(this),
+        };
     }
 
     async onMQTTConnected() {
         this.mqtt.subscribe(this.statusTopic);
 
         // MQTT discovery of all paired devices on startup.
-        for (const device of this.zigbee.getClients()) {
-            const mappedModel = zigbeeHerdsmanConverters.findByZigbeeModel(device.modelID);
-            if (mappedModel) {
-                this.discover(device.ieeeAddr, mappedModel, true);
-            }
-        }
+        this.refreshDiscovery();
+
+        this.mqtt.subscribe(`${settings.get().mqtt.base_topic}/bridge/homeassistant/+`);
     }
 
-    static getComponents(entity) {
+    getDeviceComponents(entity) {
         if (!entity) {
             return [];
         }
@@ -1326,23 +1331,64 @@ class HomeAssistant extends BaseExtension {
         this.discovered[entityID] = true;
     }
 
-    onMQTTMessage(topic, message) {
-        if (topic !== this.statusTopic) {
+    async onMQTTMessage(topic, message) {
+        if (topic === this.statusTopic) {
+            if (message.toLowerCase() === 'online') {
+                const timer = setTimeout(async () => {
+                    // Publish all device states.
+                    for (const device of this.zigbee.getClients()) {
+                        if (this.state.exists(device.ieeeAddr)) {
+                            this.publishEntityState(device.ieeeAddr, this.state.get(device.ieeeAddr));
+                        }
+                    }
+
+                    clearTimeout(timer);
+                }, 20000);
+            }
+            return true;
+        }
+
+        const match = topic.match(topicRegex);
+        if (!match) {
             return false;
         }
 
-        if (message.toLowerCase() === 'online') {
-            const timer = setTimeout(async () => {
-                // Publish all device states.
-                for (const device of this.zigbee.getClients()) {
-                    if (this.state.exists(device.ieeeAddr)) {
-                        this.publishEntityState(device.ieeeAddr, this.state.get(device.ieeeAddr));
-                    }
-                }
-
-                clearTimeout(timer);
-            }, 20000);
+        const command = match[1];
+        if (!this.mqttCommands.hasOwnProperty(command)) {
+            return false;
         }
+
+        return await this.mqttCommands[command](topic, message);
+    }
+
+    mqttGetComponents() {
+        const devices = this.zigbee.getDevices().map(device => {
+            const deviceFromSettings = settings.getDevice(device.ieeeAddr);
+            const friendlyName = deviceFromSettings ? deviceFromSettings.friendly_name : device.ieeeAddr;
+
+            return {
+                ieeeAddr: device.ieeeAddr,
+                type: device.type,
+                network_address: device.networkAddress,
+                friendly_name: device.type === 'Coordinator' ? 'Coordinator' : friendlyName,
+                components: device.type === 'Coordinator' ? ['Coordinator'] : this.getDeviceComponents(device),
+            };
+        });
+
+        this.mqtt.publish('bridge/homeassistant/components', JSON.stringify(devices), {});
+
+        return true;
+    }
+
+    async refreshDiscovery() {
+        for (const device of this.zigbee.getClients()) {
+            const mappedModel = zigbeeHerdsmanConverters.findByZigbeeModel(device.modelID);
+            if (mappedModel) {
+                this.discover(device.ieeeAddr, mappedModel, true);
+            }
+        }
+
+        return true;
     }
 
     onZigbeeEvent(type, data, mappedDevice, settingsDevice) {


### PR DESCRIPTION
@Koenkk Here's a proposal...

Current Z2MA (my tool) is parsing topics to find supported "components" of each devices.  It would be a lot easier to have something like this PR.

What do you think?