### PR TITLE
Fix disabling HA discovery after device was discovered

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -611,7 +611,7 @@ class HomeAssistant extends Extension {
         // deep clone of the config objects
         configs = JSON.parse(JSON.stringify(configs));
 
-        if (resolvedEntity.settings.hasOwnProperty('homeassistant')) {
+        if (resolvedEntity.settings.homeassistant) {
             configs.forEach((config) => {
                 const configOverride = resolvedEntity.settings.homeassistant[config.object_id];
                 if (configOverride) {
@@ -854,6 +854,9 @@ class HomeAssistant extends Extension {
                 const objectID = discoveryMatch[3];
                 clear = !this.getConfigs(resolvedEntity).find((c) => c.type === type && c.object_id === objectID);
             }
+            // Device was flagged to be excluded from homeassistant discovery
+            clear = clear || (resolvedEntity.settings.hasOwnProperty('homeassistant') &&
+                                !resolvedEntity.settings.homeassistant);
 
             if (clear) {
                 logger.debug(`Clearing Home Assistant config '${topic}'`);


### PR DESCRIPTION
This fixes rare case when device was published in HA discovery, and then through configuration.yaml was set homeassistant: null (to disable this device discovery)

Here is  workflow:

1) I have discovered device
2) I want to kick this device from hass discovery
3) I set device specific config homeassistant: null
4) Restart z2m
5) Device was removed from discovery

```
0|zigbee2mqtt  | Zigbee2MQTT:error 2020-12-05 13:09:22: Failed to call 'HomeAssistant' 'onMQTTMessage' (TypeError: Cannot read property 'light' of null
0|zigbee2mqtt  |     at /home/nur/.nvm/versions/node/v12.18.3/lib/node_modules/zigbee2mqtt/lib/extension/homeassistant.js:616:77
0|zigbee2mqtt  |     at Array.forEach (<anonymous>)
```