### PR TITLE
Add Environment Variable Override

### DIFF
--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -438,9 +438,53 @@ function read() {
     return s;
 }
 
+function applyEnvironmentVariables(settings) {
+    const iterate = (obj, path) => {
+        Object.keys(obj).forEach((key) => {
+            if (key !== 'type') {
+                if (key !== 'properties') {
+                    const type = (obj[key].type || 'object').toString();
+                    const envPart = path.reduce((acc, val) => `${acc}${val}_`, '');
+                    const envVariableName = (`ZIGBEE2MQTT_${envPart}${key}`).toUpperCase();
+
+                    if (process.env[envVariableName]) {
+                        const setting = path.reduce((acc, val, index) => {
+                            acc[val] = acc[val] || {};
+                            return acc[val];
+                        }, settings);
+
+                        if (type.indexOf('object') >= 0 || type.indexOf('array') >= 0) {
+                            setting[key] = JSON.parse(process.env[envVariableName]);
+                        }
+                        if (type.indexOf('number') >= 0) {
+                            setting[key] = process.env[envVariableName] * 1;
+                        }
+                        if (type.indexOf('boolean') >= 0) {
+                            setting[key] = process.env[envVariableName].toLowerCase() === 'true' ? true : false;
+                        }
+                        if (type.indexOf('string') >= 0) {
+                            setting[key] = process.env[envVariableName];
+                        }
+                    }
+                }
+
+                if (typeof obj[key] === 'object') {
+                    const newPath = [...path];
+                    if (key !== 'properties') {
+                        newPath.push(key);
+                    }
+                    iterate(obj[key], newPath);
+                }
+            }
+        });
+    };
+    iterate(schema.properties, []);
+}
+
 function get() {
     if (!_settings) {
         _settings = read();
+        applyEnvironmentVariables(_settings);
     }
 
     return _settings;

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -129,6 +129,13 @@ const defaults = {
         timestamp_format: 'YYYY-MM-DD HH:mm:ss',
     },
     external_converters: [],
+    env_var_tests: {
+        string_val: 'test value',
+        boolean_val: true,
+        number_val: 1,
+        object_val: {property: 'test value'},
+        array_val: ['one', 'two'],
+    },
 };
 
 const schema = {
@@ -284,6 +291,17 @@ const schema = {
                     },
                     required: ['friendly_name'],
                 },
+            },
+        },
+        env_var_tests: {
+            type: 'object',
+            properties: {
+                string_val: {type: 'string'},
+                boolean_val: {type: 'boolean'},
+                number_val: {type: 'number'},
+                object_val: {type: 'object'},
+                array_val: {type: 'array'},
+                empty_object: {type: 'object'},
             },
         },
     },
@@ -446,7 +464,6 @@ function applyEnvironmentVariables(settings) {
                     const type = (obj[key].type || 'object').toString();
                     const envPart = path.reduce((acc, val) => `${acc}${val}_`, '');
                     const envVariableName = (`ZIGBEE2MQTT_${envPart}${key}`).toUpperCase();
-
                     if (process.env[envVariableName]) {
                         const setting = path.reduce((acc, val, index) => {
                             acc[val] = acc[val] || {};
@@ -460,7 +477,7 @@ function applyEnvironmentVariables(settings) {
                             setting[key] = process.env[envVariableName] * 1;
                         }
                         if (type.indexOf('boolean') >= 0) {
-                            setting[key] = process.env[envVariableName].toLowerCase() === 'true' ? true : false;
+                            setting[key] = process.env[envVariableName].toLowerCase() === 'true';
                         }
                         if (type.indexOf('string') >= 0) {
                             setting[key] = process.env[envVariableName];
@@ -788,10 +805,14 @@ module.exports = {
     _write: write,
     _reRead: () => {
         _settings = read();
+        applyEnvironmentVariables(_settings);
         _settingsWithDefaults = objectAssignDeep.noMutate(defaults, get());
     },
     _clear: () => {
         _settings = null;
     },
-    _getDefaults: () => defaults,
+    _getDefaults: () => {
+        applyEnvironmentVariables(defaults);
+        return defaults;
+    },
 };

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -786,12 +786,14 @@ module.exports = {
     // For tests only
     _write: write,
     _reRead: () => {
-        _settings = read();
-        applyEnvironmentVariables(_settings);
-        _settingsWithDefaults = objectAssignDeep.noMutate(defaults, get());
+        _settings = null;
+        get();
+        _settingsWithDefaults = null;
+        getWithDefaults();
     },
     _clear: () => {
         _settings = null;
+        _settingsWithDefaults = null;
     },
     _getDefaults: () => defaults,
 };

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -129,13 +129,6 @@ const defaults = {
         timestamp_format: 'YYYY-MM-DD HH:mm:ss',
     },
     external_converters: [],
-    env_var_tests: {
-        string_val: 'test value',
-        boolean_val: true,
-        number_val: 1,
-        object_val: {property: 'test value'},
-        array_val: ['one', 'two'],
-    },
 };
 
 const schema = {
@@ -291,17 +284,6 @@ const schema = {
                     },
                     required: ['friendly_name'],
                 },
-            },
-        },
-        env_var_tests: {
-            type: 'object',
-            properties: {
-                string_val: {type: 'string'},
-                boolean_val: {type: 'boolean'},
-                number_val: {type: 'number'},
-                object_val: {type: 'object'},
-                array_val: {type: 'array'},
-                empty_object: {type: 'object'},
             },
         },
     },
@@ -463,7 +445,7 @@ function applyEnvironmentVariables(settings) {
                 if (key !== 'properties') {
                     const type = (obj[key].type || 'object').toString();
                     const envPart = path.reduce((acc, val) => `${acc}${val}_`, '');
-                    const envVariableName = (`ZIGBEE2MQTT_${envPart}${key}`).toUpperCase();
+                    const envVariableName = (`ZIGBEE2MQTT_CONFIG_${envPart}${key}`).toUpperCase();
                     if (process.env[envVariableName]) {
                         const setting = path.reduce((acc, val, index) => {
                             acc[val] = acc[val] || {};

--- a/lib/util/settings.js
+++ b/lib/util/settings.js
@@ -811,8 +811,5 @@ module.exports = {
     _clear: () => {
         _settings = null;
     },
-    _getDefaults: () => {
-        applyEnvironmentVariables(defaults);
-        return defaults;
-    },
+    _getDefaults: () => defaults,
 };

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -9,6 +9,7 @@ const devicesFile = data.joinPath('devices.yaml');
 const groupsFile = data.joinPath('groups.yaml');
 const secretFile = data.joinPath('secret.yaml');
 const yaml = require('js-yaml');
+const objectAssignDeep = require(`object-assign-deep`);
 
 const minimalConfig = {
     permit_join: true,
@@ -29,7 +30,7 @@ describe('Settings', () => {
     }
     const clearEnvironmentVariables = () => {
         Object.keys(process.env).forEach((key) => { 
-            if(key.indexOf('ZIGBEE2MQTT_') >= 0) {
+            if(key.indexOf('ZIGBEE2MQTT_CONFIG_') >= 0) {
                 delete process.env[key];
             }
         });
@@ -62,37 +63,41 @@ describe('Settings', () => {
     });
 
     it('Should apply environment variables', () => {
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_STRING_VAL'] = 'test value';
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_NUMBER_VAL'] = 1;
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_BOOLEAN_VAL'] = 'true';
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_OBJECT_VAL'] = '{"property": "test value"}';
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_ARRAY_VAL'] = '["one", "two"]';
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_EMPTY_OBJECT'] = '{"property": "test value"}';
+        process.env['ZIGBEE2MQTT_CONFIG_SERIAL_DISABLE_LED'] = 'true';
+        process.env['ZIGBEE2MQTT_CONFIG_ADVANCED_SOFT_RESET_TIMEOUT'] = 1;
+        process.env['ZIGBEE2MQTT_CONFIG_EXPERIMENTAL_OUTPUT'] = 'csvtest';
+        process.env['ZIGBEE2MQTT_CONFIG_ADVANCED_AVAILABILITY_BLOCKLIST'] = '["0x43597f0dac781b1e", "x223b0aef2ae8d1b0"]';
+        process.env['ZIGBEE2MQTT_CONFIG_MAP_OPTIONS_GRAPHVIZ_COLORS_FILL'] = '{"enddevice": "#ff0000", "coordinator": "#00ff00", "router": "#0000ff"}';
+        process.env['ZIGBEE2MQTT_CONFIG_MQTT_BASE_TOPIC'] = 'testtopic';
 
         write(configurationFile, {});
         const s = settings.get();
-        const expected = settings._getDefaults();
+        const expected = objectAssignDeep.noMutate({}, settings._getDefaults());
         expected.devices = {};
         expected.groups = {};
-        expected.env_var_tests.empty_object = {property: 'test value'}
+        expected.serial.disable_led = true;
+        expected.advanced.soft_reset_timeout = 1;
+        expected.experimental.output = 'csvtest';
+        expected.advanced.availability_blocklist = ['0x43597f0dac781b1e', 'x223b0aef2ae8d1b0'];
+        expected.map_options.graphviz.colors.fill = {enddevice: '#ff0000', coordinator: '#00ff00', router: '#0000ff'};
+        expected.mqtt.base_topic = 'testtopic';
 
         expect(s).toStrictEqual(expected);
     });
 
-    it('Should apply environment variables not matching defaults', () => {
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_STRING_VAL'] = 'test value 1';
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_NUMBER_VAL'] = 2;
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_BOOLEAN_VAL'] = 'false';
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_OBJECT_VAL'] = '{"property": "test value 1"}';
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_ARRAY_VAL'] = '["one", "two 1"]';
-        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_EMPTY_OBJECT'] = '{"property": "test value 1"}';
+    it('Should apply environment variables and not match defaults', () => {
+        process.env['ZIGBEE2MQTT_CONFIG_SERIAL_DISABLE_LED'] = 'true';
+        process.env['ZIGBEE2MQTT_CONFIG_ADVANCED_SOFT_RESET_TIMEOUT'] = 1;
+        process.env['ZIGBEE2MQTT_CONFIG_EXPERIMENTAL_OUTPUT'] = 'csvtest';
+        process.env['ZIGBEE2MQTT_CONFIG_ADVANCED_AVAILABILITY_BLOCKLIST'] = '["0x43597f0dac781b1e", "x223b0aef2ae8d1b0"]';
+        process.env['ZIGBEE2MQTT_CONFIG_MAP_OPTIONS_GRAPHVIZ_COLORS_FILL'] = '{"enddevice": "#ff0000", "coordinator": "#00ff00", "router": "#0000ff"}';
+        process.env['ZIGBEE2MQTT_CONFIG_MQTT_BASE_TOPIC'] = 'testtopic';
 
         write(configurationFile, {});
         const s = settings.get();
-        const expected = settings._getDefaults();
+        const expected = objectAssignDeep.noMutate({}, settings._getDefaults());
         expected.devices = {};
         expected.groups = {};
-        expected.env_var_tests.empty_object = {property: 'test value'}
 
         expect(s).not.toStrictEqual(expected);
     });

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -85,23 +85,6 @@ describe('Settings', () => {
         expect(s).toStrictEqual(expected);
     });
 
-    it('Should apply environment variables and not match defaults', () => {
-        process.env['ZIGBEE2MQTT_CONFIG_SERIAL_DISABLE_LED'] = 'true';
-        process.env['ZIGBEE2MQTT_CONFIG_ADVANCED_SOFT_RESET_TIMEOUT'] = 1;
-        process.env['ZIGBEE2MQTT_CONFIG_EXPERIMENTAL_OUTPUT'] = 'csvtest';
-        process.env['ZIGBEE2MQTT_CONFIG_ADVANCED_AVAILABILITY_BLOCKLIST'] = '["0x43597f0dac781b1e", "x223b0aef2ae8d1b0"]';
-        process.env['ZIGBEE2MQTT_CONFIG_MAP_OPTIONS_GRAPHVIZ_COLORS_FILL'] = '{"enddevice": "#ff0000", "coordinator": "#00ff00", "router": "#0000ff"}';
-        process.env['ZIGBEE2MQTT_CONFIG_MQTT_BASE_TOPIC'] = 'testtopic';
-
-        write(configurationFile, {});
-        const s = settings.get();
-        const expected = objectAssignDeep.noMutate({}, settings._getDefaults());
-        expected.devices = {};
-        expected.groups = {};
-
-        expect(s).not.toStrictEqual(expected);
-    });
-
     it('Should add devices', () => {
         write(configurationFile, {});
         settings.addDevice('0x12345678');

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -79,6 +79,24 @@ describe('Settings', () => {
         expect(s).toStrictEqual(expected);
     });
 
+    it('Should apply environment variables not matching defaults', () => {
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_STRING_VAL'] = 'test value 1';
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_NUMBER_VAL'] = 2;
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_BOOLEAN_VAL'] = 'false';
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_OBJECT_VAL'] = '{"property": "test value 1"}';
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_ARRAY_VAL'] = '["one", "two 1"]';
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_EMPTY_OBJECT'] = '{"property": "test value 1"}';
+
+        write(configurationFile, {});
+        const s = settings.get();
+        const expected = settings._getDefaults();
+        expected.devices = {};
+        expected.groups = {};
+        expected.env_var_tests.empty_object = {property: 'test value'}
+
+        expect(s).not.toStrictEqual(expected);
+    });
+
     it('Should add devices', () => {
         write(configurationFile, {});
         settings.addDevice('0x12345678');

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -27,11 +27,19 @@ describe('Settings', () => {
     const remove = (file) => {
         if (fs.existsSync(file)) fs.unlinkSync(file);
     }
+    const clearEnvironmentVariables = () => {
+        Object.keys(process.env).forEach((key) => { 
+            if(key.indexOf('ZIGBEE2MQTT_') >= 0) {
+                delete process.env[key];
+            }
+        });
+    }
 
     beforeEach(() => {
         remove(configurationFile);
         remove(devicesFile);
         remove(groupsFile);
+        clearEnvironmentVariables();
     });
 
     it('Should return default settings', () => {
@@ -50,6 +58,24 @@ describe('Settings', () => {
         expected.devices = {};
         expected.groups = {};
         expected.permit_join = true;
+        expect(s).toStrictEqual(expected);
+    });
+
+    it('Should apply environment variables', () => {
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_STRING_VAL'] = 'test value';
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_NUMBER_VAL'] = 1;
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_BOOLEAN_VAL'] = 'true';
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_OBJECT_VAL'] = '{"property": "test value"}';
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_ARRAY_VAL'] = '["one", "two"]';
+        process.env['ZIGBEE2MQTT_ENV_VAR_TESTS_EMPTY_OBJECT'] = '{"property": "test value"}';
+
+        write(configurationFile, {});
+        const s = settings.get();
+        const expected = settings._getDefaults();
+        expected.devices = {};
+        expected.groups = {};
+        expected.env_var_tests.empty_object = {property: 'test value'}
+
         expect(s).toStrictEqual(expected);
     });
 


### PR DESCRIPTION
I need to be able to manage settings on this service via Environment Variables.   I've added the ability to override anything in the settings schema with a corresponding environment variable.  

e.g. to override settings.serial.port you can set ZIGBEE2MQTT_SERIAL_PORT=/dev/ttyS0
to override the mqtt username you can set ZIGBEE2MQTT_MQTT_USER=testusername

This new addition will not perform any action on existing installations unless the matching environment variable is set.  I have tested this setting string, number, boolean, object and array values.