### PR TITLE
Update Sinope TH1123ZB, TH1124ZB and TH1300ZB for Home Assistant

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1428,7 +1428,7 @@ const mapping = {
     'LVS-SN10ZW': [cfg.sensor_battery, cfg.binary_sensor_occupancy],
     'LVS-ZB15R': [cfg.switch],
     'TH1123ZB': [
-        climate(7, 30, 'occupied_heating_setpoint', 0,5), cfg.sensor_local_temperature,
+        climate(7, 30, 'occupied_heating_setpoint', 0.5), cfg.sensor_local_temperature,
         cfg.lock_keypad_lockout, cfg.sensor_power, cfg.sensor_energy,
     ],
     'TH1124ZB': [

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1428,12 +1428,15 @@ const mapping = {
     'LVS-SN10ZW': [cfg.sensor_battery, cfg.binary_sensor_occupancy],
     'LVS-ZB15R': [cfg.switch],
     'TH1123ZB': [
-        climate(7, 30, 'occupied_heating_setpoint', 1.0), cfg.sensor_local_temperature,
-        cfg.lock_keypad_lockout, cfg.sensor_power,
+        climate(7, 30, 'occupied_heating_setpoint', 0,5), cfg.sensor_local_temperature,
+        cfg.lock_keypad_lockout, cfg.sensor_power, cfg.sensor_energy,
     ],
-    'TH1124ZB': [climate()],
+    'TH1124ZB': [
+        climate(7, 30, 'occupied_heating_setpoint', 0.5), cfg.sensor_local_temperature,
+        cfg.lock_keypad_lockout, cfg.sensor_power, cfg.sensor_energy,
+    ],
     'TH1300ZB': [
-        climate(7, 30, 'occupied_heating_setpoint', 0.5),
+        climate(7, 30, 'occupied_heating_setpoint', 0.5), cfg.sensor_local_temperature,
         cfg.lock_keypad_lockout,
     ],
     'TH1400ZB': [climate()],


### PR DESCRIPTION
Uniformized Home Assistant behavior/features for Sinope baseboards and floor thermostats.
TH1123ZB, TH1124ZB and TH1300ZB:
- change temperature setpoint resolution to 0,5C

TH1123ZB, and TH1124ZB:
- add energy entity
TH1124ZB and TH1300ZB:
- add local temperature entity

TH1124ZB:
- add keypad lockout (climate entity attribute)
- add power entity