### PR TITLE
added new device and added new cfg light_switch

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -456,6 +456,15 @@ const cfg = {
             command_topic: true,
         },
     },
+    'light_switch': {
+        type: 'light',
+        object_id: 'light',
+        discovery_payload: {
+            brightness: false,
+            schema: 'json',
+            command_topic: true,
+        },
+    },
 
     // Switch
     'switch': {
@@ -1508,6 +1517,7 @@ const mapping = {
     '511.040': [cfg.light_brightness_colortemp_colorxy],
     '511.344': [cfg.sensor_battery, cfg.sensor_action, cfg.sensor_action_color],
     'SMSZB-120': [cfg.binary_sensor_smoke, cfg.sensor_temperature, cfg.sensor_battery],
+	'DTB-ED2004-012': [cfg.light_switch],
 };
 
 Object.keys(mapping).forEach((key) => {


### PR DESCRIPTION
Hi

i would like to add HA support for my new Device DTB-ED2004-012
Since this device does only contains a switch and does usually switch a lamp, i decided to add a new configuration to homeassistant.js

```
    'light_switch': {
        type: 'light',
        object_id: 'light',
        discovery_payload: {
            brightness: false,
            schema: 'json',
            command_topic: true,
        },
    },
```

Unfortunately, there was no "switch only" lamp actually. 

Thanks for your great project.
Regards
Claudio