### PR TITLE
Feedback requested: add polling for commandOn & commandOff

### DIFF
--- a/lib/extension/deviceReport.js
+++ b/lib/extension/deviceReport.js
@@ -54,6 +54,21 @@ const pollOnMessage = [
         // When the bound devices/members of group have the following manufacturerID
         manufacturerID: ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
     },
+    {
+        // Key is used this.pollDebouncers uniqueness
+        key: 2,
+        // On messages that have the cluster and type of below
+        cluster: {
+            genOnOff: [
+                {type: 'commandOn', data: {}},
+                {type: 'commandOff', data: {}},
+            ],
+        },
+        // Read the following attributes
+        read: {cluster: 'genOnOff', attributes: ['onOff']},
+        // When the bound devices/members of group have the following manufacturerID
+        manufacturerID: ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
+    },
 ];
 
 class DeviceReport extends BaseExtension {

--- a/lib/extension/deviceReport.js
+++ b/lib/extension/deviceReport.js
@@ -55,18 +55,14 @@ const pollOnMessage = [
         manufacturerID: ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
     },
     {
-        // Key is used this.pollDebouncers uniqueness
         key: 2,
-        // On messages that have the cluster and type of below
         cluster: {
             genOnOff: [
                 {type: 'commandOn', data: {}},
                 {type: 'commandOff', data: {}},
             ],
         },
-        // Read the following attributes
         read: {cluster: 'genOnOff', attributes: ['onOff']},
-        // When the bound devices/members of group have the following manufacturerID
         manufacturerID: ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
     },
 ];


### PR DESCRIPTION
As part of the work & experiments I did around https://github.com/Koenkk/zigbee-herdsman-converters/pull/879, I ran into the following problems:

- Binding the getOnOff of the switch to a group enables switching of lights even when zigbee2mqtt is not running.
- Devices that are part of that group which do not support reporting - e.g. lots of older Philips Hue devices - will be controlled properly, however the state update won't get reflected in zigbee2mqtt.

Now, I believe this PR creates more communication overhead than necessary, and I'd be happy to rework it. For example, it could limit the polling to messages that originate from an RM01. Other ideas?



When using groups together with devices that do not support reporting, this is needed
to have the new state reflected.