### PR TITLE
Added MQTT logging to TouchLink Reset process

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -371,15 +371,15 @@ class BridgeConfig extends BaseExtension {
 
     async touchlinkFactoryReset() {
         logger.info('Starting touchlink factory reset...');
-        this.mqtt.log('touchlink', {status: 'reset_in_progress'});
+        this.mqtt.log('touchlink', 'reset_started', {status: 'in_progress'});
         const result = await this.zigbee.touchlinkFactoryReset();
 
         if (result) {
             logger.info('Successfully factory reset device through Touchlink');
-            this.mqtt.log('touchlink', {status: 'success'});
+            this.mqtt.log('touchlink', 'reset_success', {status: 'success'});
         } else {
             logger.warn('Failed to factory reset device through Touchlink');
-            this.mqtt.log('touchlink', {status: 'failed'});
+            this.mqtt.log('touchlink', 'reset_failed', {status: 'failed'});
         }
     }
 }

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -371,7 +371,7 @@ class BridgeConfig extends BaseExtension {
 
     async touchlinkFactoryReset() {
         logger.info('Starting touchlink factory reset...');
-        this.mqtt.log('touchlink', 'reset_started', {status: 'in_progress'});
+        this.mqtt.log('touchlink', 'reset_started', {status: 'started'});
         const result = await this.zigbee.touchlinkFactoryReset();
 
         if (result) {

--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -371,12 +371,15 @@ class BridgeConfig extends BaseExtension {
 
     async touchlinkFactoryReset() {
         logger.info('Starting touchlink factory reset...');
+        this.mqtt.log('touchlink', {status: 'reset_in_progress'});
         const result = await this.zigbee.touchlinkFactoryReset();
 
         if (result) {
             logger.info('Successfully factory reset device through Touchlink');
+            this.mqtt.log('touchlink', {status: 'success'});
         } else {
             logger.warn('Failed to factory reset device through Touchlink');
+            this.mqtt.log('touchlink', {status: 'failed'});
         }
     }
 }


### PR DESCRIPTION
I added some MQTT logging for the TouchLink reset progress.
It might be helpful in future development of zigbee2mqttAssistant
[https://github.com/yllibed/Zigbee2MqttAssistant/issues/181](https://github.com/yllibed/Zigbee2MqttAssistant/issues/181)

It is done in a similar way as in #2936 

The status can have three different values
`{"type":"touchlink","message":"reset_started","meta":{"status":"in_progress"}}`
`{"type":"touchlink","message":"reset_success","meta":{"status":"success"}}`
`{"type":"touchlink","message":"reset_failed","meta":{"status":"failed"}}`
