### PR TITLE
Added homeassistant mapping for OSRAM A60 DIM Z3

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -605,6 +605,7 @@ const mapping = {
     '72922-A': [cfg.switch],
     'AC03642': [cfg.light_brightness_colortemp],
     'AC08560': [cfg.light_brightness],
+    'AC10786-DIM': [cfg.light_brightness],
     'DNCKATSW002': [switchWithPostfix('left'), switchWithPostfix('right')],
     'DNCKATSW003': [switchWithPostfix('left'), switchWithPostfix('right'), switchWithPostfix('center')],
     'DNCKATSW004': [


### PR DESCRIPTION
See https://github.com/Koenkk/zigbee-herdsman-converters/pull/941 for the corresponding device support in zigbee-herdsman-converters