### PR TITLE
Fix for HEIMAN Smart socket HS2SK (NXP version) haElectricalMeasurement.

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1025,6 +1025,7 @@ const manualMaping = {
         cfg.sensor_power, cfg.sensor_temperature, cfg.sensor_consumption,
     ],
     'HS2SK': [cfg.switch, cfg.sensor_power, cfg.sensor_voltage, cfg.sensor_current],
+    'HS2SK_nxp': [cfg.switch, cfg.sensor_power, cfg.sensor_voltage, cfg.sensor_current],
     'HS2SS': [cfg.sensor_action, cfg.sensor_battery],
     '45853GE': [cfg.switch, cfg.sensor_power],
     '3315-G': [


### PR DESCRIPTION
Device does not support reporting. Need to poll.