### PR TITLE
Add possibility to override execution command at runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,12 @@ FROM node:12-alpine as base
 WORKDIR /app
 RUN apk add --no-cache tzdata eudev
 
-COPY package.json .
+COPY package.json ./
 
 # Dependencies
 FROM base as dependencies
 
-COPY npm-shrinkwrap.json .
+COPY npm-shrinkwrap.json ./
 
 RUN apk add --no-cache --virtual .buildtools make gcc g++ python linux-headers git && \
     npm ci --production && \
@@ -19,12 +19,13 @@ FROM base as release
 
 COPY --from=dependencies /app/node_modules ./node_modules
 COPY lib ./lib
-COPY index.js docker/run.sh data/configuration.yaml ./
+COPY index.js data/configuration.yaml ./
+COPY docker/docker-entrypoint.sh /usr/local/bin/
 
-RUN chmod +x /app/run.sh
 RUN mkdir /app/data
 
 ARG COMMIT
 RUN echo "{\"hash\": \"$COMMIT\"}" > .hash.json
 
-ENTRYPOINT ["./run.sh"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["npm", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,9 @@ FROM base as release
 COPY --from=dependencies /app/node_modules ./node_modules
 COPY lib ./lib
 COPY index.js data/configuration.yaml ./
+
 COPY docker/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 RUN mkdir /app/data
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ ! -z "$ZIGBEE2MQTT_DATA" ]; then
     DATA="$ZIGBEE2MQTT_DATA"
@@ -13,4 +14,4 @@ if [ ! -f "$DATA/configuration.yaml" ]; then
     cp /app/configuration.yaml "$DATA/configuration.yaml"
 fi
 
-exec npm start
+exec "$@"


### PR DESCRIPTION
The possibility to override execution command is really usefull durig dev, the entrypoint script initialize container data at runtime and then CMD defines the default executable that can be overridden at runtime.