### PR TITLE
Add PM-B540, TS0115

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1277,6 +1277,7 @@ const mapping = {
     '9290022166': [cfg.light_brightness_colortemp_colorxy],
     'PM-C140-ZB': [cfg.sensor_power, cfg.switch],
     'PM-B530-ZB': [cfg.sensor_power, cfg.switch],
+    'PM-B540-ZB': [cfg.sensor_power, cfg.switch],
     'PM-B430-ZB': [cfg.sensor_power, cfg.switch],
     'ptvo.switch': [
         switchEndpoint('l1'), switchEndpoint('l2'), switchEndpoint('l3'),
@@ -1768,6 +1769,10 @@ const mapping = {
     'YRL-220L': [cfg.lock, cfg.sensor_battery],
     'YSR-MINI-01': [cfg.light_brightness_colortemp_colorxy],
     '9290023349': [cfg.light_brightness],
+    'TS0115': [
+        switchEndpoint('l1'), switchEndpoint('l2'), switchEndpoint('l3'), switchEndpoint('l4'),
+        switchEndpoint('l5'),
+    ],
 };
 
 /**


### PR DESCRIPTION
Support Dawon PM-B540,
UseeLink TS0115(https://ko.aliexpress.com/item/4000108371113.html?spm=a2g0o.productlist.0.0.55f169eaiSgWdl&algo_pvid=a2d855e8-89cc-42ea-ab68-8b04c981c537&algo_expid=a2d855e8-89cc-42ea-ab68-8b04c981c537-1&btsid=0ab6f82c15943852972118657e0a09&ws_ab_test=searchweb0_0,searchweb201602_,searchweb201603_)
TS0115 Model is multi type(EU, US, UK, Universal, Etc.) and 2 type Amp(10A, 16A)