### PR TITLE
Support Linkind PIR motion in HA

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1564,7 +1564,7 @@ const mapping = {
     'AU-A1ZBPIRS': [cfg.binary_sensor_occupancy, cfg.binary_sensor_battery_low],
     'TS0121': [cfg.switch],
     'ZK03840': [thermostat()],
-    'ZS1100400-IN-V1A02': [cfg.binary_sensor_occupancy],
+    'ZS1100400-IN-V1A02': [cfg.binary_sensor_occupancy, cfg.binary_sensor_battery_low],
 };
 
 /**

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1564,6 +1564,7 @@ const mapping = {
     'AU-A1ZBPIRS': [cfg.binary_sensor_occupancy, cfg.binary_sensor_battery_low],
     'TS0121': [cfg.switch],
     'ZK03840': [thermostat()],
+    'ZS1100400-IN-V1A02': [cfg.binary_sensor_occupancy],
 };
 
 /**


### PR DESCRIPTION
This marks the Linkind PIR motion sensor as having
binary_sensor_occupancy with HomeAssistant.

The sensor likely has additional capabilities like battery reporting but
I don't know how to make sense of the rest of its information yet.