### PR TITLE
Fix conflict between illuminance and illuminance_lux

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -157,7 +157,7 @@ const cfg = {
     },
     'sensor_illuminance_lux': {
         type: 'sensor',
-        object_id: 'illuminance',
+        object_id: 'illuminance_lux',
         discovery_payload: {
             unit_of_measurement: 'lx',
             device_class: 'illuminance',

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -32,6 +32,27 @@ describe('HomeAssistant extension', () => {
         expect(missing).toHaveLength(0);
     });
 
+    it('Should not have duplicate type/object_ids in a mapping', () => {
+        const duplicated = [];
+        const HomeAssistant = require('../lib/extension/homeassistant');
+        const ha = new HomeAssistant(null, null, null, null, {on: () => {}});
+
+        require('zigbee-herdsman-converters').devices.forEach((d) => {
+            const mapping = ha._getMapping()[d.model];
+            const cfg_type_object_ids = [];
+
+            mapping.forEach((c) => {
+                if (cfg_type_object_ids.includes(c['type'] + '/' + c['object_id'])) {
+                    duplicated.push(d.model);
+                } else {
+                    cfg_type_object_ids.push(c['type'] + '/' + c['object_id']);
+                }
+            });
+        });
+
+        expect(duplicated).toHaveLength(0);
+    });
+
     it('Should discover devices', async () => {
         controller = new Controller(false);
         await controller.start();


### PR DESCRIPTION
On certain devices, e.g. GZCGQ01LM, 9290012607, 9290019758, TERNCY-PP01 etc, both
cfg.sensor_illuminance and cfg.sensor_illuminance_lux are applied. As both of these
had the same object_id, only one would show in Home Assistant. Oddly, a mix of both
would apply - e.g. I would get the illuminance value, with the illuminance_lux unit
of 'lx'.

The new test, without the change to add _lux, would produce the following output:

     FAIL  test/homeassistant.test.js (7.952s)
      ● HomeAssistant extension › Should not have duplicate type/object_ids in a mapping

        expect(received).toHaveLength(expected)

        Expected length: 0
        Received length: 4
        Received array:  ["GZCGQ01LM", "9290012607", "9290019758", "TERNCY-PP01"]

          51 |         });
          52 |
        > 53 |         expect(duplicated).toHaveLength(0);
             |                            ^
          54 |     });
          55 |
          56 |     it('Should discover devices', async () => {

          at Object.it (test/homeassistant.test.js:53:28)