### PR TITLE
Return friendlyNames as answer to get_group_membership

### DIFF
--- a/lib/extension/legacy/deviceGroupMembership.js
+++ b/lib/extension/legacy/deviceGroupMembership.js
@@ -29,7 +29,7 @@ class DeviceGroupMembership extends Extension {
             `genGroups`, 'getMembership', {groupcount: 0, grouplist: []}, {}, true,
         );
 
-        if(!response) {
+        if (!response) {
             logger.warn(`Couldn't get group membership of ${entity.device.ieeeAddr}`);
             return;
         }

--- a/lib/extension/legacy/deviceGroupMembership.js
+++ b/lib/extension/legacy/deviceGroupMembership.js
@@ -29,7 +29,13 @@ class DeviceGroupMembership extends Extension {
             `genGroups`, 'getMembership', {groupcount: 0, grouplist: []}, {}, true,
         );
 
-        const {grouplist, capacity} = response;
+        let {grouplist, capacity} = response;
+
+        grouplist = grouplist.map(gid => {
+            let g = settings.getGroup(gid);
+            return g ? g.friendlyName : gid;
+        });
+        
         const msgGroupList = `${entity.device.ieeeAddr} is in groups [${grouplist}]`;
         let msgCapacity;
         if (capacity === 254) {

--- a/lib/extension/legacy/deviceGroupMembership.js
+++ b/lib/extension/legacy/deviceGroupMembership.js
@@ -29,6 +29,11 @@ class DeviceGroupMembership extends Extension {
             `genGroups`, 'getMembership', {groupcount: 0, grouplist: []}, {}, true,
         );
 
+        if(!response) {
+            logger.warn(`Couldn't get group membership of ${entity.device.ieeeAddr}`);
+            return;
+        }
+
         let {grouplist, capacity} = response;
 
         grouplist = grouplist.map((gid) => {

--- a/lib/extension/legacy/deviceGroupMembership.js
+++ b/lib/extension/legacy/deviceGroupMembership.js
@@ -31,11 +31,11 @@ class DeviceGroupMembership extends Extension {
 
         let {grouplist, capacity} = response;
 
-        grouplist = grouplist.map(gid => {
-            let g = settings.getGroup(gid);
+        grouplist = grouplist.map((gid) => {
+            const g = settings.getGroup(gid);
             return g ? g.friendlyName : gid;
         });
-        
+
         const msgGroupList = `${entity.device.ieeeAddr} is in groups [${grouplist}]`;
         let msgCapacity;
         if (capacity === 254) {


### PR DESCRIPTION
It would be a lot more useful, if you'd return the friendly names of the groups :wink: