### PR TITLE
Add missing devices options to settings.schema.json

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -490,6 +490,30 @@
           "title": "QoS",
           "descritption": "QoS level for MQTT messages of this device"
         },
+        "debounce": {
+          "type": "number",
+          "title": "Debounce",
+          "description": "Debounces messages of this device"
+        },
+        "debounce_ignore": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": ["action"],
+          "title": "Ignore debounce",
+          "description": "Protects unique payload values of specified payload properties from overriding within debounce time"
+        },
+        "retrieve_state": {
+          "type": "boolean",
+          "title": "Retrieve State",
+          "description": "Retrieves the state after setting it (Should only be enabled when the reporting feature does not work for this device)"
+        },
+        "optimistic": {
+          "type": "boolean",
+          "title": "Optimistic",
+          "description": "Publish optimistic state after set (default true)"
+        },
         "filtered_attributes": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Looks like a few more were missing that just debounce: https://github.com/Koenkk/zigbee2mqtt.io/blob/05fc32d8e09bf4cc1bccfc4acb8f618ce7ab3a22/docs/information/configuration.md#device-specific-configuration