### PR TITLE
Allow redefine autodiscovery type

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1574,6 +1574,19 @@ class HomeAssistant extends Extension {
             configs = configs.filter((c) => c !== cfg.sensor_action && c !== cfg.sensor_click);
         }
 
+        // deep clone of the config objects
+        configs = JSON.parse(JSON.stringify(configs));
+
+        if (resolvedEntity.settings.hasOwnProperty('homeassistant')) {
+            configs.forEach((config) => {
+                const configOverride = resolvedEntity.settings.homeassistant[config.object_id];
+                if (configOverride) {
+                    config.object_id = configOverride.object_id || config.object_id;
+                    config.type = configOverride.type || config.type;
+                }
+            });
+        }
+
         return configs;
     }
 
@@ -1735,7 +1748,9 @@ class HomeAssistant extends Extension {
             if (resolvedEntity.settings.hasOwnProperty('homeassistant')) {
                 const add = (obj) => {
                     Object.keys(obj).forEach((key) => {
-                        if (['number', 'string', 'boolean'].includes(typeof obj[key])) {
+                        if (['type', 'object_id'].includes(key)) {
+                            return;
+                        } else if (['number', 'string', 'boolean'].includes(typeof obj[key])) {
                             payload[key] = obj[key];
                         } else if (obj[key] === null) {
                             delete payload[key];

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -395,7 +395,7 @@ describe('HomeAssistant extension', () => {
               "manufacturer": "Xiaomi",
               "model": "Aqara single key wired wall switch without neutral wire. Doesn't work as a router and doesn't support power meter (QBKG04LM)",
               "name": "my_switch",
-              "sw_version": "Zigbee2MQTT 1.15.0-dev"
+              "sw_version": this.version
             },
             "json_attributes_topic": "zigbee2mqtt/my_switch",
             "name": "my_light_name_override",


### PR DESCRIPTION
Unfortunately the previous PR (#4593 ) was incorrect as it was merging the `type` and `object_id` into the payload instead of the config. 
This solves the issue by moving the `type`/`object_id` override logic to the right place, the `getConfigs` method