### PR TITLE
Poll lamps with Philips, Atmel, Gledopto, Mueller-Licht manufacturer codes

### DIFF
--- a/lib/extension/report.js
+++ b/lib/extension/report.js
@@ -82,7 +82,10 @@ const pollOnMessage = [
         // Read the following attributes
         read: {cluster: 'genLevelCtrl', attributes: ['currentLevel']},
         // When the bound devices/members of group have the following manufacturerID
-        manufacturerID: ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
+        manufacturerIDs: [
+            ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
+            ZigbeeHerdsman.Zcl.ManufacturerCode.ATMEL,
+        ],
     },
     {
         key: 2,
@@ -98,7 +101,10 @@ const pollOnMessage = [
             ],
         },
         read: {cluster: 'genOnOff', attributes: ['onOff']},
-        manufacturerID: ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
+        manufacturerIDs: [
+            ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
+            ZigbeeHerdsman.Zcl.ManufacturerCode.ATMEL,
+        ],
     },
 ];
 
@@ -264,7 +270,7 @@ class Report extends Extension {
 
             for (const endpoint of toPoll) {
                 for (const poll of polls) {
-                    if (poll.manufacturerID !== endpoint.getDevice().manufacturerID) {
+                    if (!poll.manufacturerIDs.includes(endpoint.getDevice().manufacturerID)) {
                         continue;
                     }
 

--- a/lib/extension/report.js
+++ b/lib/extension/report.js
@@ -81,10 +81,12 @@ const pollOnMessage = [
         },
         // Read the following attributes
         read: {cluster: 'genLevelCtrl', attributes: ['currentLevel']},
-        // When the bound devices/members of group have the following manufacturerID
+        // When the bound devices/members of group have the following manufacturerIDs
         manufacturerIDs: [
             ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
             ZigbeeHerdsman.Zcl.ManufacturerCode.ATMEL,
+            ZigbeeHerdsman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
+            ZigbeeHerdsman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
         ],
     },
     {
@@ -104,6 +106,8 @@ const pollOnMessage = [
         manufacturerIDs: [
             ZigbeeHerdsman.Zcl.ManufacturerCode.Philips,
             ZigbeeHerdsman.Zcl.ManufacturerCode.ATMEL,
+            ZigbeeHerdsman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
+            ZigbeeHerdsman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
         ],
     },
 ];

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -267,7 +267,7 @@ describe('Report', () => {
         expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledTimes(2);
 
         // Should only call Hue bulb, not e.g. tradfri
-        expect(zigbeeHerdsman.devices.bulb.getEndpoint(1).read).toHaveBeenCalledTimes(0);
+        expect(zigbeeHerdsman.devices.bulb_2.getEndpoint(1).read).toHaveBeenCalledTimes(0);
     });
 
     it('Should not configure reporting for the ZNLDP12LM closuresWindowCovering as it is ignored', async () => {


### PR DESCRIPTION
This fixes #4969 by checking for both Philips and Atmel manufacturer codes (as we came to realize that Philips Hue lamps have components from both)