### PR TITLE
Add support for Centralite 4200-C Smart Outlet in homeassistant.js

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1705,6 +1705,7 @@ const mapping = {
     '3460-L': [cfg.sensor_action, cfg.sensor_temperature, cfg.sensor_battery],
     '3157100': [climate(10, 30, 'occupied_heating_setpoint', 1, ['off', 'heat', 'cool'],
         ['auto', 'on'], [], true, true), cfg.sensor_battery],
+    '4200-C': [cfg.switch],
     '4257050-RZHAC': [cfg.switch, cfg.sensor_power],
     '27087-03': [cfg.switch, cfg.sensor_battery],
     '99140-002': [cfg.lock, cfg.sensor_battery],


### PR DESCRIPTION
Support for this device was added under: Koenkk/zigbee-herdsman-converters [PR 1578](https://github.com/Koenkk/zigbee-herdsman-converters/pull/1578)