### PR TITLE
Add OWON WSP404 Smart Plug to Home Assistant MQTT

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1922,6 +1922,7 @@ const mapping = {
     'SR-ZG9001T4-DIM-EU': [cfg.sensor_action],
     '929002335001': [cfg.light_brightness],
     '43084': [cfg.switch],
+    'WSP404': [cfg.switch, cfg.sensor_power, cfg.sensor_energy],
 };
 
 const defaultStatusTopic = 'homeassistant/status';


### PR DESCRIPTION
Device with switch, power sensor and energy measurements entities.