### PR TITLE
Add support for expiring retained messages.

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -269,7 +269,7 @@ class Controller {
             retain: utils.getObjectsProperty([entity.settings, deviceOptions], 'retain', false),
             qos: utils.getObjectsProperty([entity.settings, deviceOptions], 'qos', 0),
         };
-        
+
         const retention = utils.getObjectsProperty([entity.settings, deviceOptions], 'retention', false);
         if (retention !== false) {
             options.properties = {messageExpiryInterval: retention};

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -270,6 +270,10 @@ class Controller {
             qos: utils.getObjectsProperty([entity.settings, deviceOptions], 'qos', 0),
         };
 
+        if (entity.settings.hasOwnProperty('retention')) {
+            options.properties = {messageExpiryInterval: entity.settings.retention};
+        }
+
         if (entity.type === 'device' && settings.get().mqtt.include_device_information) {
             const device = this.zigbee.getDeviceByIeeeAddr(entity.device.ieeeAddr);
             const attributes = [

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -269,9 +269,10 @@ class Controller {
             retain: utils.getObjectsProperty([entity.settings, deviceOptions], 'retain', false),
             qos: utils.getObjectsProperty([entity.settings, deviceOptions], 'qos', 0),
         };
-
-        if (entity.settings.hasOwnProperty('retention')) {
-            options.properties = {messageExpiryInterval: entity.settings.retention};
+        
+        const retention = utils.getObjectsProperty([entity.settings, deviceOptions], 'retention', false);
+        if (retention !== false) {
+            options.properties = {messageExpiryInterval: retention};
         }
 
         if (entity.type === 'device' && settings.get().mqtt.include_device_information) {

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -22,6 +22,10 @@ class MQTT extends events.EventEmitter {
             },
         };
 
+        if (mqttSettings.version) {
+            options.protocolVersion = mqttSettings.version;
+        }
+
         if (mqttSettings.keepalive) {
             logger.debug(`Using MQTT keepalive: ${mqttSettings.keepalive}`);
             options.keepalive = mqttSettings.keepalive;

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -138,6 +138,7 @@ const schema = {
                 client_id: {type: 'string'},
                 reject_unauthorized: {type: 'boolean'},
                 include_device_information: {type: 'boolean'},
+                version: {type: 'number'},
             },
             required: ['base_topic', 'server'],
         },
@@ -231,6 +232,7 @@ const schema = {
                     properties: {
                         friendly_name: {type: 'string'},
                         retain: {type: 'boolean'},
+                        retention: {type: 'number'},
                         qos: {type: 'number'},
                         filtered_attributes: {type: 'array', items: {type: 'string'}},
                     },
@@ -311,6 +313,13 @@ function validate() {
     };
     Object.values(_settingsWithDefaults.devices).forEach((d) => check(d.friendly_name));
     Object.values(_settingsWithDefaults.groups).forEach((g) => check(g.friendly_name));
+
+    if (_settingsWithDefaults.mqtt.version != 5) {
+        Object.values(_settingsWithDefaults.devices).forEach(
+            (d) => {
+                if (d.retention) throw new Error('MQTT retention requires protocol version 5');
+            });
+    }
 
     return !valid ? validate.errors.map((v) => `${v.dataPath.substring(1)} ${v.message}`) : null;
 }

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -314,11 +314,12 @@ function validate() {
     Object.values(_settingsWithDefaults.devices).forEach((d) => check(d.friendly_name));
     Object.values(_settingsWithDefaults.groups).forEach((g) => check(g.friendly_name));
 
-    if (_settingsWithDefaults.mqtt.version != 5) {
-        Object.values(_settingsWithDefaults.devices).forEach(
-            (d) => {
-                if (d.retention) throw new Error('MQTT retention requires protocol version 5');
-            });
+    if (_settingsWithDefaults.mqtt.version !== 5) {
+        for (const device of Object.values(_settingsWithDefaults.devices)) {
+            if (device.retention) {
+                throw new Error('MQTT retention requires protocol version 5');
+            }
+        }
     }
 
     return !valid ? validate.errors.map((v) => `${v.dataPath.substring(1)} ${v.message}`) : null;

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -464,6 +464,18 @@ describe('Settings', () => {
         }).toThrow(new Error("Device '0x123' already exists"));
     });
 
+    it('Should not allow retention configuration without MQTT v5', () => {
+        write(configurationFile, {
+            devices: {'0x0017880104e45519': {friendly_name: 'tain', retention: 900}},
+        });
+
+        settings._reRead();
+
+        expect(() => {
+            settings.validate();
+        }).toThrowError('MQTT retention requires protocol version 5');
+    });
+
     it('Should ban devices', () => {
         write(configurationFile, {});
         settings.banDevice('0x123');


### PR DESCRIPTION
For most of my environmental monitoring use cases, I want the readings
retained so I can pick them up from clients at any time, but if the
sensor (or zigbee2mqtt) fails, I want the readings to go away so I can
tell the difference between a stale reading and a missing reading.

This is easily accomplished in MQTTv5 using the "message expiry
interval" property.  To add that to zigbee2mqtt, I added a 'version'
option to the mqtt section so I can specify to connect with version 5
and added a 'retention' property to devices allowing me to specify how
long items should be retained.

e.g.

    mqtt:
      base_topic: site/zigbee2mqtt
      server: 'mqtt://myserver'
      user: zigbee
      version: 5
    serial:
      port: /dev/ttyACM0
    devices:
      '0x00358d00022308da':
        friendly_name: someroom
        retain: true
        retention: 900