### PR TITLE
Make thermostat more like thermostatHeatCool

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1245,7 +1245,7 @@ const mapping = {
     'TH1124ZB': [thermostat()],
     'TH1400ZB': [thermostat()],
     'TH1500ZB': [thermostat()],
-    'Zen-01-W': [thermostat()],
+    'Zen-01-W': [thermostat(10, 30, 'occupied_heating_setpoint', 0.5)],
     '9290022166': [cfg.light_brightness_colortemp_colorxy],
     'PM-C140-ZB': [cfg.sensor_power, cfg.switch],
     'PM-B530-ZB': [cfg.sensor_power, cfg.switch],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -696,7 +696,9 @@ const thermostat = (minTemp=7, maxTemp=30, temperatureStateProperty='occupied_he
             temperature_command_topic: temperatureStateProperty,
             temp_step: tempStep,
             action_topic: true,
-            action_template: '{{ value_json.operation }}',
+            action_template:
+                '{% set values = {\'idle\':\'off\',\'heat\':\'heating\',\'cool\':\'cooling\',\'fan only\':\'fan\'}'+
+                ' %}{{ values[value_json.running_state] }}',
         },
     };
 };


### PR DESCRIPTION
This change tries to unify the two thermostat templates a little.
I'm making this change because I wanted to enable tracking the current
state of the Zen thermostat and noticed that the logic was very specific
to a subset of thermostats.

The matching change in zigbee-herdsman-converters ensures that the
thermostats that were sending the "operation" field use the new format
and should effectively behave the same after the change.