### PR TITLE
Complementary pull request to zigbee-herdsman-converters pull 1355

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -683,6 +683,19 @@ const switchEndpoint = (endpointName) => {
     };
 };
 
+// There must be some kind of error, as when I try to use in '067774' they don't show up in HA.
+const actionEndpoint = (endpointName) => {
+    return {
+        type: 'action',
+        object_id: `action_${endpointName}`,
+        discovery_payload: {
+            value_template: `{{ value_json.action_${endpointName} }}`,
+            command_topic: true,
+            command_topic_prefix: endpointName,
+        },
+    };
+};
+
 const lightEndpoint = (configType, endpointName) => {
     const config = objectAssignDeep.noMutate(cfg[configType]);
     config['object_id'] = `light_${endpointName}`;
@@ -1437,6 +1450,9 @@ const mapping = {
     'WV704R0A0902': [thermostat()],
     '067776': [cfg.cover_position],
     '067773': [cfg.sensor_action, cfg.sensor_battery],
+    // FIX THIS. With just cfg.sensor_action it works, but if I try to add both endpoints supports, they don't show up in HA.
+    '067774': [cfg.sensor_action, actionEndpoint('left'), actionEndpoint('right'), cfg.sensor_battery],
+    '067694': [cfg.sensor_click, cfg.sensor_battery],
     '067771': [cfg.light_brightness],
     '064873': [cfg.sensor_action],
     'K4003C': [cfg.switch, cfg.sensor_action],


### PR DESCRIPTION
This is a complementary pull request to https://github.com/Koenkk/zigbee-herdsman-converters/pull/1355 .
However (see '067774' and new actionEndpoint()), with just cfg.sensor_action it works, but if I try to add both endpoints supports, they don't show up in HA.