### PR TITLE
Add Home Assistant discovery for ROB_200-010-0

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1784,6 +1784,7 @@ const mapping = {
     'TYZS1L': [cfg.light_brightness_colortemp_colorxy],
     '43102': [cfg.switch],
     '1746430P7': [cfg.light_brightness_colortemp_colorxy],
+    'ROB_200-010-0': [cfg.cover_position],
 };
 
 const defaultStatusTopic = 'homeassistant/status';


### PR DESCRIPTION
Adding mapping for:
    zigbeeModel: 'Motor Controller',
    model: 'ROB_200-010-0',
    vendor: 'ROBB',
    description: 'Zigbee Curtain Motor Controller',