### PR TITLE
Network parameters / config displayed in zigbee2mqtt/bridge/config

### DIFF
--- a/lib/extension/bridge.js
+++ b/lib/extension/bridge.js
@@ -347,6 +347,7 @@ class Bridge extends Extension {
             version: this.zigbee2mqttVersion.version,
             commit: this.zigbee2mqttVersion.commitHash,
             coordinator: this.coordinatorVersion,
+            network: await this.zigbee.getNetworkParameters(),
             log_level: logger.getLevel(),
             permit_join: await this.zigbee.getPermitJoin(),
         };

--- a/lib/extension/bridge.js
+++ b/lib/extension/bridge.js
@@ -347,7 +347,7 @@ class Bridge extends Extension {
             version: this.zigbee2mqttVersion.version,
             commit: this.zigbee2mqttVersion.commitHash,
             coordinator: this.coordinatorVersion,
-            network: await this.zigbee.getNetworkParameters(),
+            network: utils.toSnakeCase(await this.zigbee.getNetworkParameters()),
             log_level: logger.getLevel(),
             permit_join: await this.zigbee.getPermitJoin(),
         };

--- a/lib/extension/legacy/bridgeLegacy.js
+++ b/lib/extension/legacy/bridgeLegacy.js
@@ -378,6 +378,7 @@ class BridgeLegacy extends Extension {
             version: info.version,
             commit: info.commitHash,
             coordinator,
+            network: await this.zigbee.getNetworkParameters(),
             log_level: logger.getLevel(),
             permit_join: await this.zigbee.getPermitJoin(),
         };

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -162,8 +162,11 @@ function* getExternalConvertersDefinitions(settings) {
 function toSnakeCase(value) {
     if (typeof value === 'object') {
         for (const key of Object.keys(value)) {
-            value[toSnakeCase(key)] = value[key];
-            delete value[key];
+            const keySnakeCase = toSnakeCase(key);
+            if (key !== keySnakeCase) {
+                value[keySnakeCase] = value[key];
+                delete value[key];
+            }
         }
         return value;
     } else {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -101,6 +101,10 @@ class Zigbee extends events.EventEmitter {
     async getCoordinatorVersion() {
         return this.herdsman.getCoordinatorVersion();
     }
+    
+     async getNetworkParameters() {
+        return this.herdsman.getNetworkParameters();
+    }	
 
     async reset(type) {
         await this.herdsman.reset(type);

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -102,7 +102,7 @@ class Zigbee extends events.EventEmitter {
         return this.herdsman.getCoordinatorVersion();
     }
 
-     async getNetworkParameters() {
+    async getNetworkParameters() {
         return this.herdsman.getNetworkParameters();
     }
 

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -101,10 +101,10 @@ class Zigbee extends events.EventEmitter {
     async getCoordinatorVersion() {
         return this.herdsman.getCoordinatorVersion();
     }
-    
+
      async getNetworkParameters() {
         return this.herdsman.getNetworkParameters();
-    }	
+    }
 
     async reset(type) {
         await this.herdsman.reset(type);

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -37,7 +37,7 @@ describe('Bridge', () => {
         const version = await require('../lib/util/utils').getZigbee2mqttVersion();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/info',
-          JSON.stringify({"version":version.version,"commit":version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1,"revision":20190425}},"network":{"panID":6754,"extendedPanID":"0xdddddddddddddddd","channel":10},"log_level":"info","permit_join":false}),
+          JSON.stringify({"version":version.version,"commit":version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1,"revision":20190425}},"network":{"panID":5674,"extendedPanID":[0,11,22],"channel":15},"log_level":"info","permit_join":false}),
           { retain: true, qos: 0 },
           expect.any(Function)
         );

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -33,7 +33,7 @@ describe('Bridge', () => {
         await flushPromises();
     });
 
-    it('onlythis Should publish bridge info on startup', async () => {
+    it('Should publish bridge info on startup', async () => {
         const version = await require('../lib/util/utils').getZigbee2mqttVersion();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/info',

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -33,11 +33,11 @@ describe('Bridge', () => {
         await flushPromises();
     });
 
-    it('Should publish bridge info on startup', async () => {
+    it('onlythis Should publish bridge info on startup', async () => {
         const version = await require('../lib/util/utils').getZigbee2mqttVersion();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/info',
-          JSON.stringify({"version":version.version,"commit":version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1,"revision":20190425}},"network":{"panID":5674,"extendedPanID":[0,11,22],"channel":15},"log_level":"info","permit_join":false}),
+          JSON.stringify({"version":version.version,"commit":version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1,"revision":20190425}},"network":{"channel":15,"pan_id":5674,"extended_pan_id":[0,11,22]},"log_level":"info","permit_join":false}),
           { retain: true, qos: 0 },
           expect.any(Function)
         );

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -37,7 +37,7 @@ describe('Bridge', () => {
         const version = await require('../lib/util/utils').getZigbee2mqttVersion();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/info',
-          JSON.stringify({"version":version.version,"commit":version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1,"revision":20190425}},"log_level":"info","permit_join":false}),
+          JSON.stringify({"version":version.version,"commit":version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1,"revision":20190425}},"network":{"panID":6754,"extendedPanID":"0xdddddddddddddddd","channel":10},"log_level":"info","permit_join":false}),
           { retain: true, qos: 0 },
           expect.any(Function)
         );

--- a/test/legacy/bridgeLegacy.test.js
+++ b/test/legacy/bridgeLegacy.test.js
@@ -29,7 +29,7 @@ describe('Bridge legacy', () => {
     it('Should publish bridge configuration on startup', async () => {
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/config',
-          JSON.stringify({"version":this.version.version,"commit":this.version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1, "revision": 20190425}},"log_level":'info',"permit_join":false}),
+          JSON.stringify({"version":this.version.version,"commit":this.version.commitHash,"coordinator":{"type":"z-Stack","meta":{"version":1, "revision": 20190425}},"network":{"panID":5674,"extendedPanID":[0,11,22],"channel":15},"log_level":'info',"permit_join":false}),
           { retain: true, qos: 0 },
           expect.any(Function)
         );


### PR DESCRIPTION
I'm developing a home automation solution and I think it is important to display the PAN ID as well as the channel currently in use and not only the one specified in config file. I will allow the user to change these parameters and after restarting the service this allow us to know if the new settings have been applied properly