### PR TITLE
add support for forced reconfigure

### DIFF
--- a/lib/extension/configure.js
+++ b/lib/extension/configure.js
@@ -14,6 +14,7 @@ class Configure extends Extension {
 
         this.legacyApi = settings.get().advanced.legacy_api;
         this.legacyTopic = `${settings.get().mqtt.base_topic}/bridge/configure`;
+        this.legacyTopicForce = `${settings.get().mqtt.base_topic}/bridge/configure/force`;
     }
 
     shouldConfigure(resolvedEntity) {
@@ -38,13 +39,14 @@ class Configure extends Extension {
         /* istanbul ignore else */
         if (this.legacyApi) {
             this.mqtt.subscribe(this.legacyTopic);
+            this.mqtt.subscribe(this.legacyTopicForce);
         }
     }
 
     async onMQTTMessage(topic, message) {
         /* istanbul ignore else */
         if (this.legacyApi) {
-            if (topic !== this.legacyTopic) {
+            if (topic !== this.legacyTopic && topic !== this.legacyTopicForce) {
                 return;
             }
 
@@ -54,7 +56,9 @@ class Configure extends Extension {
                 return;
             }
 
-            if (!resolvedEntity.definition || !resolvedEntity.definition.configure) {
+            if (topic === this.legacyTopicForce) {
+                logger.warn(`Forcing configure of '${resolvedEntity.name}'.`);
+            } else if (!resolvedEntity.definition || !resolvedEntity.definition.configure) {
                 logger.warn(`Skipping configure of '${resolvedEntity.name}', device does not require this.`);
                 return;
             }

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -111,6 +111,12 @@ describe('Configure', () => {
         expect(logger.warn).toHaveBeenCalledWith(`Skipping configure of 'bulb', device does not require this.`)
     });
 
+    it('Shouldnt skip reconfigure when device does not require this but force was specified', async () => {
+        await MQTT.events.message('zigbee2mqtt/bridge/configure/force', 'bulb');
+        await flushPromises();
+        expect(logger.warn).toHaveBeenCalledWith(`Forcing configure of 'bulb'.`)
+    });
+
     it('Should not configure when interviewing', async () => {
         const device = zigbeeHerdsman.devices.remote;
         delete device.meta.configured;


### PR DESCRIPTION
Add an additional route `zigbee2mqtt/bridge/configure/force` which allows to force the reconfiguration of a device, even if it doesn't require this.

This implements: https://github.com/Koenkk/zigbee2mqtt/issues/3778