### PR TITLE
Fix missing color temp for ZG2819S/511.344

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -296,6 +296,14 @@ const cfg = {
             icon: 'mdi:palette',
         },
     },
+    'sensor_action_color_temperature': {
+        type: 'sensor',
+        object_id: 'action_color_temperature',
+        discovery_payload: {
+            value_template: '{{ value_json.action_color_temperature }}',
+            icon: 'hass:thermometer',
+        },
+    },
     'sensor_brightness': {
         type: 'sensor',
         object_id: 'brightness',
@@ -1516,7 +1524,7 @@ const mapping = {
     'TH1300ZB': [thermostat()],
     'SP 220': [cfg.switch],
     '511.040': [cfg.light_brightness_colortemp_colorxy],
-    '511.344': [cfg.sensor_battery, cfg.sensor_action, cfg.sensor_action_color],
+    '511.344': [cfg.sensor_battery, cfg.sensor_action, cfg.sensor_action_color, cfg.sensor_action_color_temperature],
     'SMSZB-120': [cfg.binary_sensor_smoke, cfg.sensor_temperature, cfg.sensor_battery],
     'HALIGHTDIMWWE14': [cfg.light_brightness],
     'GreenPower_On_Off_Switch': [cfg.sensor_action],


### PR DESCRIPTION
Added color temperature support for HA integration.
Forgot to re-add it after restructuring the code in the last PR