### PR TITLE
Fix use of deprecated values in HA Cover platform discovery

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -277,7 +277,7 @@ class HomeAssistant extends Extension {
 
                     if (hasPosition) {
                         discoveryEntry.discovery_payload = {...discoveryEntry.discovery_payload,
-                            value_template: '{{ value_json.position }}',
+                            position_template: '{{ value_json.position }}',
                             set_position_template: '{ "position": {{ position }} }',
                             set_position_topic: true,
                             position_topic: true,

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -669,7 +669,7 @@ describe('HomeAssistant extension', () => {
             position_topic: 'zigbee2mqtt/smart vent',
             set_position_topic: 'zigbee2mqtt/smart vent/set',
             set_position_template: '{ "position": {{ position }} }',
-            value_template: '{{ value_json.position }}',
+            position_template: '{{ value_json.position }}',
             json_attributes_topic: 'zigbee2mqtt/smart vent',
             name: 'smart vent',
             unique_id: '0x0017880104e45551_cover_zigbee2mqtt',


### PR DESCRIPTION
Home Assistant 2021.3.0 deprecates the use of `value_template` for MQTT covers, instead, it will be using `position_template` (which is a drop-in replacement).

Upstream change: <https://github.com/home-assistant/core/pull/46059>

The current method used by the Zigbee2MQTT discovery will be dropped in Home Assistant 2021.6.0 and currently generates warnings:

![image](https://user-images.githubusercontent.com/195327/109810100-641c1f00-7c29-11eb-8b44-dc8508475767.png)

