### PR TITLE
Implement cli version of z2m

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const path = require('path');
+process.env['ZIGBEE2MQTT_DATA'] = process.env['ZIGBEE2MQTT_DATA'] || path.join(process.env['HOME'], '.z2m');
+require('./index');

--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
     "collectCoverageFrom": [
       "lib/**"
     ]
+  },
+  "bin": {
+    "zigbee2mqtt": "./cli.js"
   }
 }


### PR DESCRIPTION
This commit implements z2m as generic cli application. After publishing this package, users will be able to install z2m as generic npm package (no need to bother with git clone/pul/npm ci etc)

`npm install -g zigbee2mqtt`

and launch using `zigbee2mqtt` command. 
Default data folder is located in users HOME directory and called `.z2m`

example: `/Users/nur/.z2m`

CLI respects `ZIGBEE2MQTT_DATA` env variable.