### PR TITLE
Removing illuminance from Hive MOT003

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1592,10 +1592,7 @@ const mapping = {
     '511.040': [cfg.light_brightness_colortemp_colorxy],
     '511.344': [cfg.sensor_battery, cfg.sensor_action, cfg.sensor_action_color, cfg.sensor_action_color_temperature],
     'SMSZB-120': [cfg.binary_sensor_smoke, cfg.sensor_temperature, cfg.sensor_battery],
-    'MOT003': [
-        cfg.sensor_temperature, cfg.binary_sensor_occupancy, cfg.sensor_illuminance,
-        cfg.sensor_illuminance_lux, cfg.binary_sensor_battery_low, cfg.sensor_battery,
-    ],
+    'MOT003': [cfg.binary_sensor_occupancy, cfg.sensor_temperature, cfg.sensor_battery, cfg.binary_sensor_battery_low],
     'HALIGHTDIMWWE14': [cfg.light_brightness],
     'GreenPower_On_Off_Switch': [cfg.sensor_action],
     'GreenPower_7': [cfg.sensor_action],


### PR DESCRIPTION
This is a part of the fix for Koenkk/zigbee-herdsman-converters#1288