### PR TITLE
Added support for Linkind Smart Zigbee LED

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1156,7 +1156,7 @@ const mapping = {
     '9290018215': [cfg.light_brightness],
     '1743230P7': [cfg.light_brightness_colortemp_colorxy],
     '100.110.51': [cfg.light_brightness_colortemp],
-    'ZBT-CCTLight-D0106': [cfg.light_brightness],
+    'ZL1000100-CCT-US-V1A02': [cfg.light_brightness],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1156,6 +1156,7 @@ const mapping = {
     '9290018215': [cfg.light_brightness],
     '1743230P7': [cfg.light_brightness_colortemp_colorxy],
     '100.110.51': [cfg.light_brightness_colortemp],
+    'ZBT-CCTLight-D0106': [cfg.light_brightness],
 };
 
 Object.keys(mapping).forEach((key) => {


### PR DESCRIPTION
Added support for Linkind Smart Zigbee LED bulb
( https://www.linkind.com/product-page/smart-zigbee-led-9w-a19-bulb-dimmable-tunable-hub-required-alexa-control )