### PR TITLE
update 3323-G cfg.binary_sensor_contact from cfg.binary_sensor_occupancy

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1305,7 +1305,7 @@ const mapping = {
     'LifeControl_Leak_Sensor': [cfg.binary_sensor_water_leak, cfg.sensor_battery],
     'LifeControl_Door_Sensor': [cfg.binary_sensor_contact, cfg.sensor_battery],
     'LifeControl_RGB_Led': [cfg.light_brightness_colortemp_colorxy],
-    '3323-G': [cfg.binary_sensor_occupancy, cfg.sensor_temperature, cfg.binary_sensor_battery_low],
+    '3323-G': [cfg.binary_sensor_contact, cfg.sensor_temperature, cfg.binary_sensor_battery_low],
     'ZL1000400-CCT-EU-2-V1A02': [cfg.light_brightness_colortemp],
     'ROB_200-007-0': [cfg.sensor_action, cfg.sensor_battery],
     'PM-S140-ZB': [cfg.switch],


### PR DESCRIPTION
Hi, I noticed after I switched back from my own fork and added an additional sensor that homeassistant thought it was an occupancy sensor instead of a contact sensor. Thanks!