### PR TITLE
Add Sinopé water leak detector mapping for Home Assistant

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1746,6 +1746,7 @@ const mapping = {
     'SPE600': [cfg.switch, cfg.sensor_power],
     '067774': [cfg.sensor_action, cfg.sensor_battery],
     '067694': [cfg.sensor_action, cfg.sensor_battery],
+    'WL4200': [cfg.binary_sensor_water_leak, cfg.binary_sensor_battery_low],
 };
 
 /**


### PR DESCRIPTION
Related: https://github.com/Koenkk/zigbee-herdsman-converters/pull/1389