### PR TITLE
#3352 order state/brightness based on current bulb state

### DIFF
--- a/lib/extension/entityPublish.js
+++ b/lib/extension/entityPublish.js
@@ -113,26 +113,37 @@ class EntityPublish extends Extension {
             }
         }
 
+        const deviceState = this.state.get(entity.settings.ID) || {};
+        const isOn = deviceState && deviceState.state === 'ON' ? true : false;
+
         /**
          * Home Assistant always publishes 'state', even when e.g. only setting
          * the color temperature. This would lead to 2 zigbee publishes, where the first one
          * (state) is probably unecessary.
          */
-        const deviceState = this.state.get(entity.settings.ID) || {};
         if (settings.get().homeassistant) {
             const hasColorTemp = json.hasOwnProperty('color_temp');
             const hasColor = json.hasOwnProperty('color');
             const hasBrightness = json.hasOwnProperty('brightness');
-            const isOn = deviceState && deviceState.state === 'ON' ? true : false;
             if (isOn && (hasColorTemp || hasColor) && !hasBrightness) {
                 delete json.state;
                 logger.debug('Skipping state because of Home Assistant');
             }
         }
 
-        // Ensure that state and brightness are executed before other commands.
+        /**
+         * Order state & brightness based on current bulb state
+         *
+         * Not all bulbs support setting the color/color_temp while it is off
+         * this results in inconsistant behavior between different vendors.
+         *
+         * bulb on => move state & brightness to the back
+         * bulb off => move state & brightness to the front
+         */
         const entries = Object.entries(json);
-        entries.sort((a, b) => (['state', 'brightness', 'brightness_percent'].includes(a[0]) ? -1 : 1));
+        entries.sort((a, b) => (
+            ['state', 'brightness', 'brightness_percent'].includes(a[0]) ? (isOn ? 1 : -1) : (isOn ? -1 : 1)
+        ));
 
         // For each attribute call the corresponding converter
         const usedConverters = [];


### PR DESCRIPTION
As mentioned in PR #3361, we can improve this some more to get more consistent behavior.

I did some tests both trådfri, innr, and hue now work the same and as expected.

I also verified this with some debug prints I removed before creating the PR, first was the original order and then after it was re-ordered.
```
BULB == ON
zigbee2mqtt:error 2020-04-15 17:55:21: state,off,color,#FF0000
zigbee2mqtt:error 2020-04-15 17:55:21: color,#FF0000,state,off
BULB == OFF
zigbee2mqtt:error 2020-04-15 17:55:37: color,#00FF00,state,on
zigbee2mqtt:error 2020-04-15 17:55:37: state,on,color,#00FF00
```