### PR TITLE
Add energy sensor for Salus SP600

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -950,7 +950,7 @@ const mapping = {
     'GL-S-003Z': [cfg.light_brightness_colorxy_white],
     'GL-S-005Z': [cfg.light_brightness_colortemp_colorxy],
     'HS1DS-E': [cfg.binary_sensor_contact],
-    'SP600': [cfg.switch, cfg.sensor_power],
+    'SP600': [cfg.switch, cfg.sensor_power, cfg.sensor_energy],
     '1613V': [cfg.switch, cfg.sensor_power],
     'XVV-Mega23M12': [cfg.light_brightness_colortemp],
     'GL-B-007Z': [cfg.light_brightness_colortemp_colorxy],


### PR DESCRIPTION
The Salus SP600 has a `Simple Metering` cluster with the `Current Summation Delivered` [attribute available](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/converters/fromZigbee.js#L1338-L1342). This can be used in Home Assistant to display an energy sensor.

Tested with new device.