### PR TITLE
Don't try and load non .js extensions

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -74,7 +74,7 @@ class Controller {
 
         const extensionPath = data.joinPath('extension');
         if (fs.existsSync(extensionPath)) {
-            const extensions = fs.readdirSync(extensionPath).filter(f => f.endsWith('.js'));
+            const extensions = fs.readdirSync(extensionPath).filter((f) => f.endsWith('.js'));
             for (const extension of extensions) {
                 const Extension = require(path.join(extensionPath, extension.split('.')[0]));
                 this.extensions.push(new Extension(...args, logger));

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -74,7 +74,7 @@ class Controller {
 
         const extensionPath = data.joinPath('extension');
         if (fs.existsSync(extensionPath)) {
-            const extensions = fs.readdirSync(extensionPath);
+            const extensions = fs.readdirSync(extensionPath).filter(f => f.endsWith('.js'));
             for (const extension of extensions) {
                 const Extension = require(path.join(extensionPath, extension.split('.')[0]));
                 this.extensions.push(new Extension(...args, logger));


### PR DESCRIPTION
After this change we can now simple rename the `myext.js` to `myext.js.disabled` or something not ending in `.js` to stop loading it.

This also prevents having the file open in vim (creates a myext.js.swp) from crashing z2m on restart.