### PR TITLE
Adding availability support to Commercial Electric Downlight

### DIFF
--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -6,9 +6,13 @@ const BaseExtension = require('./baseExtension');
 
 // Some EndDevices should be pinged
 // e.g. E11-G13 https://github.com/Koenkk/zigbee2mqtt/issues/775#issuecomment-453683846
-const forcedPingable = [
-    zigbeeHerdsmanConverters.devices.find((d) => d.model === 'E11-G13'),
+const pingableModels = [
+    'E11-G13',
+    '53170161',
 ];
+
+const forcedPingable =
+    zigbeeHerdsmanConverters.devices.filter((d) => pingableModels.includes(d.model));
 
 const toZigbeeCandidates = ['state', 'brightness', 'color', 'color_temp'];
 


### PR DESCRIPTION
I own several of these [Commercial Electric Downlights](https://www.zigbee2mqtt.io/devices/53170161.html), which work well with zigbee2mqtt.

However, despite being mains-powered, they do not report as such (they return 'Unknown'), and are EndDevices, so they are not periodically pinged for device availability checks. (Totally devastated to find out after all these years that these things aren't routers either 😭)

I tried adding this model to `lib/extension/deviceAvailability.js` in the same way availability support for the [Sengled E11-G13 bulbs was added](https://github.com/Koenkk/zigbee2mqtt/pull/860), tested with all my bulbs, and lo and behold, the availability checks work as desired. The correct availability status now appears in these bulbs' topics, and I'm observing what I'd expect to in the logs.

Accounting for the addition of multiple devices here, I've made it so that the herdsman device list is only iterated over once, [as opposed to duplicating line 10](https://github.com/Koenkk/zigbee2mqtt/pull/2922/files#diff-9ef32f4472df64b8c675c48a2ff96b76L10), which would iterate through that list for each model.

I based my branch off of 1.10, but 2 suites and 4 tests are failing locally before I even add in my changes. Not sure if that's an issue on my end or not. I also noticed that [the test that was submitted with the Sengled PR](https://github.com/Koenkk/zigbee2mqtt/pull/860/files#diff-7e0deefe3e51ee9d22897d223a513b41R38) is no longer there, so I've omitted one for this model, but happy to correct that if you feel I should.