### PR TITLE
Fix Reporting for Multi-Endpoint Devices

### DIFF
--- a/lib/extension/report.js
+++ b/lib/extension/report.js
@@ -173,6 +173,7 @@ class Report extends Extension {
         // https://github.com/Koenkk/zigbee2mqtt/issues/966
         if (messageType === 'deviceAnnounce' && utils.isIkeaTradfriDevice(device)) return true;
 
+        if (resolvedEntity.device.interviewing === true) return false;
         if (device.meta.hasOwnProperty('reporting') && device.meta.reporting === reportKey) return false;
         if (!utils.isRouter(device) || utils.isBatteryPowered(device)) return false;
         // Gledopto devices don't support reporting.

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -108,6 +108,20 @@ describe('Report', () => {
         expect(device.meta.reporting).toBeUndefined();
     });
 
+    it('Should not configure reporting when interviewing', async () => {
+        const device = zigbeeHerdsman.devices.bulb_2;
+        const endpoint = device.getEndpoint(1);
+        device.interviewing = true;
+        delete device.meta.reporting;
+        mockClear(device);
+        const payload = {data: {onOff: 1}, cluster: 'genOnOff', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 10};
+        await zigbeeHerdsman.events.message(payload);
+        await flushPromises();
+        expect(endpoint.bind).toHaveBeenCalledTimes(0);
+        expect(endpoint.configureReporting).toHaveBeenCalledTimes(0);
+        expect(device.meta.reporting).toBeUndefined();
+    });
+
     it('Should not configure reporting when receicing message from device which has already been setup yet', async () => {
         const device = zigbeeHerdsman.devices.bulb;
         const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
Reporting setup seems to start while the interview process is still active. At this point in time, only the input clusters of the first endpoint seem to be known (at least with the ubisys S2) and therefore only the first endpoint gets considered for binding and reporting while the other(s) will be ignored. As the reporting flag in the database will still be written as a success, reporting setup will not be retried later, leading to the other endpoints never being bound.

To avoid this, I basically copied the check for the interview process from https://github.com/Koenkk/zigbee2mqtt/blob/9009de24aca1027283bfbfbe399f9071254184db/lib/extension/configure.js#L30-L32 to delay reporting setup until the (new) device is known completely.