### PR TITLE
Update devices.js

### DIFF
--- a/adurosmart-81812
+++ b/adurosmart-81812
@@ -1,0 +1,20 @@
+    // AduroSmart
+    {
+        zigbeeModel: ['ZLL-ExtendedColo'],
+        model: '81809',
+        vendor: 'AduroSmart',
+        description: 'ERIA Colors and White A19 60W',
+        extend: generic.light_onoff_brightness_colortemp_colorxy,
+        endpoint: (device) => {
+            return {
+                'default': 2,
+            };
+        },
+    },
+    {
+        zigbeeModel: ['ZLL-ColorTempera', 'ZLL-ColorTemperature'],
+        model: '81812',
+        vendor: 'AduroSmart',
+        description: 'ERIA Tunable White A19 60W',
+        extend: generic.light_onoff_brightness_colortemp,
+    },


### PR DESCRIPTION
Add specific support for Adurosmart ERIA #81812 Tunable White A19.
Optionally change the description for #81809 as per description at https://adurosmart.com/product/eria-colors-and-white-a19-60w-2/