### PR TITLE
GL-C-007S

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -719,6 +719,7 @@ const mapping = {
     'E1524/E1810': [cfg.sensor_action, cfg.sensor_battery],
     'GL-C-006': [cfg.light_brightness_colortemp],
     'GL-C-007': [cfg.light_brightness_colorxy_white],
+    'GL-C-007S': [cfg.light_brightness_colorxy_white],
     'GL-C-007/GL-C-008': [cfg.light_brightness_colortemp_colorxy_white],
     '100.424.11': [cfg.light_brightness_colortemp],
     'AC0251100NJ/AC0251700NJ': [cfg.sensor_action, cfg.sensor_battery],


### PR DESCRIPTION
Gledopto GL-C-007S

Add support for Gledopto GL-C-007S
Zigbee LED controller RGBW plus model