### PR TITLE
backup.sh: check old data-backup dir

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+if [ -d data-backup ]; then
+   echo "ERROR: Backup directory exists. May be previous restoring was failed?"
+   echo "1. Save 'data-backup' and 'data' dirs to safe location to make possibility to restore config later."
+   echo "2. Manually delete 'data-backup' dir and try again."
+   exit 1
+fi
+
 echo "Stopping Zigbee2MQTT..."
 sudo systemctl stop zigbee2mqtt
 


### PR DESCRIPTION
Sometimes, after unsuccessful restore, `data-backup` still exists.

I added some code to check this case.