### PR TITLE
Allow ping on startup for devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ typings/
 # dotenv environment variables file
 .env
 
+# webstorm files
+.idea
+
 # data
 data/database.db
 data/config.json

--- a/lib/extension/availability.js
+++ b/lib/extension/availability.js
@@ -20,7 +20,9 @@ class Availability extends Extension {
     constructor(zigbee, mqtt, state, publishEntityState, eventBus) {
         super(zigbee, mqtt, state, publishEntityState, eventBus);
 
+        this.refresh_state_on_startup = settings.get().advanced.availability_refresh_state_on_startup;
         this.availability_timeout = settings.get().advanced.availability_timeout;
+        this.availability_reconnect_converter_keys = settings.get().advanced.availability_reconnect_converter_keys;
         this.timers = {};
         this.state = {};
 
@@ -60,32 +62,70 @@ class Availability extends Extension {
         return device.type === 'Router' && device.powerSource !== 'Battery';
     }
 
-    onMQTTConnected() {
+    async onMQTTConnected() {
         for (const device of this.zigbee.getClients()) {
-            // Mark all devices as online on start
-            const ieeeAddr = device.ieeeAddr;
-            this.publishAvailability(device, this.state.hasOwnProperty(ieeeAddr) ? this.state[ieeeAddr] : true, true);
+            this.connectDevice(device);
+        }
+    }
 
-            if (this.inPasslistOrNotInBlocklist(device)) {
-                if (this.isPingable(device)) {
-                    this.setTimerPingable(device);
-                } else {
-                    this.timers[ieeeAddr] = setInterval(() => {
-                        this.handleIntervalNotPingable(device);
-                    }, utils.secondsToMilliseconds(300));
-                }
+    isPingOnStartupEnabledForDevice(device) {
+        // Allows for "non-pingable" devices  (e.g., battery powered locks) to be pinged at startup
+        return this.getSettingForDevice(
+            this.isPingable(device),
+            'availability_ping_device_on_startup',
+            device );
+    }
+
+    isRefreshOnStartupEnabledForDevice(device) {
+        return this.getSettingForDevice(
+            this.refresh_state_on_startup && this.isPingable(device),
+            'availability_refresh_state_on_startup',
+            device );
+    }
+
+    getSettingForDevice(initialValue, setting, device) {
+        // Update pingable devices on startup, if enabled.
+        let value = initialValue;
+        const deviceSettings = settings.getDevice(device.ieeeAddr);
+        // Listen to device overrides
+        if (deviceSettings &&
+            deviceSettings.hasOwnProperty(setting)) {
+            value = deviceSettings[setting];
+        }
+        return value;
+    }
+
+    async connectDevice(device) {
+        // Mark all devices as online on start
+        const ieeeAddr = device.ieeeAddr;
+
+        if (this.isPingOnStartupEnabledForDevice(device)) {
+            await this.handleIntervalPingable(device, false);
+        }
+
+        this.publishAvailability(
+            device,
+            this.state.hasOwnProperty(ieeeAddr) ? this.state[ieeeAddr] : true, true);
+
+        if (this.inPasslistOrNotInBlocklist(device)) {
+            if (this.isPingable(device)) {
+                this.setTimerPingable(device);
+            } else {
+                this.timers[ieeeAddr] = setInterval(() => {
+                    this.handleIntervalNotPingable(device);
+                }, utils.secondsToMilliseconds(300));
             }
         }
     }
 
-    async handleIntervalPingable(device) {
-        // When a device is already unavailable, log the ping failed on 'debug' instead of 'error'.
+    async handleIntervalPingable(device, queue=true) {
         const resolvedEntity = this.zigbee.resolveEntity(device.ieeeAddr);
         if (!resolvedEntity) {
             logger.debug(`Stop pinging '${device.ieeeAddr}', device is not known anymore`);
             return;
         }
 
+        // When a device is already unavailable, log the ping failed on 'debug' instead of 'error'.
         const level = this.state.hasOwnProperty(device.ieeeAddr) && !this.state[device.ieeeAddr] ? 'debug' : 'error';
         try {
             await device.ping();
@@ -95,7 +135,9 @@ class Availability extends Extension {
             this.publishAvailability(device, false);
             logger[level](`Failed to ping '${resolvedEntity.name}'`);
         } finally {
-            this.setTimerPingable(device);
+            if (queue) {
+                this.setTimerPingable(device);
+            }
         }
     }
 
@@ -132,35 +174,57 @@ class Availability extends Extension {
         this.zigbee.getClients().forEach((device) => this.publishAvailability(device, false));
     }
 
-    async onReconnect(device) {
+    async refreshState(device) {
         const resolvedEntity = this.zigbee.resolveEntity(device);
         if (resolvedEntity && resolvedEntity.definition) {
+            // device_setting availability_on_reconnect allows for disabling state lookup on reconnect. Useful to save
+            // battery, while still allowing availability
+            if (resolvedEntity.settings.hasOwnProperty('availability_allow_refresh_state') &&
+                !resolvedEntity.settings.availability_allow_refresh_state) return;
+
             const used = [];
             try {
-                for (const key of ['state', 'brightness', 'color', 'color_temp']) {
+                const meta = {
+                    options: {...settings.get().device_options, ...resolvedEntity.settings},
+                    logger,
+                    device: resolvedEntity.device,
+                    mapped: resolvedEntity.definition,
+                };
+                for (const key of this.availability_reconnect_converter_keys) {
                     const converter = resolvedEntity.definition.toZigbee.find((tz) => tz.key.includes(key));
                     if (converter && !used.includes(converter)) {
-                        await converter.convertGet(device.endpoints[0], key, {});
+                        await converter.convertGet(device.endpoints[0], key, meta);
                         used.push(converter);
                     }
                 }
             } catch (error) {
-                logger.error(`Failed to read state of '${resolvedEntity.name}' after reconnect`);
+                logger.error(`Failed to read state of '${resolvedEntity.name}' after reconnect`, error);
             }
         }
     }
 
     publishAvailability(device, available, force=false) {
         const ieeeAddr = device.ieeeAddr;
-        if (this.state.hasOwnProperty(ieeeAddr) && !this.state[ieeeAddr] && available) {
-            this.onReconnect(device);
+
+        const shouldPublishAvailability = this.state[ieeeAddr] !== available || force;
+
+        const shouldRefreshDueToStartup = available && !this.state.hasOwnProperty(ieeeAddr) &&
+            this.isRefreshOnStartupEnabledForDevice(device);
+        const shouldRefreshDueToReconnect = available &&
+            this.state.hasOwnProperty(ieeeAddr) && !this.state[ieeeAddr];
+
+        // Update before refreshing, so that we don't trigger multiple times
+        this.state[ieeeAddr] = available;
+
+        if (shouldRefreshDueToStartup || shouldRefreshDueToReconnect) {
+            this.refreshState(device);
         }
 
-        const deviceSettings = settings.getDevice(ieeeAddr);
-        const name = deviceSettings ? deviceSettings.friendlyName : ieeeAddr;
-        const topic = `${name}/availability`;
-        const payload = available ? 'online' : 'offline';
-        if (this.state[ieeeAddr] !== available || force) {
+        if (shouldPublishAvailability) {
+            const deviceSettings = settings.getDevice(ieeeAddr);
+            const name = deviceSettings ? deviceSettings.friendlyName : ieeeAddr;
+            const topic = `${name}/availability`;
+            const payload = available ? 'online' : 'offline';
             this.state[ieeeAddr] = available;
             this.mqtt.publish(topic, payload, {retain: true, qos: 0});
         }
@@ -191,7 +255,7 @@ class Availability extends Extension {
                      *
                      * This isn't needed for TRADFRI devices as they already send the state themself.
                      */
-                    this.onReconnect(device);
+                    this.refreshState(device);
                 }
             }
         }

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1984,7 +1984,7 @@ class HomeAssistant extends Extension {
          * Implements the MQTT device trigger (https://www.home-assistant.io/integrations/device_trigger.mqtt/)
          * The MQTT device trigger does not support JSON parsing, so it cannot listen to zigbee2mqtt/my_device
          * Whenever a device publish an {action: *} we discover an MQTT device trigger sensor
-         * and republish it to zigbee2mqtt/my_devic/action
+         * and republish it to zigbee2mqtt/my_device/action
          */
         const key = ['action', 'click'].find((k) => data.payload[k] && data.payload[k] !== '');
         if (data.entity.definition && key) {

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -62,6 +62,8 @@ const defaults = {
 
         // Availability timeout in seconds, disabled by default.
         availability_timeout: 0,
+        availability_refresh_state_on_startup: false,
+        availability_reconnect_converter_keys: ['state', 'brightness', 'color', 'color_temp', 'pin_code'],
         availability_blocklist: [],
         availability_passlist: [],
         // Deprecated, use block/passlist
@@ -197,6 +199,8 @@ const schema = {
                 last_seen: {type: 'string', enum: ['disable', 'ISO_8601', 'ISO_8601_local', 'epoch']},
                 elapsed: {type: 'boolean'},
                 availability_timeout: {type: 'number', minimum: 0},
+                availability_refresh_state_on_startup: {type: 'boolean'},
+                availability_reconnect_converter_keys: {type: 'array', items: {type: 'string'}},
                 availability_blocklist: {type: 'array', items: {type: 'string'}},
                 availability_passlist: {type: 'array', items: {type: 'string'}},
                 // Deprecated, use block/passlist


### PR DESCRIPTION
Hi Koenkk,

On the discussion of our MR in zigbee-herdsman-converters, this is my implementation to allow for detecting state on reconnect.

With a new option on the availabiltiy extension `availability_update_on_startup`, it will ping all pingable devices while zigbee2mqtt is starting up. Additionally, one can override at the device level to enable this for non-pingable (battery) devices (such as a door lock).

It uses the existing onReconnect functionality, with the addition of a `to_zigbee` optional converter method `onReconnect`, which can be used to handle custom `onReconnect` functionality. For our `pin_code` locks, it looks for device metadata to determine the number of pin_codes it must lookup.

Lastly, I also introduced `availability_on_reconnect` as a device level (I could easily remove it) which disables the onReconnect polling for a given device after it has become available (if known device doesn't like polling, but availability is still desired).

With this combination...

```
  availability_timeout: 60
  availability_update_on_startup: true

device_options for kwikset lock:
    read_pin_value: true
    availability_refresh_on_startup: true
```

1. Mains powered lights are pinged (in parallel, since the `connectDevice` method is not await'd) on startup, and if found, onReconnect is called, querying for state of the light, which eliminates out-of-sync errors.
2. The Kwikset lock is pinged on startup, and if found, onReconnect is called, querying for state, then descending into tz.pincode_lock.onReconnect, which queries for the current state of all user codes

Let me know your thoughts, and thanks for all your work!