### PR TITLE
added reading of device options via mqtt

### DIFF
--- a/lib/extension/bridgeConfig.js
+++ b/lib/extension/bridgeConfig.js
@@ -78,15 +78,20 @@ class BridgeConfig extends BaseExtension {
             return;
         }
 
-        if (!json.hasOwnProperty('friendly_name') || !json.hasOwnProperty('options')) {
-            logger.error('Invalid JSON message, should contain "friendly_name" and "options"');
+       if (!json.hasOwnProperty('friendly_name')) {
+            logger.error('Invalid JSON message, should contain "friendly_name"');
             return;
         }
 
         const entity = settings.getEntity(json.friendly_name);
         assert(entity, `Entity '${json.friendly_name}' does not exist`);
-        settings.changeDeviceOptions(entity.ID, json.options);
-        logger.info(`Changed device specific options of '${json.friendly_name}' (${JSON.stringify(json.options)})`);
+
+        if (!json.hasOwnProperty('options')) {
+            this.mqtt.publish(`bridge/config/device_options/get`, JSON.stringify(settings.getDeviceOptions(entity.ID)));
+        } else {
+            settings.changeDeviceOptions(entity.ID, json.options);
+            logger.info(`Changed device specific options of '${json.friendly_name}' (${JSON.stringify(json.options)})`);
+        }
     }
 
     async permitJoin(topic, message) {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -595,6 +595,15 @@ function changeDeviceOptions(IDorName, newOptions) {
     write();
 }
 
+function getDeviceOptions(IDorName) {
+    const device = getDeviceThrowIfNotExists(IDorName);
+    const settings = get();
+    const currentOptions = settings.devices[device.ID];
+
+    return currentOptions;
+}
+
+
 function changeFriendlyName(IDorName, newName) {
     if (getGroup(newName) || getDevice(newName)) {
         throw new Error(`friendly_name '${newName}' is already in use`);
@@ -629,6 +638,7 @@ module.exports = {
     addDeviceToGroup,
     removeDeviceFromGroup,
     changeDeviceOptions,
+    getDeviceOptions,
     changeFriendlyName,
 
     // For tests only


### PR DESCRIPTION
This adds the possibility to read device options via mqtt.
To read the options of a specific device, a message to 
`zigbee2mqtt/bridge/config/device_options` has to me sent with only the friendly name in the payload:
`{
    payload: {
        friendly_name: "DeviceName"
    }
}`

As a result, an message with all configured options will be sent to
`zigbee2mqtt/bridge/config/device_options/get`