### PR TITLE
Update Invalid rename message format expected to be proper json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}

--- a/lib/extension/legacy/bridgeLegacy.js
+++ b/lib/extension/legacy/bridgeLegacy.js
@@ -192,7 +192,7 @@ class BridgeLegacy extends Extension {
     }
 
     rename(topic, message) {
-        const invalid = `Invalid rename message format expected {old: 'friendly_name', new: 'new_name} got ${message}`;
+        const invalid = `Invalid rename message format expected {"old": "friendly_name", "new": "new_name"} got ${message}`;
 
         let json = null;
         try {

--- a/lib/extension/legacy/bridgeLegacy.js
+++ b/lib/extension/legacy/bridgeLegacy.js
@@ -192,7 +192,8 @@ class BridgeLegacy extends Extension {
     }
 
     rename(topic, message) {
-        const invalid = `Invalid rename message format expected {"old": "friendly_name", "new": "new_name"} got ${message}`;
+        const invalid =
+            `Invalid rename message format expected {"old": "friendly_name", "new": "new_name"} got ${message}`;
 
         let json = null;
         try {


### PR DESCRIPTION
The example in the 'Invalid rename message format expected' error message, was not proper JSON and missing the last string end.

I hope this change only helps new users like myself.