### PR TITLE
Fixed check if entity is of type "device" in deviceConfigure.js.

### DIFF
--- a/lib/extension/deviceConfigure.js
+++ b/lib/extension/deviceConfigure.js
@@ -44,7 +44,7 @@ class DeviceConfigure extends BaseExtension {
         }
 
         const entity = this.zigbee.resolveEntity(message);
-        if (!entity || !entity.type === 'device') {
+        if (!entity || entity.type !== 'device') {
             logger.error(`Device '${message}' does not exist`);
             return;
         }


### PR DESCRIPTION
The current statement (!entity.type === 'device') will always evaluate to false since it compares a boolean to a string.