### PR TITLE
Added new device DTB-ED2004-012 and added new cfg light_switch

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1592,7 +1592,7 @@ const mapping = {
     'DTB-ED2004-012': [cfg.switch],
     'MCLH-08': [cfg.sensor_temperature, cfg.sensor_humidity, cfg.sensor_eco2, cfg.sensor_voc],
     'GL-FL-005TZ': [cfg.light_brightness_colortemp_colorxy],
-    'ED2004-012': [],
+    'ED2004-012': [cfg.switch],
     'ZG192910-4': [cfg.light_brightness_colortemp],
     'SLT2': [],
     'ZL1000700-22-EU-V1A02': [cfg.light_brightness],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1589,7 +1589,6 @@ const mapping = {
     'TS0121': [cfg.switch],
     'ZK03840': [thermostat()],
     'ZS1100400-IN-V1A02': [cfg.binary_sensor_occupancy, cfg.binary_sensor_battery_low],
-    'DTB-ED2004-012': [cfg.switch],
     'MCLH-08': [cfg.sensor_temperature, cfg.sensor_humidity, cfg.sensor_eco2, cfg.sensor_voc],
     'GL-FL-005TZ': [cfg.light_brightness_colortemp_colorxy],
     'ED2004-012': [cfg.switch],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -464,6 +464,15 @@ const cfg = {
             command_topic: true,
         },
     },
+    'light_switch': {
+        type: 'light',
+        object_id: 'light',
+        discovery_payload: {
+            brightness: false,
+            schema: 'json',
+            command_topic: true,
+        },
+    },
 
     // Switch
     'switch': {
@@ -1566,6 +1575,7 @@ const mapping = {
     'TS0121': [cfg.switch],
     'ZK03840': [thermostat()],
     'ZS1100400-IN-V1A02': [cfg.binary_sensor_occupancy, cfg.binary_sensor_battery_low],
+    'DTB-ED2004-012': [cfg.light_switch],
 };
 
 /**

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -456,6 +456,15 @@ const cfg = {
             command_topic: true,
         },
     },
+    'light_switch': {
+        type: 'light',
+        object_id: 'light',
+        discovery_payload: {
+            brightness: false,
+            schema: 'json',
+            command_topic: true,
+        },
+    },
 
     // Switch
     'switch': {
@@ -1508,6 +1517,7 @@ const mapping = {
     '511.040': [cfg.light_brightness_colortemp_colorxy],
     '511.344': [cfg.sensor_battery, cfg.sensor_action, cfg.sensor_action_color],
     'SMSZB-120': [cfg.binary_sensor_smoke, cfg.sensor_temperature, cfg.sensor_battery],
+	'DTB-ED2004-012': [cfg.light_switch],
 };
 
 Object.keys(mapping).forEach((key) => {


### PR DESCRIPTION
Hi

i would like to add HA support for my new Device DTB-ED2004-012
Since this device does only contains a switch and does usually switch a lamp, i decided to add a new configuration to homeassistant.js

```
    'light_switch': {
        type: 'light',
        object_id: 'light',
        discovery_payload: {
            brightness: false,
            schema: 'json',
            command_topic: true,
        },
    },
```

Unfortunately, there was no "switch only" lamp actually. 

Thanks for your great project.
Regards
Claudio