### PR TITLE
Add temp and consumption to ZNCZ02LM

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -730,7 +730,7 @@ const mapping = {
     'MCCGQ11LM': [cfg.binary_sensor_contact, cfg.sensor_battery],
     'SJCGQ11LM': [cfg.binary_sensor_water_leak, cfg.sensor_battery],
     'MFKZQ01LM': [cfg.sensor_action, cfg.sensor_battery],
-    'ZNCZ02LM': [cfg.switch, cfg.sensor_power],
+    'ZNCZ02LM': [cfg.switch, cfg.sensor_power, cfg.sensor_temperature, cfg.sensor_consumption],
     'QBCZ11LM': [cfg.switch, cfg.sensor_power],
     'LED1545G12': [cfg.light_brightness_colortemp],
     'LED1623G12': [cfg.light_brightness],


### PR DESCRIPTION
ZNCZ02LM supports temperature and consumption data but this wasn't showing up in home assistant. Looks like the device may have just been added before temp and consumption data was. 

I assume the other regional variants of this plug also have this information (ZNCZ03LM, ZNCZ04LM, ZNCZ12LM and SP-EUC01). However I don't own any of the other variants so I can't confirm. Let me know if you want to amend the PR to make changes to them.

I will create a PR for the docs too.