### PR TITLE
Update TH1123ZB Home Assistant config

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -954,7 +954,12 @@ const mapping = {
     'ZM-CSW002-D': [switchWithPostfix('l1'), switchWithPostfix('l2'), cfg.sensor_power],
     'LVS-SN10ZW': [cfg.sensor_battery, cfg.binary_sensor_occupancy],
     'LVS-ZB15R': [cfg.switch],
-    'TH1123ZB': [cfg.thermostat()],
+    'TH1123ZB': [
+      cfg.thermostat(7, 30, 'occupied_heating_setpoint', 1.0),
+      cfg.sensor_local_temperature,
+      cfg.lock_keypad_lockout,
+      cfg.sensor_power,
+    ],
     'TH1124ZB': [cfg.thermostat()],
     'TH1400ZB': [cfg.thermostat()],
     'TH1500ZB': [cfg.thermostat()],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -955,10 +955,8 @@ const mapping = {
     'LVS-SN10ZW': [cfg.sensor_battery, cfg.binary_sensor_occupancy],
     'LVS-ZB15R': [cfg.switch],
     'TH1123ZB': [
-      cfg.thermostat(7, 30, 'occupied_heating_setpoint', 1.0),
-      cfg.sensor_local_temperature,
-      cfg.lock_keypad_lockout,
-      cfg.sensor_power,
+        cfg.thermostat(7, 30, 'occupied_heating_setpoint', 1.0), cfg.sensor_local_temperature,
+        cfg.lock_keypad_lockout, cfg.sensor_power,
     ],
     'TH1124ZB': [cfg.thermostat()],
     'TH1400ZB': [cfg.thermostat()],


### PR DESCRIPTION
Added config parameters for Sinope TH1123ZB line voltage thermostat:
- Keypad lockout using the code for Stelpro thermostats.
- Power sensor.