### PR TITLE
Support E1E-G7F

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1661,6 +1661,7 @@ const mapping = {
     'LH-990ZB': [cfg.binary_sensor_occupancy, cfg.binary_sensor_battery_low],
     'HO-09ZB': [cfg.binary_sensor_contact, cfg.binary_sensor_battery_low],
     '500.67': [cfg.sensor_action],
+    'E1E-G7F': [cfg.sensor_action],
 };
 
 /**


### PR DESCRIPTION
I couldn't see battery data in the output so I have only added the sensor_action type. This works and home assistant can see button presses + link quality.

This is linked to: https://github.com/Koenkk/zigbee-herdsman-converters/pull/1265