### PR TITLE
Log zigbee-herdsman version on startup

### DIFF
--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -72,7 +72,7 @@ async function getZigbee2mqttVersion() {
 async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
         const git = require('git-last-commit');
-        const packageJSON = require('../node_modules/zigbee-herdsman/package.json');
+        const packageJSON = require('../../node_modules/zigbee-herdsman/package.json');
         const version = packageJSON.version;
 
         git.getLastCommit((err, commit) => {
@@ -80,7 +80,7 @@ async function getZigbeeHerdsmanVersion() {
 
             if (err) {
                 try {
-                    commitHash = require('../node_modules/zigbee-herdsman/.hash.json').hash;
+                    commitHash = require('../../node_modules/zigbee-herdsman/.hash.json').hash;
                 } catch (error) {
                     commitHash = 'unknown';
                 }

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -69,6 +69,30 @@ async function getZigbee2mqttVersion() {
     });
 }
 
+async function getZigbeeHerdsmanVersion() {
+    return new Promise((resolve, reject) => {
+        const git = require('git-last-commit');
+        const packageJSON = require('../node_modules/zigbee-herdsman/package.json');
+        const version = packageJSON.version;
+
+        git.getLastCommit((err, commit) => {
+            let commitHash = null;
+
+            if (err) {
+                try {
+                    commitHash = require('../node_modules/zigbee-herdsman/.hash.json').hash;
+                } catch (error) {
+                    commitHash = 'unknown';
+                }
+            } else {
+                commitHash = commit.shortHash;
+            }
+
+            resolve({commitHash, version});
+        });
+    });
+}
+
 function formatDate(date, type) {
     let result;
 

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -73,7 +73,6 @@ async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
         const packageJSON = require('../../node_modules/zigbee-herdsman/package.json');
         const version = packageJSON.version;
-        const commitHash = null;
         resolve({version});
     });
 }

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -74,8 +74,7 @@ async function getZigbeeHerdsmanVersion() {
         const git = require('git-last-commit');
         const packageJSON = require('../node_modules/zigbee-herdsman/package.json');
         const version = packageJSON.version;
-        let commitHash = null
-        resolve({commitHash, version});
+        resolve({version});
     });
 }
 

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -72,7 +72,7 @@ async function getZigbee2mqttVersion() {
 async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
         const git = require('git-last-commit');
-        const packageJSON = require('../node_modules/zigbee-herdsman/package.json');
+        const packageJSON = require('../../node_modules/zigbee-herdsman/package.json');
         const version = packageJSON.version;
         git.getLastCommit((err, commit) => {
             let commitHash = null;

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -71,7 +71,6 @@ async function getZigbee2mqttVersion() {
 
 async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
-        const git = require('git-last-commit');
         const packageJSON = require('../node_modules/zigbee-herdsman/package.json');
         const version = packageJSON.version;
         resolve({version});

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -73,7 +73,7 @@ async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
         const git = require('git-last-commit');
         const packageJSON = require('../../node_modules/zigbee-herdsman/package.json');
-        const version = packageJSON.version;
+        const versionHerdsman = packageJSON.version;
         git.getLastCommit((err, commit) => {
             let commitHash = null;
 
@@ -83,7 +83,7 @@ async function getZigbeeHerdsmanVersion() {
                 commitHash = commit.shortHash;
             }
 
-            resolve({commitHash, version});
+            resolve({commitHash, versionHerdsman});
         });    
     });
 }

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -192,7 +192,7 @@ module.exports = {
     millisecondsToSeconds: (milliseconds) => milliseconds / 1000,
     secondsToMilliseconds: (seconds) => seconds * 1000,
     getZigbee2mqttVersion,
-    getZigbeeHerdsmanVersion,
+    getDependVersion,
     objectHasProperties,
     toSnakeCase,
     getObjectProperty,

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -72,24 +72,10 @@ async function getZigbee2mqttVersion() {
 async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
         const git = require('git-last-commit');
-        const packageJSON = require('../../node_modules/zigbee-herdsman/package.json');
+        const packageJSON = require('../node_modules/zigbee-herdsman/package.json');
         const version = packageJSON.version;
-
-        git.getLastCommit((err, commit) => {
-            let commitHash = null;
-
-            if (err) {
-                try {
-                    commitHash = require('../../node_modules/zigbee-herdsman/.hash.json').hash;
-                } catch (error) {
-                    commitHash = 'unknown';
-                }
-            } else {
-                commitHash = commit.shortHash;
-            }
-
-            resolve({commitHash, version});
-        });
+        let commitHash = null
+        resolve({commitHash, version});
     });
 }
 

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -69,9 +69,9 @@ async function getZigbee2mqttVersion() {
     });
 }
 
-async function getZigbeeHerdsmanVersion() {
+async function getDependVersion(depend) {
     return new Promise((resolve, reject) => {
-        const packageJSON = require('../../node_modules/zigbee-herdsman/package.json');
+        const packageJSON = require('../../node_modules/'+depend+'/package.json');
         const version = packageJSON.version;
         resolve({version});
     });

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -71,9 +71,20 @@ async function getZigbee2mqttVersion() {
 
 async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
+        const git = require('git-last-commit');
         const packageJSON = require('../node_modules/zigbee-herdsman/package.json');
         const version = packageJSON.version;
-        resolve({version});
+        git.getLastCommit((err, commit) => {
+            let commitHash = null;
+
+            if (err) {
+                    commitHash = 'unknown';
+            } else {
+                commitHash = commit.shortHash;
+            }
+
+            resolve({commitHash, version});
+        });    
     });
 }
 

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -72,9 +72,9 @@ async function getZigbee2mqttVersion() {
 async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
         const packageJSON = require('../../node_modules/zigbee-herdsman/package.json');
-        const versionHerdsman = packageJSON.version;
+        const version = packageJSON.version;
         const commitHash = null;
-        resolve({commitHash, versionHerdsman});
+        resolve({version});
     });
 }
 

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -71,20 +71,10 @@ async function getZigbee2mqttVersion() {
 
 async function getZigbeeHerdsmanVersion() {
     return new Promise((resolve, reject) => {
-        const git = require('git-last-commit');
         const packageJSON = require('../../node_modules/zigbee-herdsman/package.json');
         const versionHerdsman = packageJSON.version;
-        git.getLastCommit((err, commit) => {
-            let commitHash = null;
-
-            if (err) {
-                    commitHash = 'unknown';
-            } else {
-                commitHash = commit.shortHash;
-            }
-
-            resolve({commitHash, versionHerdsman});
-        });    
+        const commitHash = null;
+        resolve({commitHash, versionHerdsman});
     });
 }
 

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -208,6 +208,7 @@ module.exports = {
     millisecondsToSeconds: (milliseconds) => milliseconds / 1000,
     secondsToMilliseconds: (seconds) => seconds * 1000,
     getZigbee2mqttVersion,
+    getZigbeeHerdsmanVersion,
     objectHasProperties,
     toSnakeCase,
     getObjectProperty,

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -69,7 +69,7 @@ async function getZigbee2mqttVersion() {
     });
 }
 
-async function getDependVersion(depend) {
+async function getDependencyVersion(depend) {
     return new Promise((resolve, reject) => {
         const packageJSON = require('../../node_modules/'+depend+'/package.json');
         const version = packageJSON.version;
@@ -192,7 +192,7 @@ module.exports = {
     millisecondsToSeconds: (milliseconds) => milliseconds / 1000,
     secondsToMilliseconds: (seconds) => seconds * 1000,
     getZigbee2mqttVersion,
-    getDependVersion,
+    getDependencyVersion,
     objectHasProperties,
     toSnakeCase,
     getObjectProperty,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,8 +19,8 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        const infoHerdsman = await utils.getZigbeeHerdsmanVersion();
-        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
+//        const infoHerdsman = await utils.getZigbeeHerdsmanVersion();
+//        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {
                 panID: settings.get().advanced.pan_id,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,9 +19,9 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        var dependency = 'zigbee-herdsman';
-        //const infoHerdsman = await utils.getZigbeeHerdsmanVersion(dependency);
-        //logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
+        const dependency = 'zigbee-herdsman';
+        const infoHerdsman = await utils.getDependVersion(dependency);
+        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {
                 panID: settings.get().advanced.pan_id,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,8 +19,8 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        //const infoHerdsman = await utils.getZigbeeHerdsmanVersion(zigbee-herdsman);
-        //logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
+        const infoHerdsman = await utils.getZigbeeHerdsmanVersion('zigbee-herdsman');
+        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {
                 panID: settings.get().advanced.pan_id,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,7 +19,7 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        const infoHerdsman = await utils.getZigbeeHerdsmanVersion();
+        const infoHerdsman = await utils.getZigbeeHerdsmanVersion(zigbee-herdsman);
         logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,8 +19,8 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        const infoHerdsman = await utils.getZigbeeHerdsmanVersion(zigbee-herdsman);
-        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
+        //const infoHerdsman = await utils.getZigbeeHerdsmanVersion(zigbee-herdsman);
+        //logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {
                 panID: settings.get().advanced.pan_id,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -20,8 +20,8 @@ class Zigbee extends events.EventEmitter {
 
     async start() {
         var dependency = 'zigbee-herdsman';
-        const infoHerdsman = await utils.getZigbeeHerdsmanVersion(dependency);
-        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
+        //const infoHerdsman = await utils.getZigbeeHerdsmanVersion(dependency);
+        //logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {
                 panID: settings.get().advanced.pan_id,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,7 +19,7 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        const dependency = 'zigbee-herdsman';
+        var dependency = 'zigbee-herdsman';
         const infoHerdsman = await utils.getZigbeeHerdsmanVersion(dependency);
         logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,9 +19,8 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        const dependency = 'zigbee-herdsman';
-        const infoHerdsman = await utils.getDependVersion(dependency);
-        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
+        const infoHerdsman = await utils.getDependVersion('zigbee-herdsman');
+        logger.info(`Starting zigbee-herdsman (${infoHerdsman.version})`);
         const herdsmanSettings = {
             network: {
                 panID: settings.get().advanced.pan_id,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,8 +19,8 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-//        const infoHerdsman = await utils.getZigbeeHerdsmanVersion();
-//        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
+        const infoHerdsman = await utils.getZigbeeHerdsmanVersion();
+        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {
                 panID: settings.get().advanced.pan_id,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,7 +19,8 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        logger.info(`Starting zigbee-herdsman...`);
+        const infoHerdsman = await utils.getZigbeeHerdsmanVersion();
+        logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {
                 panID: settings.get().advanced.pan_id,

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,7 +19,7 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        const infoHerdsman = await utils.getDependVersion('zigbee-herdsman');
+        const infoHerdsman = await utils.getDependencyVersion('zigbee-herdsman');
         logger.info(`Starting zigbee-herdsman (${infoHerdsman.version})`);
         const herdsmanSettings = {
             network: {

--- a/lib/zigbee.js
+++ b/lib/zigbee.js
@@ -19,7 +19,8 @@ class Zigbee extends events.EventEmitter {
     }
 
     async start() {
-        const infoHerdsman = await utils.getZigbeeHerdsmanVersion('zigbee-herdsman');
+        const dependency = 'zigbee-herdsman';
+        const infoHerdsman = await utils.getZigbeeHerdsmanVersion(dependency);
         logger.info(`Starting zigbee-herdsman ${infoHerdsman.version}`);
         const herdsmanSettings = {
             network: {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -36,9 +36,11 @@ describe('Utils', () => {
 
         mockReturnValue = [false, {shortHash: '123'}]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "123", "version": version});
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "123", "version": version});
 
         mockReturnValue = [true, null]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "unknown", "version": version});
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "unknown", "version": version});        
     })
 
     it('To local iso string', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -45,7 +45,7 @@ describe('Utils', () => {
     })
 
     it('Check Dependency Version', async () => {
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});
+        expect(await utils.getDependVersion(zigbee-herdsman)).toStrictEqual({"version": versionHerdsman});
     })
     
     it('To local iso string', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -37,16 +37,14 @@ describe('Utils', () => {
 
         mockReturnValue = [false, {shortHash: '123'}]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "123", "version": version});
-//        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});
 
         mockReturnValue = [true, null]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "unknown", "version": version});
-//      expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});      
     })
 
-    it('Check Dependency Version', async () => {
+    it('Check dependency version', async () => {
         var dependency = 'zigbee-herdsman';
-        expect(await utils.getDependVersion(dependency)).toStrictEqual({"version": versionHerdsman});
+        expect(await utils.getDependencyVersion(dependency)).toStrictEqual({"version": versionHerdsman});
     })
     
     it('To local iso string', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,6 @@
 const utils = require('../lib/util/utils.js');
 const version = require('../package.json').version;
+const versionHerdsman = require('../node_modules/zigbee-herdsman/package.json').version;
 
 describe('Utils', () => {
     describe('Is xiaomi device', () => {
@@ -36,11 +37,11 @@ describe('Utils', () => {
 
         mockReturnValue = [false, {shortHash: '123'}]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "123", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "123", "version": version});
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "123", "version": versionHerdsman});
 
         mockReturnValue = [true, null]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "unknown", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "unknown", "version": version});        
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "unknown", "version": versionHerdsman});        
     })
 
     it('To local iso string', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -37,11 +37,11 @@ describe('Utils', () => {
 
         mockReturnValue = [false, {shortHash: '123'}]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "123", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "123","version": versionHerdsman});
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});
 
         mockReturnValue = [true, null]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "unknown", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "unknown","version": versionHerdsman});        
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});        
     })
 
     it('To local iso string', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -44,6 +44,10 @@ describe('Utils', () => {
 //      expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});      
     })
 
+    it('Check Dependency Version', async () => {
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});
+    })
+    
     it('To local iso string', async () => {
         var date = new Date('August 19, 1975 23:15:30 UTC+00:00');
         var getTimezoneOffset = Date.prototype.getTimezoneOffset;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -37,11 +37,11 @@ describe('Utils', () => {
 
         mockReturnValue = [false, {shortHash: '123'}]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "123", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "123","version": versionHerdsman});
 
         mockReturnValue = [true, null]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "unknown", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});        
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "unknown","version": versionHerdsman});        
     })
 
     it('To local iso string', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -37,11 +37,11 @@ describe('Utils', () => {
 
         mockReturnValue = [false, {shortHash: '123'}]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "123", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "123", "version": versionHerdsman});
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});
 
         mockReturnValue = [true, null]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "unknown", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"commitHash": "unknown", "version": versionHerdsman});        
+        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});        
     })
 
     it('To local iso string', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -45,7 +45,8 @@ describe('Utils', () => {
     })
 
     it('Check Dependency Version', async () => {
-        expect(await utils.getDependVersion(zigbee-herdsman)).toStrictEqual({"version": versionHerdsman});
+        var dependency = 'zigbee-herdsman';
+        expect(await utils.getDependVersion(dependency)).toStrictEqual({"version": versionHerdsman});
     })
     
     it('To local iso string', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -37,11 +37,11 @@ describe('Utils', () => {
 
         mockReturnValue = [false, {shortHash: '123'}]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "123", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});
+//        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});
 
         mockReturnValue = [true, null]
         expect(await utils.getZigbee2mqttVersion()).toStrictEqual({"commitHash": "unknown", "version": version});
-        expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});        
+//      expect(await utils.getZigbeeHerdsmanVersion()).toStrictEqual({"version": versionHerdsman});      
     })
 
     it('To local iso string', async () => {


### PR DESCRIPTION
Allow current zigbee-herdsman version to be exposed to controller for logging and to startup output.