### PR TITLE
Add support to home assistant for ZL1000700-22-EU-V1A02

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1376,7 +1376,6 @@ const mapping = {
     '1743130P7': [cfg.light_brightness_colortemp_colorxy],
     '100.110.51': [cfg.light_brightness_colortemp],
     'ZL1000100-CCT-US-V1A02': [cfg.light_brightness],
-    'ZL1000700-22-EU-V1A02': [cfg.light_brightness],
     'ZL1000701-27-EU-V1A02': [cfg.light_brightness],
     'HGZB-DLC4-N12B': [cfg.light_brightness_colortemp_colorxy],
     'U86KCJ-ZP': [cfg.sensor_action],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1376,6 +1376,8 @@ const mapping = {
     '1743130P7': [cfg.light_brightness_colortemp_colorxy],
     '100.110.51': [cfg.light_brightness_colortemp],
     'ZL1000100-CCT-US-V1A02': [cfg.light_brightness],
+    'ZL1000700-22-EU-V1A02': [cfg.light_brightness],
+    'ZL1000701-27-EU-V1A02': [cfg.light_brightness],
     'HGZB-DLC4-N12B': [cfg.light_brightness_colortemp_colorxy],
     'U86KCJ-ZP': [cfg.sensor_action],
     'HS1HT': [cfg.sensor_temperature, cfg.sensor_humidity, cfg.sensor_battery],


### PR DESCRIPTION
Add support for Linkind bulb ZL1000700-22-EU-V1A02 

Device added to the converters in: https://github.com/Koenkk/zigbee-herdsman-converters/pull/1198.

Device: ZL1000701-27-EU-V1A02 was already present in the converters but not in the home assistant, so I added it. 