### PR TITLE
add direction sensor to HA AD 

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -500,6 +500,14 @@ const cfg = {
             value_template: '{{ value_json.radiation_dose_per_hour }}',
         },
     },
+    'sensor_direction': {
+        type: 'sensor',
+        object_id: 'direction',
+        discovery_payload: {
+            value_template: '{{ value_json.direction }}',
+            icon: 'mdi:rotate-3d-variant',
+        },
+    },
 
     // Light
     'light_brightness_colortemp_colorxy': {
@@ -1597,7 +1605,7 @@ const mapping = {
     '07046L': [cfg.sensor_action],
     '07045L': [cfg.binary_sensor_contact, cfg.binary_sensor_tamper, cfg.binary_sensor_battery_low],
     '3402831P7': [cfg.light_brightness_colortemp],
-    'TERNCY-SD01': [cfg.sensor_click, cfg.sensor_battery, cfg.sensor_action],
+    'TERNCY-SD01': [cfg.sensor_click, cfg.sensor_battery, cfg.sensor_action, cfg.sensor_direction],
     '07048L': [cfg.switch, cfg.sensor_power],
     'ICZB-KPD14S': [cfg.sensor_battery, cfg.sensor_click, cfg.sensor_action],
     '73743': [cfg.sensor_action, cfg.sensor_battery],


### PR DESCRIPTION
Selfishly added direction sensor to HA AD to be used in automations. Enables easy automatiing with direction as main sensor state and number of clicks in state attribute `number`

Used with Terncy smart dial and maybe some other controllers...