### PR TITLE
Fix for GL-S-003Z

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -990,7 +990,7 @@ const mapping = {
     '44435': [cfg.light_brightness_colortemp_colorxy],
     '404006/404008/404004': [cfg.light_brightness_colortemp],
     'MLI-404011': [cfg.sensor_action],
-    'GL-S-003Z': [cfg.light_brightness_colorxy],
+    'GL-S-003Z': [cfg.light_brightness_colortemp_colorxy],
     'GL-S-005Z': [cfg.light_brightness_colortemp_colorxy],
     'HS1DS-E': [cfg.binary_sensor_contact],
     'SP600': [cfg.switch, cfg.sensor_power, cfg.sensor_energy],


### PR DESCRIPTION
this fix the GL-S-003Z.
It is a RGBW light but it behave like a rgb+cct light.
without this an error is displayed in the logs ""white_value" is an invalid option"  and the white light stays off (took me 6 month to realize^^)

zigbee2mqtt:error Publish 'set' 'white_value' failed: 'TypeError: Cannot read property 'state' of undefined'

there is an issue opened about it:
https://github.com/Koenkk/zigbee2mqtt/issues/3165