### PR TITLE
Update HA Discovery Info on Rename

### DIFF
--- a/lib/eventBus.js
+++ b/lib/eventBus.js
@@ -3,8 +3,9 @@ const assert = require('assert');
 
 const allowedEvents = [
     'deviceRemoved', // Device has been removed
-    'publishEntityState', // Entity state will be published
     'deviceRenamed', // Device has been renamed
+    'groupRenamed', // Group has been renamed
+    'publishEntityState', // Entity state will be published
 ];
 
 class EventBus extends events.EventEmitter {

--- a/lib/eventBus.js
+++ b/lib/eventBus.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const allowedEvents = [
     'deviceRemoved', // Device has been removed
     'publishEntityState', // Entity state will be published
+    'deviceRenamed', // Device has been renamed
 ];
 
 class EventBus extends events.EventEmitter {

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -218,6 +218,8 @@ class BridgeConfig extends BaseExtension {
             const isGroup = settings.getGroup(from) !== null;
             settings.changeFriendlyName(from, to);
             logger.info(`Successfully renamed - ${from} to ${to} `);
+            const entity = this.zigbee.resolveEntity(to);
+            this.eventBus.emit('deviceRenamed', {device: entity.device});
             this.mqtt.log(`${isGroup ? 'group' : 'device'}_renamed`, {from, to});
         } catch (error) {
             logger.error(`Failed to rename - ${from} to ${to}`);

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -218,8 +218,13 @@ class BridgeConfig extends BaseExtension {
             const isGroup = settings.getGroup(from) !== null;
             settings.changeFriendlyName(from, to);
             logger.info(`Successfully renamed - ${from} to ${to} `);
-            const entity = this.zigbee.resolveEntity(to);
-            this.eventBus.emit('deviceRenamed', {device: entity.device});
+            if (isGroup) {
+                const entity = this.zigbee.resolveEntity(to);
+                this.eventBus.emit('groupRenamed', {group: entity.group});
+            } else {
+                const entity = this.zigbee.resolveEntity(to);
+                this.eventBus.emit('deviceRenamed', {device: entity.device});
+            }
             this.mqtt.log(`${isGroup ? 'group' : 'device'}_renamed`, {from, to});
         } catch (error) {
             logger.error(`Failed to rename - ${from} to ${to}`);

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -219,7 +219,8 @@ class BridgeConfig extends BaseExtension {
             settings.changeFriendlyName(from, to);
             logger.info(`Successfully renamed - ${from} to ${to} `);
             const entity = this.zigbee.resolveEntity(to);
-            this.eventBus.emit(`${isGroup ? 'group' : 'device'}Renamed`, {device: entity.device});
+            const eventData = isGroup ? {group: entity.group} : {device: entity.device};
+            this.eventBus.emit(`${isGroup ? 'group' : 'device'}Renamed`, eventData);
             this.mqtt.log(`${isGroup ? 'group' : 'device'}_renamed`, {from, to});
         } catch (error) {
             logger.error(`Failed to rename - ${from} to ${to}`);

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -218,13 +218,8 @@ class BridgeConfig extends BaseExtension {
             const isGroup = settings.getGroup(from) !== null;
             settings.changeFriendlyName(from, to);
             logger.info(`Successfully renamed - ${from} to ${to} `);
-            if (isGroup) {
-                const entity = this.zigbee.resolveEntity(to);
-                this.eventBus.emit('groupRenamed', {group: entity.group});
-            } else {
-                const entity = this.zigbee.resolveEntity(to);
-                this.eventBus.emit('deviceRenamed', {device: entity.device});
-            }
+            const entity = this.zigbee.resolveEntity(to);
+            this.eventBus.emit(`${isGroup ? 'group' : 'device'}Renamed`, {device: entity.device});
             this.mqtt.log(`${isGroup ? 'group' : 'device'}_renamed`, {from, to});
         } catch (error) {
             logger.error(`Failed to rename - ${from} to ${to}`);

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1305,6 +1305,7 @@ class HomeAssistant extends BaseExtension {
 
         this.eventBus.on('deviceRemoved', (data) => this.onDeviceRemoved(data.device));
         this.eventBus.on('publishEntityState', (data) => this.onPublishEntityState(data));
+        this.eventBus.on('deviceRenamed', (data) => this.onDeviceRenamed(data.device));
     }
 
     onDeviceRemoved(device) {
@@ -1349,6 +1350,12 @@ class HomeAssistant extends BaseExtension {
 
             await this.mqtt.publish(`${data.entity.name}/${key}`, value, {});
         }
+    }
+
+    onDeviceRenamed(device) {
+        const mappedModel = zigbeeHerdsmanConverters.findByZigbeeModel(device.modelID);
+        logger.info(`Refreshing Home Assistant discovery topic for '${device.ieeeAddr}'`);
+        this.discover(device, mappedModel, true);
     }
 
     async onMQTTConnected() {

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -688,6 +688,40 @@ describe('HomeAssistant extension', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
     });
 
+    it('Should refresh discovery when device is renamed', async () => {
+        controller = new Controller(false);
+        await controller.start();
+        await flushPromises();
+        MQTT.publish.mockClear();
+        MQTT.events.message('zigbee2mqtt/bridge/config/rename', '{"old": "weather_sensor", "new": "weather_sensor_renamed"}');
+        await flushPromises();
+
+        const payload = {
+            'unit_of_measurement': '°C',
+            'device_class': 'temperature',
+            'value_template': '{{ value_json.temperature }}',
+            'state_topic': 'zigbee2mqtt/weather_sensor_renamed',
+            'json_attributes_topic': 'zigbee2mqtt/weather_sensor_renamed',
+            'name': 'weather_sensor_renamed_temperature',
+            'unique_id': '0x0017880104e45522_temperature_zigbee2mqtt',
+            'device': {
+                'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
+                'name': 'weather_sensor_renamed',
+                'sw_version': this.version,
+                'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
+                'manufacturer': 'Xiaomi',
+            },
+            'availability_topic': 'zigbee2mqtt/bridge/state',
+        };
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/sensor/0x0017880104e45522/temperature/config',
+            JSON.stringify(payload),
+            { retain: true, qos: 0 },
+            expect.any(Function),
+        );
+    });
+
     it('Should discover update_available sensor when device supports it', async () => {
         controller = new Controller(false);
         await controller.start();


### PR DESCRIPTION
Update HA discovery info when a device is renamed. Adds a new deviceRenamed
event to the event bus, allowing the HA extension to react to the rename

Fixes #2440