### PR TITLE
HA discovery: use default name when present

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -645,9 +645,14 @@ class HomeAssistant extends Extension {
 
             payload.json_attributes_topic = stateTopic;
 
+            if (resolvedEntity.settings.hasOwnProperty('homeassistant') && resolvedEntity.settings.homeassistant.name) {
+                payload.name = resolvedEntity.settings.homeassistant.name;
+            } else {
+                payload.name = friendlyName;
+            }
+
             // Set (unique) name, separate by space if friendlyName contains space.
-            const nameSeparator = friendlyName.includes('_') ? '_' : ' ';
-            payload.name = friendlyName;
+            const nameSeparator = payload.name.includes('_') ? '_' : ' ';
             if (config.object_id.startsWith(config.type) && config.object_id.includes('_')) {
                 payload.name += `${nameSeparator}${config.object_id.split(/_(.+)/)[1]}`;
             } else if (!config.object_id.startsWith(config.type)) {
@@ -766,9 +771,9 @@ class HomeAssistant extends Extension {
 
             // Override configuration with user settings.
             if (resolvedEntity.settings.hasOwnProperty('homeassistant')) {
-                const add = (obj) => {
+                const add = (obj, ignoredKeys = []) => {
                     Object.keys(obj).forEach((key) => {
-                        if (['type', 'object_id'].includes(key)) {
+                        if (['type', 'object_id', ...ignoredKeys].includes(key)) {
                             return;
                         } else if (['number', 'string', 'boolean'].includes(typeof obj[key])) {
                             payload[key] = obj[key];
@@ -782,7 +787,7 @@ class HomeAssistant extends Extension {
                     });
                 };
 
-                add(resolvedEntity.settings.homeassistant);
+                add(resolvedEntity.settings.homeassistant, ['name']);
 
                 if (resolvedEntity.settings.homeassistant.hasOwnProperty(config.object_id)) {
                     add(resolvedEntity.settings.homeassistant[config.object_id]);

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -771,9 +771,9 @@ class HomeAssistant extends Extension {
 
             // Override configuration with user settings.
             if (resolvedEntity.settings.hasOwnProperty('homeassistant')) {
-                const add = (obj, ignoredKeys = []) => {
+                const add = (obj) => {
                     Object.keys(obj).forEach((key) => {
-                        if (['type', 'object_id', ...ignoredKeys].includes(key)) {
+                        if (['type', 'object_id', 'name'].includes(key)) {
                             return;
                         } else if (['number', 'string', 'boolean'].includes(typeof obj[key])) {
                             payload[key] = obj[key];
@@ -787,7 +787,7 @@ class HomeAssistant extends Extension {
                     });
                 };
 
-                add(resolvedEntity.settings.homeassistant, ['name']);
+                add(resolvedEntity.settings.homeassistant);
 
                 if (resolvedEntity.settings.homeassistant.hasOwnProperty(config.object_id)) {
                     add(resolvedEntity.settings.homeassistant[config.object_id]);

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -514,6 +514,105 @@ describe('HomeAssistant extension', () => {
 
     });
 
+    it('Should discover devices with unique names', async () => {
+        settings.set(['devices', '0x0017880104e45541'], {
+            retain: false,
+            friendly_name: 'my_switch',
+            homeassistant: {
+                name: 'my_switch_name_override'
+            },
+        })
+
+        controller = new Controller(false);
+        await controller.start();
+
+        const basePayload = {
+            'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
+            "device": {
+              "identifiers": [
+                "zigbee2mqtt_0x0017880104e45541"
+              ],
+              "manufacturer": "Xiaomi",
+              "model": "Aqara single key wired wall switch without neutral wire. Doesn't work as a router and doesn't support power meter (QBKG04LM)",
+              "name": "my_switch",
+              "sw_version": this.version
+            },
+            "json_attributes_topic": "zigbee2mqtt/my_switch",
+        };
+
+        let payload;
+        await flushPromises();
+
+        payload = {
+            ...basePayload,
+            "command_topic": "zigbee2mqtt/my_switch/set",
+            "name": "my_switch_name_override",
+            "payload_off": "OFF",
+            "payload_on": "ON",
+            "state_topic": "zigbee2mqtt/my_switch",
+            "unique_id": "0x0017880104e45541_switch_zigbee2mqtt",
+            "value_template": "{{ value_json.state }}"
+        }
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/switch/0x0017880104e45541/switch/config',
+            stringify(payload),
+            { retain: true, qos: 0 },
+            expect.any(Function),
+        );
+
+        payload = {
+            ...basePayload,
+            icon: "mdi:toggle-switch",
+            name: "my_switch_name_override_click",
+            state_topic: "zigbee2mqtt/my_switch",
+            unique_id: "0x0017880104e45541_click_zigbee2mqtt",
+            value_template: "{{ value_json.click }}",
+          }
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/sensor/0x0017880104e45541/click/config',
+            stringify(payload),
+            { retain: true, qos: 0 },
+            expect.any(Function),
+        );
+
+        payload = {
+            ...basePayload,
+            icon: "mdi:gesture-double-tap",
+            name: "my_switch_name_override_action",
+            state_topic: "zigbee2mqtt/my_switch",
+            unique_id: "0x0017880104e45541_action_zigbee2mqtt",
+            value_template: "{{ value_json.action }}",
+        }
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/sensor/0x0017880104e45541/action/config',
+            stringify(payload),
+            { retain: true, qos: 0 },
+            expect.any(Function),
+        );
+
+        payload = {
+            ...basePayload,
+            icon: "mdi:signal",
+            name: "my_switch_name_override_linkquality",
+            state_topic: "zigbee2mqtt/my_switch",
+            unique_id: "0x0017880104e45541_linkquality_zigbee2mqtt",
+            unit_of_measurement: "lqi",
+            value_template: "{{ value_json.linkquality }}",
+        }
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/sensor/0x0017880104e45541/linkquality/config',
+            stringify(payload),
+            { retain: true, qos: 0 },
+            expect.any(Function),
+        );
+
+        
+    });
+
     it('Shouldnt discover devices when homeassistant null is set in device options', async () => {
         settings.set(['devices', '0x0017880104e45522'], {
             homeassistant: null,


### PR DESCRIPTION
Currently, when `name` is overrided directly under `homeassistant` like below, entity names are not unique anymore.
```yaml
friendly_name: desk/button
homeassistant:
  name: Desk Button
```
![image](https://user-images.githubusercontent.com/11139388/110972158-5c185980-8364-11eb-9ebe-c620239e4c31.png)

This PR fixes that by using provided `name` as base instead of completely overriding all entities:

![image](https://user-images.githubusercontent.com/11139388/110972456-b0bbd480-8364-11eb-95a8-e7cd471569d5.png)
