### PR TITLE
Expose `position` for compatible thermostats

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -382,6 +382,7 @@ class HomeAssistant extends Extension {
                             illuminance_lux: {device_class: 'illuminance'},
                             illuminance: {device_class: 'illuminance'},
                             soil_moisture: {icon: 'mdi:water-percent'},
+                            position: {icon: 'mdi:valve'},
                             pressure: {device_class: 'pressure'},
                             power: {icon: 'mdi:flash'},
                             linkquality: {icon: 'mdi:signal'},


### PR DESCRIPTION
This exposes an absolute position, which is number between 0% and 100%.

This allows to monitor how much open or closed is valve.

Requires: https://github.com/Koenkk/zigbee-herdsman-converters/pull/1747