### PR TITLE
Network parameters / config displayed in zigbee2mqtt/bridge/config

### DIFF
--- a/lib/extension/bridge.js
+++ b/lib/extension/bridge.js
@@ -332,6 +332,7 @@ class Bridge extends Extension {
             version: this.zigbee2mqttVersion.version,
             commit: this.zigbee2mqttVersion.commitHash,
             coordinator: this.coordinatorVersion,
+            network: await this.zigbee.getNetworkParameters(),
             log_level: logger.getLevel(),
             permit_join: await this.zigbee.getPermitJoin(),
         };

--- a/lib/extension/legacy/bridgeLegacy.js
+++ b/lib/extension/legacy/bridgeLegacy.js
@@ -378,7 +378,8 @@ class BridgeLegacy extends Extension {
             version: info.version,
             commit: info.commitHash,
             coordinator,
-            log_level: logger.getLevel(),
+            network: await this.zigbee.getNetworkParameters(),
+	    log_level: logger.getLevel(),
             permit_join: await this.zigbee.getPermitJoin(),
         };
 

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -102,6 +102,10 @@ class Zigbee extends events.EventEmitter {
         return this.herdsman.getCoordinatorVersion();
     }
 
+    async getNetworkParameters() {
+        return this.herdsman.getNetworkParameters();
+    }	
+
     async reset(type) {
         await this.herdsman.reset(type);
     }

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -36,7 +36,7 @@ describe('Bridge', () => {
         const version = await require('../lib/util/utils').getZigbee2mqttVersion();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/info',
-          JSON.stringify({"version":version.version,"commit":version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1,"revision":20190425}},"log_level":"info","permit_join":false}),
+          JSON.stringify({"version":version.version,"commit":version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1,"revision":20190425}},"network":{"panID":6754,"extendedPanID":"0xdddddddddddddddd","channel":10},"log_level":"info","permit_join":false}),
           { retain: true, qos: 0 },
           expect.any(Function)
         );


### PR DESCRIPTION
I'm developing a home automation solution and I think it is important to display the PAN ID as well as the channel currently in use and not only the one specified in config file. I will allow the user to change these parameters and after restarting the service this allow us to know if the new settings have been applied properly 