### PR TITLE
Add keepalive option for MQTT

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -22,6 +22,11 @@ class MQTT extends events.EventEmitter {
             },
         };
 
+        if (mqttSettings.keepalive) {
+            logger.debug(`Using MQTT keepalive: ${mqttSettings.keepalive}`);
+            options.keepalive = mqttSettings.keepalive;
+        }
+
         if (mqttSettings.ca) {
             logger.debug(`MQTT SSL/TLS: Path to CA certificate = ${mqttSettings.ca}`);
             options.ca = fs.readFileSync(mqttSettings.ca);

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -121,6 +121,7 @@ const schema = {
             properties: {
                 base_topic: {type: 'string'},
                 server: {type: 'string'},
+                keepalive: {type: 'number'},
                 ca: {type: 'string'},
                 key: {type: 'string'},
                 cert: {type: 'string'},

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -57,6 +57,7 @@ describe('Controller', () => {
         const configuration = {
             base_topic: "zigbee2mqtt",
             server: "mqtt://localhost",
+            keepalive: 30,
             ca, cert, key,
             password: 'pass',
             user: 'user1',
@@ -69,6 +70,7 @@ describe('Controller', () => {
         expect(MQTT.connect).toHaveBeenCalledTimes(1);
         const expected = {
             "will": {"payload": "offline", "retain": true, "topic": "zigbee2mqtt/bridge/state"},
+            keepalive: 30,
             ca: Buffer.from([99, 97]),
             key: Buffer.from([107, 101, 121]),
             cert: Buffer.from([99, 101, 114, 116]),


### PR DESCRIPTION
This PR introduced the ability to set a keepalive for MQTT, as documented in https://github.com/mqttjs/MQTT.js#mqttclientstreambuilder-options

If nothing set, by default a keepalive of 60 seconds is used.