### PR TITLE
Allow attribute and json in parallel

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -281,7 +281,11 @@ class Controller {
         }
 
         if (Object.entries(messagePayload).length) {
-            if (settings.get().experimental.output === 'json') {
+            if (settings.get().experimental.output === 'attribute_and_json') {
+                await this.mqtt.publish(entity.name, JSON.stringify(messagePayload), options);
+                await this.iteratePayloadAttributeOutput(`${entity.name}/`, messagePayload, options);
+            }
+            else if (settings.get().experimental.output === 'json') {
                 await this.mqtt.publish(entity.name, JSON.stringify(messagePayload), options);
             } else {
                 /* istanbul ignore else */

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -284,8 +284,7 @@ class Controller {
             if (settings.get().experimental.output === 'attribute_and_json') {
                 await this.mqtt.publish(entity.name, JSON.stringify(messagePayload), options);
                 await this.iteratePayloadAttributeOutput(`${entity.name}/`, messagePayload, options);
-            }
-            else if (settings.get().experimental.output === 'json') {
+            } else if (settings.get().experimental.output === 'json') {
                 await this.mqtt.publish(entity.name, JSON.stringify(messagePayload), options);
             } else {
                 /* istanbul ignore else */

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -39,7 +39,7 @@ const defaults = {
         },
     },
     experimental: {
-        // json or attribute
+        // json or attribute or attribute_and_json
         output: 'json',
     },
     advanced: {

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -397,6 +397,20 @@ describe('Controller', () => {
         expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb/dummy-2", 'no', {"qos": 0, "retain": true}, expect.any(Function));
     });
 
+    it('Publish entity state attribute_json output', async () => {
+        await controller.start();
+        settings.set(['experimental', 'output'], 'attribute_and_json');
+        MQTT.publish.mockClear();
+        await controller.publishEntityState('bulb', {state: 'ON', brightness: 200, color_temp: 370, linkquality: 99});
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledTimes(5);
+        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb/state", "ON", {"qos": 0, "retain": true}, expect.any(Function));
+        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb/brightness", "200", {"qos": 0, "retain": true}, expect.any(Function));
+        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb/color_temp", "370", {"qos": 0, "retain": true}, expect.any(Function));
+        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb/linkquality", "99", {"qos": 0, "retain": true}, expect.any(Function));
+        expect(MQTT.publish).toHaveBeenCalledWith("zigbee2mqtt/bulb", '{"state":"ON","brightness":200,"color_temp":370,"linkquality":99}', {"qos": 0, "retain": true}, expect.any(Function));
+    });
+
     it('Publish entity state with device information', async () => {
         await controller.start();
         settings.set(['mqtt', 'include_device_information'], true);


### PR DESCRIPTION
Allow output : `attribute_and_json`

If some consumers still need `json` I also want to use the more convenient `attribute` mode.