### PR TITLE
Homeassistent does not support 'sleep' as system_mode

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -162,6 +162,12 @@ class HomeAssistant extends Extension {
 
                     const mode = expose.features.find((f) => f.name === 'system_mode');
                     if (mode) {
+                        if (mode.values.includes('sleep')) {
+                            // 'sleep' is not supported by homeassistent, but is valid according to ZCL
+                            // TRV that support sleep (e.g. Viessmann) will have it removed from here,
+                            // this allows other expose consumers to still use it, e.g. the frontend.
+                            mode.values.splice(mode.values.indexOf('sleep'), 1);
+                        }
                         discoveryEntry.discovery_payload.mode_state_topic = true;
                         discoveryEntry.discovery_payload.mode_state_template = `{{ value_json.${mode.property} }}`;
                         discoveryEntry.discovery_payload.modes = mode.values;


### PR DESCRIPTION
But 'sleep' is a valid ZCL system_mode, so far only the Viessmann TRV supports it.
We simply drop the exposed system_mode value to not confuse homeassistent.

This is a follow up to Koenkk/zigbee-herdsman-converters#2314, as mentioned I don't have a homeassistent setup to test this with.

But the following standalone code did work as I expected it:
```
let mode = {"values": ['heat', 'sleep']};
if (mode.values.includes('sleep')) mode.values.splice(mode.values.indexOf('sleep'), 1);
```

At the end mode.values only contained 'heat'.