### PR TITLE
Add EchoStar SAGE by Hughes Doorbell Sensor (SAGE206612)

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1678,6 +1678,7 @@ const mapping = {
     '4058075816459': [cfg.sensor_action],
     '14592.0': [cfg.switch],
     '73699': [cfg.light_brightness_colorxy],
+    'SAGE206612': [cfg.sensor_action, cfg.sensor_battery],
 };
 
 /**


### PR DESCRIPTION
Added support for EchoStar SAGE by Hughes Doorbell Sensor (SAGE206612) device
See https://github.com/Koenkk/zigbee-herdsman-converters/pull/1284