### PR TITLE
feat: Add support for Nue / 3A Door Sensor

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -2087,6 +2087,7 @@ const mapping = {
     'TS0601_switch_3_gang': [switchEndpoint('l1'), switchEndpoint('l2'), switchEndpoint('l3')],
     '4655BC0-R': [cfg.binary_sensor_contact, cfg.binary_sensor_battery_low],
     'T2011': [cfg.light_brightness_colortemp],
+    'HGZB-13A': [cfg.binary_sensor_contact],
 };
 
 const defaultStatusTopic = 'homeassistant/status';


### PR DESCRIPTION
Support the Nue / 3A contact sensor for home assistant.