### PR TITLE
ZNCZ04LM extended attributes support

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1386,7 +1386,7 @@ const mapping = {
     'ZG9101SAC-HP-Switch': [cfg.switch],
     'ZNCZ04LM': [
     	cfg.switch, cfg.sensor_power, cfg.sensor_consumption,
-    	cfg.sensor_current,	cfg.sensor_voltage, cfg.sensor_temperature,
+    	cfg.sensor_current, cfg.sensor_voltage, cfg.sensor_temperature,
     ],
     'ZNCZ12LM': [cfg.switch, cfg.sensor_power],
     'GL-S-007ZS': [cfg.light_brightness_colortemp_colorxy],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1384,7 +1384,7 @@ const mapping = {
     'Eco-Dim.07': [cfg.light_brightness],
     'DIYRuZ_rspm': [cfg.switch, cfg.sensor_action, cfg.sensor_power, cfg.sensor_current],
     'ZG9101SAC-HP-Switch': [cfg.switch],
-    'ZNCZ04LM': [cfg.switch, cfg.sensor_power],
+    'ZNCZ04LM': [cfg.switch, cfg.sensor_power, cfg.sensor_current, cfg.sensor_voltage, cfg.sensor_consumption, cfg.sensor_temperature],
     'ZNCZ12LM': [cfg.switch, cfg.sensor_power],
     'GL-S-007ZS': [cfg.light_brightness_colortemp_colorxy],
     '4058075816732': [cfg.light_brightness_colortemp_colorxy],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1384,7 +1384,10 @@ const mapping = {
     'Eco-Dim.07': [cfg.light_brightness],
     'DIYRuZ_rspm': [cfg.switch, cfg.sensor_action, cfg.sensor_power, cfg.sensor_current],
     'ZG9101SAC-HP-Switch': [cfg.switch],
-    'ZNCZ04LM': [cfg.switch, cfg.sensor_power, cfg.sensor_current, cfg.sensor_voltage, cfg.sensor_consumption, cfg.sensor_temperature],
+    'ZNCZ04LM': [
+    	cfg.switch, cfg.sensor_power, cfg.sensor_consumption,
+    	cfg.sensor_current,	cfg.sensor_voltage, cfg.sensor_temperature,
+    ],
     'ZNCZ12LM': [cfg.switch, cfg.sensor_power],
     'GL-S-007ZS': [cfg.light_brightness_colortemp_colorxy],
     '4058075816732': [cfg.light_brightness_colortemp_colorxy],

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1385,8 +1385,8 @@ const mapping = {
     'DIYRuZ_rspm': [cfg.switch, cfg.sensor_action, cfg.sensor_power, cfg.sensor_current],
     'ZG9101SAC-HP-Switch': [cfg.switch],
     'ZNCZ04LM': [
-    	cfg.switch, cfg.sensor_power, cfg.sensor_consumption,
-    	cfg.sensor_current, cfg.sensor_voltage, cfg.sensor_temperature,
+        cfg.switch, cfg.sensor_power, cfg.sensor_consumption,
+        cfg.sensor_current, cfg.sensor_voltage, cfg.sensor_temperature,
     ],
     'ZNCZ12LM': [cfg.switch, cfg.sensor_power],
     'GL-S-007ZS': [cfg.light_brightness_colortemp_colorxy],


### PR DESCRIPTION
Support for extended attributes of ZNCZ04LM introduced in https://github.com/Koenkk/zigbee-herdsman-converters/pull/1318

![image](https://user-images.githubusercontent.com/3438036/84820592-91d12180-b022-11ea-8fb4-f2975b480302.png)
