### PR TITLE
Add support for ecosmart BR30 CCT bulb. A9BR3065WESDZ02

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -799,6 +799,7 @@ const mapping = {
     'CC2530.ROUTER': [cfg.binary_sensor_led],
     'AA70155': [cfg.light_brightness_colortemp],
     'A9A19A60WESDZ02': [cfg.light_brightness_colortemp],
+    'A9BR3065WESDZ02': [cfg.light_brightness_colortemp],
     '4058075816718': [cfg.light_brightness_colortemp_colorxy],
     'AA69697': [cfg.light_brightness_colortemp_colorxy],
     'HALIGHTDIMWWE27': [cfg.light_brightness],


### PR DESCRIPTION
This device is very similar to the ecosmart A19 CCT bulb