### PR TITLE
Revert "Use CMD alongside ENTRYPOINT in the Dockerfile"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,4 +28,3 @@ ARG COMMIT
 RUN echo "{\"hash\": \"$COMMIT\"}" > .hash.json
 
 ENTRYPOINT ["./run.sh"]
-CMD ["npm", "start"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -13,4 +13,4 @@ if [ ! -f "$DATA/configuration.yaml" ]; then
     cp /app/configuration.yaml "$DATA/configuration.yaml"
 fi
 
-exec "$@"
+exec npm start


### PR DESCRIPTION
Reverts Koenkk/zigbee2mqtt#3366 because of regression: https://github.com/Koenkk/zigbee2mqtt/issues/3367