### PR TITLE
Remove precision rounding from HA MQTT autodiscovery template

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1893,15 +1893,6 @@ class HomeAssistant extends Extension {
                 payload.availability_topic = `${settings.get().mqtt.base_topic}/bridge/state`;
             }
 
-            // Add precision to value_template
-            if (deviceSettings.hasOwnProperty(`${config.object_id}_precision`)) {
-                const precision = deviceSettings[`${config.object_id}_precision`];
-                let template = payload.value_template;
-                template = template.replace('{{ ', '').replace(' }}', '');
-                template = `{{ (${template} | float) | round(${precision}) }}`;
-                payload.value_template = template;
-            }
-
             if (payload.command_topic) {
                 payload.command_topic = `${settings.get().mqtt.base_topic}/${friendlyName}/`;
 

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -204,7 +204,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': "{{ (value_json.temperature | float) | round(1) }}",
+            'value_template': "{{ value_json.temperature }}",
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
@@ -229,7 +229,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '%',
             'device_class': 'humidity',
-            'value_template': '{{ (value_json.humidity | float) | round(0) }}',
+            'value_template': '{{ value_json.humidity }}',
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_humidity',
@@ -254,7 +254,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': 'hPa',
             'device_class': 'pressure',
-            'value_template': '{{ (value_json.pressure | float) | round(2) }}',
+            'value_template': '{{ value_json.pressure }}',
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_pressure',


### PR DESCRIPTION
Precision rounding should be handled in converters and made available to all MQTT consumers (not just HA) as discussed in #3620