### PR TITLE
Fix Home Assistant discovery for GL-FL-004TZS

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -982,6 +982,7 @@ const mapping = {
     'HGZB-042': [switchEndpoint('top'), switchEndpoint('bottom')],
     'HGZB-42': [switchEndpoint('top'), switchEndpoint('bottom')],
     'GL-FL-004TZ': [cfg.light_brightness_colortemp_colorxy],
+    'GL-FL-004TZS': [cfg.light_brightness_colortemp_colorxy],
     'IM6001-OTP05': [cfg.switch],
     'SV01': [
         cfg.cover_position, cfg.sensor_temperature, cfg.sensor_pressure,


### PR DESCRIPTION
Depending on how Koenkk/zigbee-herdsman-converters#1208, I think this change might or might not be needed.

Also see Koenkk/zigbee2mqtt#3480