### PR TITLE
allow to redefine homeassistant autodiscovery entity "type" and "object_id"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Frontend issues
+    url: https://github.com/nurikk/z2m-frontend/issues
+    about: Issues related to the frontend.
   - name: Home Assistant addon issues
     url: https://github.com/danielwelch/hassio-zigbee2mqtt/issues
     about: Issues related to the Home Assistant addon.

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1675,7 +1675,6 @@ class HomeAssistant extends Extension {
 
         const friendlyName = resolvedEntity.settings.friendlyName;
         this.getConfigs(resolvedEntity).forEach((config) => {
-            const topic = this.getDiscoveryTopic(config, device);
             const payload = {...config.discovery_payload};
             let stateTopic = `${settings.get().mqtt.base_topic}/${friendlyName}`;
             if (payload.state_topic_postfix) {
@@ -1842,6 +1841,7 @@ class HomeAssistant extends Extension {
                 }
             }
 
+            const topic = this.getDiscoveryTopic(config, device);
             this.mqtt.publish(topic, stringify(payload), {retain: true, qos: 0}, this.discoveryTopic);
         });
 


### PR DESCRIPTION
By moving the creation of the autodiscovery topic at the end of the discovery function (just before the mqtt publish of the autodiscovery payload) we allow for increased customisation of entities.
For example it becomes possible to redefine switches as lights (without having to create a device mapping in homeassistant)

example of redefinition of a TS0012 (dual gang zigbee switch):

```yaml
"0x0000000000000000":
  friendly_name: My Switch
  retain: true
  homeassistant:
    switch_left:
      type: light
      object_id: light_left
      name: My Switch - Upstair light
    switch_right:
      type: light
      object_id: light_right
      name: My Switch - Downstair light
```

the autodiscoery topics become
- `homeassistant/switch/0x0000000000000000/switch_left` => `homeassistant/light/0x0000000000000000/light_left` 
- `homeassistant/switch/0x0000000000000000/switch_right` => `homeassistant/light/0x0000000000000000/light_right` 