### PR TITLE
Enhanced MQTT logging when connecting

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -44,8 +44,11 @@ class MQTT extends events.EventEmitter {
         }
 
         if (mqttSettings.user && mqttSettings.password) {
+            logger.info(`Using MQTT login with username: ${mqttSettings.user}`);
             options.username = mqttSettings.user;
             options.password = mqttSettings.password;
+        } else {
+            logger.info(`Using MQTT anonymous login`);
         }
 
         if (mqttSettings.client_id) {

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -44,11 +44,11 @@ class MQTT extends events.EventEmitter {
         }
 
         if (mqttSettings.user && mqttSettings.password) {
-            logger.info(`Using MQTT login with username: ${mqttSettings.user}`);
+            logger.debug(`Using MQTT login with username: ${mqttSettings.user}`);
             options.username = mqttSettings.user;
             options.password = mqttSettings.password;
         } else {
-            logger.info(`Using MQTT anonymous login`);
+            logger.debug(`Using MQTT anonymous login`);
         }
 
         if (mqttSettings.client_id) {


### PR DESCRIPTION
Hi @Koenkk , since it took me over three days to find a misconfiguration on my site (used `username` instead of `user` in my `configuration.yaml`), I decided to enhance the logging for the connection part of MQTT to be more transparent and hopefully prevent such investigations in the future.