### PR TITLE
Added endpoints for Busch-Jaeger

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1017,7 +1017,7 @@ const mapping = {
     'GDKES-01TZXD': [cfg.switch],
     'GDKES-02TZXD': [switchWithPostfix('left'), switchWithPostfix('right')],
     'GDKES-03TZXD': [switchWithPostfix('left'), switchWithPostfix('center'), switchWithPostfix('right')],
-    'RM01': [cfg.switch, cfg.sensor_action],
+    '6735/6736/6737': [cfg.switch, cfg.sensor_action],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1017,6 +1017,7 @@ const mapping = {
     'GDKES-01TZXD': [cfg.switch],
     'GDKES-02TZXD': [switchWithPostfix('left'), switchWithPostfix('right')],
     'GDKES-03TZXD': [switchWithPostfix('left'), switchWithPostfix('center'), switchWithPostfix('right')],
+    'RM01': [cfg.switch, cfg.sensor_action],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -30,7 +30,7 @@ function toLocalISOString(dDate) {
 const postfixes = [
     'left', 'right', 'center', 'bottom_left', 'bottom_right', 'l1', 'l2', 'default',
     'top_left', 'top_right', 'white', 'rgb', 'system', 'top', 'bottom', 'center_left', 'center_right',
-    'ep1', 'ep2', 'row_1', 'row_2', 'row_3', 'row_4', 'light',
+    'ep1', 'ep2', 'row_1', 'row_2', 'row_3', 'row_4', 'relay',
 ];
 
 function flatten(arr) {

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -30,7 +30,7 @@ function toLocalISOString(dDate) {
 const postfixes = [
     'left', 'right', 'center', 'bottom_left', 'bottom_right', 'l1', 'l2', 'default',
     'top_left', 'top_right', 'white', 'rgb', 'system', 'top', 'bottom', 'center_left', 'center_right',
-    'ep1', 'ep2',
+    'ep1', 'ep2', 'row_1', 'row_2', 'row_3', 'row_4', 'light',
 ];
 
 function flatten(arr) {


### PR DESCRIPTION
Related to https://github.com/Koenkk/zigbee-herdsman-converters/pull/879

Adds the new endpoints to the postfix list, so that the symbolic names can be used for bind and unbind.

It also adds RM01 support for Home Assistant. 