### PR TITLE
Add voltage to ZNCZ02LM

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -776,7 +776,7 @@ const mapping = {
     'MCCGQ11LM': [cfg.binary_sensor_contact, cfg.sensor_battery],
     'SJCGQ11LM': [cfg.binary_sensor_water_leak, cfg.sensor_battery],
     'MFKZQ01LM': [cfg.sensor_action, cfg.sensor_battery],
-    'ZNCZ02LM': [cfg.switch, cfg.sensor_power, cfg.sensor_temperature, cfg.sensor_consumption],
+    'ZNCZ02LM': [cfg.switch, cfg.sensor_power, cfg.sensor_temperature, cfg.sensor_consumption, cfg.sensor_voltage],
     'QBCZ11LM': [cfg.switch, cfg.sensor_power],
     'LED1545G12': [cfg.light_brightness_colortemp],
     'LED1623G12': [cfg.light_brightness],


### PR DESCRIPTION
I have seen voltage reports on MQTT from my ZNCZ02LM devices. Apparently, ZNCZ02LM supports voltage but it wasn't getting into Home Assistant.
I have added it to the Home Assistant devices configuration file.

I will create a PR for the manual configuration docs too.
Let me know if there are any changes needed for the PR.