### PR TITLE
Fix colortemp ability for Paulmann RGBW Light

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -801,7 +801,7 @@ const mapping = {
     '4058075816794': [cfg.light_brightness_colortemp],
     '4052899926158': [cfg.light_brightness],
     '4058075036185': [cfg.light_brightness_colortemp_colorxy],
-    '50049': [cfg.light_brightness_colorxy],
+    '50049': [cfg.light_brightness_colortemp_colorxy],
     '915005733701': [cfg.light_brightness_colortemp_colorxy],
     'RB 285 C': [cfg.light_brightness_colortemp_colorxy],
     '3216331P5': [cfg.light_brightness_colortemp],


### PR DESCRIPTION
In `zigbee-heardsman-converters` it does already support colortemp as shown here:
https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/devices.js#L4813-L4817
