### PR TITLE
Debounce fix (Symfonisk remote)

### DIFF
--- a/lib/extension/receive.js
+++ b/lib/extension/receive.js
@@ -42,13 +42,13 @@ class Receive extends Extension {
         }
 
         if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, debounceIgnore)) {
-            if (immediate) {
-                // clear previous payload immediately to avoid duplicate
-                this.debouncers[ieeeAddr].publish.clear();
-            } else {
+            // if (immediate) {
+            //     // clear previous payload immediately to avoid duplicate
+            //     this.debouncers[ieeeAddr].publish.clear();
+            // } else {
                 // publish previous payload immediately
                 this.debouncers[ieeeAddr].publish.flush();
-            }
+            //}
         }
 
         // extend debounced payload with current

--- a/lib/extension/receive.js
+++ b/lib/extension/receive.js
@@ -15,26 +15,20 @@ class Receive extends Extension {
         this.coordinator = this.zigbee.getDevicesByType('Coordinator')[0];
     }
 
-    publishDebounce(ieeeAddr, payload, time, debounceIgnore, immediate) {
+    publishDebounce(ieeeAddr, payload, time, debounceIgnore) {
         if (!this.debouncers[ieeeAddr]) {
             this.debouncers[ieeeAddr] = {
                 payload: {},
                 publish: debounce(() => {
                     this.publishEntityState(ieeeAddr, this.debouncers[ieeeAddr].payload);
                     this.debouncers[ieeeAddr].payload = {};
-                }, time * 1000, immediate),
+                }, time * 1000),
             };
         }
 
         if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, debounceIgnore)) {
-            if (immediate) {
-                // clear previous payload immediately to avoid duplicate
-                this.debouncers[ieeeAddr].publish.clear();
-            }
-            else {
-                // publish previous payload immediately
-                this.debouncers[ieeeAddr].publish.flush();
-            }
+            // publish previous payload immediately
+            this.debouncers[ieeeAddr].publish.flush();
         }
 
         // extend debounced payload with current
@@ -123,8 +117,7 @@ class Receive extends Extension {
 
         const debounce = resolvedEntity.settings.debounce || settings.get().device_options.debounce;
         const debounceIgnore = resolvedEntity.settings.debounce_ignore || settings.get().device_options.debounce_ignore;
-        const debounceImmediate = resolvedEntity.settings.debounce_immediate || false;
-        
+
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
         // - If a payload is returned publish it to the MQTT broker
@@ -147,7 +140,7 @@ class Receive extends Extension {
 
             // Check if we have to debounce
             if (debounce) {
-                this.publishDebounce(data.device.ieeeAddr, payload, debounce, debounceIgnore, debounceImmediate);
+                this.publishDebounce(data.device.ieeeAddr, payload, debounce, debounceIgnore);
             } else {
                 this.publishEntityState(data.device.ieeeAddr, payload);
             }

--- a/lib/extension/receive.js
+++ b/lib/extension/receive.js
@@ -42,11 +42,10 @@ class Receive extends Extension {
         }
 
         if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, debounceIgnore)) {
-            if (immediate){
+            if (immediate) {
                 // clear previous payload immediately to avoid duplicate
                 this.debouncers[ieeeAddr].publish.clear();
-            }
-            else {
+            } else {
                 // publish previous payload immediately
                 this.debouncers[ieeeAddr].publish.flush();
             }

--- a/lib/extension/receive.js
+++ b/lib/extension/receive.js
@@ -15,20 +15,26 @@ class Receive extends Extension {
         this.coordinator = this.zigbee.getDevicesByType('Coordinator')[0];
     }
 
-    publishDebounce(ieeeAddr, payload, time, debounceIgnore) {
+    publishDebounce(ieeeAddr, payload, time, debounceIgnore, immediate) {
         if (!this.debouncers[ieeeAddr]) {
             this.debouncers[ieeeAddr] = {
                 payload: {},
                 publish: debounce(() => {
                     this.publishEntityState(ieeeAddr, this.debouncers[ieeeAddr].payload);
                     this.debouncers[ieeeAddr].payload = {};
-                }, time * 1000),
+                }, time * 1000, immediate),
             };
         }
 
         if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, debounceIgnore)) {
-            // publish previous payload immediately
-            this.debouncers[ieeeAddr].publish.flush();
+            if (immediate){
+                // clear previous payload immediately to avoid duplicate
+                this.debouncers[ieeeAddr].publish.clear();
+            }
+            else {
+                // publish previous payload immediately
+                this.debouncers[ieeeAddr].publish.flush();
+            }
         }
 
         // extend debounced payload with current
@@ -117,6 +123,7 @@ class Receive extends Extension {
 
         const debounce = resolvedEntity.settings.debounce || settings.get().device_options.debounce;
         const debounceIgnore = resolvedEntity.settings.debounce_ignore || settings.get().device_options.debounce_ignore;
+        const debounceImmediate = resolvedEntity.settings.debounce_immediate || false;
 
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
@@ -140,7 +147,7 @@ class Receive extends Extension {
 
             // Check if we have to debounce
             if (debounce) {
-                this.publishDebounce(data.device.ieeeAddr, payload, debounce, debounceIgnore);
+                this.publishDebounce(data.device.ieeeAddr, payload, debounce, debounceIgnore, debounceImmediate);
             } else {
                 this.publishEntityState(data.device.ieeeAddr, payload);
             }

--- a/lib/extension/receive.js
+++ b/lib/extension/receive.js
@@ -15,20 +15,26 @@ class Receive extends Extension {
         this.coordinator = this.zigbee.getDevicesByType('Coordinator')[0];
     }
 
-    publishDebounce(ieeeAddr, payload, time, debounceIgnore) {
+    publishDebounce(ieeeAddr, payload, time, debounceIgnore, immediate) {
         if (!this.debouncers[ieeeAddr]) {
             this.debouncers[ieeeAddr] = {
                 payload: {},
                 publish: debounce(() => {
                     this.publishEntityState(ieeeAddr, this.debouncers[ieeeAddr].payload);
                     this.debouncers[ieeeAddr].payload = {};
-                }, time * 1000),
+                }, time * 1000, immediate),
             };
         }
 
         if (this.isPayloadConflicted(payload, this.debouncers[ieeeAddr].payload, debounceIgnore)) {
-            // publish previous payload immediately
-            this.debouncers[ieeeAddr].publish.flush();
+            if (immediate) {
+                // clear previous payload immediately to avoid duplicate
+                this.debouncers[ieeeAddr].publish.clear();
+            }
+            else {
+                // publish previous payload immediately
+                this.debouncers[ieeeAddr].publish.flush();
+            }
         }
 
         // extend debounced payload with current
@@ -117,7 +123,8 @@ class Receive extends Extension {
 
         const debounce = resolvedEntity.settings.debounce || settings.get().device_options.debounce;
         const debounceIgnore = resolvedEntity.settings.debounce_ignore || settings.get().device_options.debounce_ignore;
-
+        const debounceImmediate = resolvedEntity.settings.debounce_immediate || false;
+        
         // Convert this Zigbee message to a MQTT message.
         // Get payload for the message.
         // - If a payload is returned publish it to the MQTT broker
@@ -140,7 +147,7 @@ class Receive extends Extension {
 
             // Check if we have to debounce
             if (debounce) {
-                this.publishDebounce(data.device.ieeeAddr, payload, debounce, debounceIgnore);
+                this.publishDebounce(data.device.ieeeAddr, payload, debounce, debounceIgnore, debounceImmediate);
             } else {
                 this.publishEntityState(data.device.ieeeAddr, payload);
             }

--- a/test/receive.test.js
+++ b/test/receive.test.js
@@ -108,7 +108,6 @@ describe('Receive', () => {
         const payload3 = {data: data3, cluster: 'msPressureMeasurement', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 10};
         await zigbeeHerdsman.events.message(payload3);
         await flushPromises();
-        jest.advanceTimersByTime(50);
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish.mock.calls[0][0]).toStrictEqual('zigbee2mqtt/weather_sensor');
         expect(JSON.parse(MQTT.publish.mock.calls[0][1])).toStrictEqual({temperature: 0.08, linkquality: 10});


### PR DESCRIPTION
Hi @Koenkk , per your request in issue #3677, I´ve created a PR. 

This is my fourth day with Z2M and I´ve never written JS before so you need to carefully review this. But so for it works with my testing...

What I want to fix is the fact that debounce does not work very well with the Symfonisk remote. We need to use the "immediate" parameter of the debounce method otherwise rotate_left/right will not be sent until the user stops rotating the remote...