### PR TITLE
Support for some noname switch identified as ZSTY-SM-11ZG-US-W

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -369,6 +369,7 @@ const manualMaping = {
         climate(5, 30, 'current_heating_setpoint', 0.5, ['off', 'heat'], [], ['manual', 'auto']),
     ],
     'HY08WE': [climate(5, 30, 'current_heating_setpoint', 0.5)],
+    'ZSTY-SM-11ZG-US-W': [cfg.switch],
 };
 
 const defaultStatusTopic = 'homeassistant/status';


### PR DESCRIPTION
It's already present in `zigbee-herdsman-converters` with config:
```
    {
        zigbeeModel: ['tdtqgwv'],
        model: 'ZSTY-SM-11ZG-US-W',
        vendor: ' Somgoms',
        description: '1 gang switch',
        extend: generic.switch,
        fromZigbee: [fz.tuya_switch2, fz.ignore_time_read, fz.ignore_basic_report],
        toZigbee: [tz.tuya_switch_state],
    },
```