### PR TITLE
Action and click trigger for multiple endpoints and 511.344 / ZG2819S support

### DIFF
--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -152,8 +152,7 @@ class DeviceReceive extends BaseExtension {
                      * https://github.com/Koenkk/zigbee2mqtt/issues/959#issuecomment-480341347
                      */
                     Object.keys(payload).forEach((key) => {
-                        if ( ['action', 'click'].includes(key) ||
-                            ( mappedDevice.meta.multiEndpoint && key.match('(action_|click_).*') ) ) {
+                        if (['action', 'click'].includes(key)) {
                             const counterPayload = {};
                             counterPayload[key] = '';
                             this.publishEntityState(data.device.ieeeAddr, counterPayload);

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -152,7 +152,9 @@ class DeviceReceive extends BaseExtension {
                      * https://github.com/Koenkk/zigbee2mqtt/issues/959#issuecomment-480341347
                      */
                     Object.keys(payload).forEach((key) => {
-                        if (['action', 'click'].includes(key)) {
+                        if ( ['action', 'click'].includes(key)
+                             || ( mappedDevice.meta.multiEndpoint && key.match("(action_|click_).*") )
+                           ) {
                             const counterPayload = {};
                             counterPayload[key] = '';
                             this.publishEntityState(data.device.ieeeAddr, counterPayload);

--- a/lib/extension/deviceReceive.js
+++ b/lib/extension/deviceReceive.js
@@ -152,9 +152,8 @@ class DeviceReceive extends BaseExtension {
                      * https://github.com/Koenkk/zigbee2mqtt/issues/959#issuecomment-480341347
                      */
                     Object.keys(payload).forEach((key) => {
-                        if ( ['action', 'click'].includes(key)
-                             || ( mappedDevice.meta.multiEndpoint && key.match("(action_|click_).*") )
-                           ) {
+                        if ( ['action', 'click'].includes(key) ||
+                            ( mappedDevice.meta.multiEndpoint && key.match('(action_|click_).*') ) ) {
                             const counterPayload = {};
                             counterPayload[key] = '';
                             this.publishEntityState(data.device.ieeeAddr, counterPayload);

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -288,6 +288,14 @@ const cfg = {
             value_template: '{{ value_json.action }}',
         },
     },
+    'sensor_action_color': {
+        type: 'sensor',
+        object_id: 'action_color',
+        discovery_payload: {
+            value_template: '{{ value_json.action_color }}',
+            icon: 'mdi:palette',
+        },
+    },
     'sensor_brightness': {
         type: 'sensor',
         object_id: 'brightness',
@@ -370,14 +378,6 @@ const cfg = {
         discovery_payload: {
             value_template: '{{ value_json.strength }}',
             icon: 'mdi:weight',
-        },
-    },
-    'sensor_color': {
-        type: 'sensor',
-        object_id: 'color',
-        discovery_payload: {
-            value_template: '{{ value_json.action_color }}',
-            icon: 'mdi:palette',
         },
     },
 
@@ -1506,7 +1506,7 @@ const mapping = {
     'TH1300ZB': [cfg.thermostat()],
     'SP 220': [cfg.switch],
     '511.040': [cfg.light_brightness_colortemp_colorxy],
-    '511.344': [cfg.sensor_battery, cfg.sensor_linkquality, cfg.sensor_action, cfg.sensor_color],
+    '511.344': [cfg.sensor_battery, cfg.sensor_action, cfg.sensor_action_color],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -548,17 +548,6 @@ const lightWithPostfix = (configType, postfix) => {
     return config;
 };
 
-const sensorActionWithPostfix = (postfix) => {
-    return {
-        type: 'sensor',
-        object_id: `action_${postfix}`,
-        discovery_payload: {
-            icon: 'mdi:gesture-tap',
-            value_template: `{{ value_json.action_${postfix} }}`,
-        },
-    };
-};
-
 const sensorClickWithPostfix = (postfix) => {
     return {
         type: 'sensor',
@@ -1361,9 +1350,12 @@ const mapping = {
     '93999': [cfg.light_brightness],
     '511.344': [
         cfg.sensor_battery, cfg.sensor_linkquality,
-        sensorClickWithPostfix('ep1'), sensorClickWithPostfix('ep2'), sensorClickWithPostfix('ep3'), sensorClickWithPostfix('ep4'),
-        sensorColorWithPostfix('ep1'), sensorColorWithPostfix('ep2'), sensorColorWithPostfix('ep3'), sensorColorWithPostfix('ep4'),
-        sensorColorTempWithPostfix('ep1'), sensorColorTempWithPostfix('ep2'), sensorColorTempWithPostfix('ep3'), sensorColorTempWithPostfix('ep4'),
+        sensorClickWithPostfix('ep1'), sensorClickWithPostfix('ep2'), sensorClickWithPostfix('ep3'),
+        sensorClickWithPostfix('ep4'),
+        sensorColorWithPostfix('ep1'), sensorColorWithPostfix('ep2'), sensorColorWithPostfix('ep3'),
+        sensorColorWithPostfix('ep4'),
+        sensorColorTempWithPostfix('ep1'), sensorColorTempWithPostfix('ep2'), sensorColorTempWithPostfix('ep3'),
+        sensorColorTempWithPostfix('ep4'),
     ],
 };
 

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -548,6 +548,50 @@ const lightWithPostfix = (configType, postfix) => {
     return config;
 };
 
+const sensorActionWithPostfix = (postfix) => {
+    return {
+        type: 'sensor',
+        object_id: `action_${postfix}`,
+        discovery_payload: {
+            icon: 'mdi:gesture-tap',
+            value_template: `{{ value_json.action_${postfix} }}`,
+        },
+    };
+};
+
+const sensorClickWithPostfix = (postfix) => {
+    return {
+        type: 'sensor',
+        object_id: `click_${postfix}`,
+        discovery_payload: {
+            icon: 'mdi:gesture-tap',
+            value_template: `{{ value_json.click_${postfix} }}`,
+        },
+    };
+};
+
+const sensorColorWithPostfix = (postfix) => {
+    return {
+        type: 'sensor',
+        object_id: `color_${postfix}`,
+        discovery_payload: {
+            icon: 'mdi:palette',
+            value_template: `{{ value_json.color_${postfix} }}`,
+        },
+    };
+};
+
+const sensorColorTempWithPostfix = (postfix) => {
+    return {
+        type: 'sensor',
+        object_id: `color_temp_${postfix}`,
+        discovery_payload: {
+            icon: 'hass:thermometer',
+            value_template: `{{ value_json.color_temp_${postfix} }}`,
+        },
+    };
+};
+
 // Map homeassitant configurations to devices.
 const mapping = {
     'WXKG01LM': [cfg.sensor_click, cfg.sensor_battery],
@@ -1315,6 +1359,12 @@ const mapping = {
     'U201SRY2KWZB': [cfg.switch],
     'U202SRY2KWZB': [switchWithPostfix('l1'), switchWithPostfix('l2')],
     '93999': [cfg.light_brightness],
+    '511.344': [
+        cfg.sensor_battery, cfg.sensor_linkquality,
+        sensorClickWithPostfix('ep1'), sensorClickWithPostfix('ep2'), sensorClickWithPostfix('ep3'), sensorClickWithPostfix('ep4'),
+        sensorColorWithPostfix('ep1'), sensorColorWithPostfix('ep2'), sensorColorWithPostfix('ep3'), sensorColorWithPostfix('ep4'),
+        sensorColorTempWithPostfix('ep1'), sensorColorTempWithPostfix('ep2'), sensorColorTempWithPostfix('ep3'), sensorColorTempWithPostfix('ep4'),
+    ],
 };
 
 Object.keys(mapping).forEach((key) => {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -372,6 +372,14 @@ const cfg = {
             icon: 'mdi:weight',
         },
     },
+    'sensor_color': {
+        type: 'sensor',
+        object_id: 'color',
+        discovery_payload: {
+            value_template: '{{ value_json.action_color }}',
+            icon: 'mdi:palette',
+        },
+    },
 
     // Light
     'light_brightness_colorxy_white': {
@@ -676,39 +684,6 @@ const lightWithPostfix = (configType, postfix) => {
     config['discovery_payload']['command_topic_prefix'] = postfix;
     config['discovery_payload']['state_topic_postfix'] = postfix;
     return config;
-};
-
-const sensorClickWithPostfix = (postfix) => {
-    return {
-        type: 'sensor',
-        object_id: `click_${postfix}`,
-        discovery_payload: {
-            icon: 'mdi:gesture-tap',
-            value_template: `{{ value_json.click_${postfix} }}`,
-        },
-    };
-};
-
-const sensorColorWithPostfix = (postfix) => {
-    return {
-        type: 'sensor',
-        object_id: `color_${postfix}`,
-        discovery_payload: {
-            icon: 'mdi:palette',
-            value_template: `{{ value_json.color_${postfix} }}`,
-        },
-    };
-};
-
-const sensorColorTempWithPostfix = (postfix) => {
-    return {
-        type: 'sensor',
-        object_id: `color_temp_${postfix}`,
-        discovery_payload: {
-            icon: 'hass:thermometer',
-            value_template: `{{ value_json.color_temp_${postfix} }}`,
-        },
-    };
 };
 
 // Map homeassitant configurations to devices.
@@ -1531,15 +1506,7 @@ const mapping = {
     'TH1300ZB': [cfg.thermostat()],
     'SP 220': [cfg.switch],
     '511.040': [cfg.light_brightness_colortemp_colorxy],
-    '511.344': [
-        cfg.sensor_battery, cfg.sensor_linkquality,
-        sensorClickWithPostfix('ep1'), sensorClickWithPostfix('ep2'), sensorClickWithPostfix('ep3'),
-        sensorClickWithPostfix('ep4'),
-        sensorColorWithPostfix('ep1'), sensorColorWithPostfix('ep2'), sensorColorWithPostfix('ep3'),
-        sensorColorWithPostfix('ep4'),
-        sensorColorTempWithPostfix('ep1'), sensorColorTempWithPostfix('ep2'), sensorColorTempWithPostfix('ep3'),
-        sensorColorTempWithPostfix('ep4'),
-    ],
+    '511.344': [cfg.sensor_battery, cfg.sensor_linkquality, cfg.sensor_action, cfg.sensor_color],
 };
 
 Object.keys(mapping).forEach((key) => {


### PR DESCRIPTION
Hey,
in addition to https://github.com/Koenkk/zigbee-herdsman-converters/pull/1127 I would like to add home assistant support for the device already mentioned and provide a fix for the action and click trigger to send an empty message for devices with multiple endpoints.

However I'm not quite sure if I fully understood your software architecture.
I you disagree with this idea could you provide an other idea or solution to implement sensors with multiple endpoints please?

Thank you for your work and time.

Regards
Ghostcode