### PR TITLE
Support commandToggle and command*WithOnOff triggering polling of Hue bulbs

### DIFF
--- a/lib/extension/bind.js
+++ b/lib/extension/bind.js
@@ -71,6 +71,7 @@ const pollOnMessage = [
                 {type: 'commandMoveWithOnOff', data: {}},
                 {type: 'commandStopWithOnOff', data: {}},
                 {type: 'commandMove', data: {}},
+                {type: 'commandMoveToLevelWithOnOff', data: {}},
             ],
         },
         // Read the following attributes
@@ -85,10 +86,17 @@ const pollOnMessage = [
     },
     {
         cluster: {
+            genLevelCtrl: [
+                {type: 'commandStepWithOnOff', data: {}},
+                {type: 'commandMoveWithOnOff', data: {}},
+                {type: 'commandStopWithOnOff', data: {}},
+                {type: 'commandMoveToLevelWithOnOff', data: {}},
+            ],
             genOnOff: [
                 {type: 'commandOn', data: {}},
                 {type: 'commandOff', data: {}},
                 {type: 'commandOffWithEffect', data: {}},
+                {type: 'commandToggle', data: {}},
             ],
             manuSpecificPhilips: [
                 {type: 'commandHueNotification', data: {button: 1}},

--- a/test/bind.test.js
+++ b/test/bind.test.js
@@ -519,7 +519,7 @@ describe('Bind', () => {
         const payload = {data, cluster: 'genLevelCtrl', device: remote, endpoint: remote.getEndpoint(1), type: 'commandStepWithOnOff', linkquality: 10, groupID: 15071};
         await zigbeeHerdsman.events.message(payload);
         await flushPromises();
-        expect(debounce).toHaveBeenCalledTimes(1);
+        expect(debounce).toHaveBeenCalledTimes(2);
         expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledTimes(1);
         expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledWith("genLevelCtrl", ["currentLevel"]);
 

--- a/test/bind.test.js
+++ b/test/bind.test.js
@@ -519,9 +519,10 @@ describe('Bind', () => {
         const payload = {data, cluster: 'genLevelCtrl', device: remote, endpoint: remote.getEndpoint(1), type: 'commandStepWithOnOff', linkquality: 10, groupID: 15071};
         await zigbeeHerdsman.events.message(payload);
         await flushPromises();
-        expect(debounce).toHaveBeenCalledTimes(2);
-        expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledTimes(1);
+        expect(debounce).toHaveBeenCalledTimes(1);
+        expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledTimes(2);
         expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledWith("genLevelCtrl", ["currentLevel"]);
+        expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledWith("genOnOff", ["onOff"]);
 
         // Should also only debounce once
         await zigbeeHerdsman.events.message(payload);

--- a/test/bind.test.js
+++ b/test/bind.test.js
@@ -519,7 +519,7 @@ describe('Bind', () => {
         const payload = {data, cluster: 'genLevelCtrl', device: remote, endpoint: remote.getEndpoint(1), type: 'commandStepWithOnOff', linkquality: 10, groupID: 15071};
         await zigbeeHerdsman.events.message(payload);
         await flushPromises();
-        expect(debounce).toHaveBeenCalledTimes(1);
+        expect(debounce).toHaveBeenCalledTimes(2);
         expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledTimes(2);
         expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledWith("genLevelCtrl", ["currentLevel"]);
         expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledWith("genOnOff", ["onOff"]);

--- a/test/bind.test.js
+++ b/test/bind.test.js
@@ -527,8 +527,8 @@ describe('Bind', () => {
         // Should also only debounce once
         await zigbeeHerdsman.events.message(payload);
         await flushPromises();
-        expect(debounce).toHaveBeenCalledTimes(1);
-        expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledTimes(2);
+        expect(debounce).toHaveBeenCalledTimes(2);
+        expect(zigbeeHerdsman.devices.bulb_color_2.getEndpoint(1).read).toHaveBeenCalledTimes(4);
 
         // Should only call Hue bulb, not e.g. tradfri
         expect(zigbeeHerdsman.devices.bulb_2.getEndpoint(1).read).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
Added Zigbee commands generated by Tradfri 5-button remote (model `TRADFRI remote control`) to the list that trigger polling on Hue bulbs. Thus this PR allows the use of Tradfri 5-button remotes to control Hue bulbs just like the Hue dimmers, without having to poll them via external automation.

* The centre button sends `commandToggle` when pushed, and `commandMoveToLevelWithOnOff` when held.
* The brightness up button turns on the bulb if it was off, via `commandStepWithOnOff` (pushed) and `commandMoveWithOnOff` (held), so need to poll `genOnOff` cluster as well. (The brightness down button does _not_ turn off the bulb.)
* Other than brightness up with bulb off, brightness up/down pushes already triggered polling.