### PR TITLE
Added log_file name setting

### DIFF
--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -14,6 +14,7 @@ const output = settings.get().advanced.log_output;
 // Directory to log to
 const timestamp = moment(Date.now()).format('YYYY-MM-DD.HH-mm-ss');
 const directory = settings.get().advanced.log_directory.replace('%TIMESTAMP%', timestamp);
+const logFilename = settings.get().advanced.log_file.replace('%TIMESTAMP%', timestamp);
 
 // Make sure that log directoy exsists when not logging to stdout only
 if (output.includes('file')) {
@@ -55,7 +56,7 @@ const transportsToUse = [
 // NOTE: the initiation of the logger, even when not added as transport tries to create the logging directory
 if (output.includes('file')) {
     transportsToUse.push(new winston.transports.File({
-        filename: path.join(directory, 'log.txt'),
+        filename: path.join(directory, logFilename),
         json: false,
         level,
         tailable: true,

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -103,9 +103,9 @@ logger.setLevel = (level) => {
 // Print to user what logging is enabled
 if (output.includes('file')) {
     if (output.includes('console')) {
-        logger.info(`Logging to console and directory: '${directory}'`);
+        logger.info(`Logging to console and directory: '${directory}' filename: ${logFilename}`);
     } else {
-        logger.info(`Logging to directory: '${directory}'`);
+        logger.info(`Logging to directory: '${directory}' filename: ${logFilename}`);
     }
     logger.cleanup();
 } else if (output.includes('console')) {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -45,6 +45,7 @@ const defaults = {
     advanced: {
         log_output: ['console', 'file'],
         log_directory: path.join(data.getPath(), 'log', '%TIMESTAMP%'),
+        log_file: 'log.txt',
         log_level: /* istanbul ignore next */ process.env.DEBUG ? 'debug' : 'info',
         soft_reset_timeout: 0,
         pan_id: 0x1a62,
@@ -158,6 +159,7 @@ const schema = {
                 log_level: {type: 'string', enum: ['info', 'warn', 'error', 'debug']},
                 log_output: {type: 'array', items: {type: 'string'}},
                 log_directory: {type: 'string'},
+                log_file: {type: 'string'},
                 baudrate: {type: 'number'},
                 rtscts: {type: 'boolean'},
                 soft_reset_timeout: {type: 'number', minimum: 0},


### PR DESCRIPTION
Added log_file to schema while preserving the default log.txt setting.
Added option to logger to use the filename and support for the %timestamp% var.

Still needs some testing.
```
  log_level: info
  log_directory: /var/log/
  log_filename: zigbee2mqtt.log # also allowes zigbee2mqtt_%TIMESTAMP%.log
  log_output:
    - console
    - file
```

Ref: https://github.com/Koenkk/zigbee2mqtt/issues/2889