### PR TITLE
Fixes #6775: Save current device state after last_seen was updated

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -283,9 +283,6 @@ class Controller {
             this.state.get(resolvedEntity.settings.ID) : {};
         const newState = objectAssignDeep.noMutate(currentState, payload);
 
-        // Update state cache with new state.
-        this.state.set(resolvedEntity.settings.ID, newState, stateChangeReason);
-
         if (settings.get().advanced.cache_state) {
             // Add cached state to payload
             messagePayload = newState;
@@ -321,6 +318,9 @@ class Controller {
         if (isDevice && lastSeen !== 'disable' && resolvedEntity.device.lastSeen) {
             messagePayload.last_seen = utils.formatDate(resolvedEntity.device.lastSeen, lastSeen);
         }
+
+        // Update state cache with new state.
+        this.state.set(resolvedEntity.settings.ID, messagePayload, stateChangeReason);
 
         // Add device linkquality.
         if (resolvedEntity.type === 'device' && resolvedEntity.device.linkquality !== undefined) {


### PR DESCRIPTION
The fix just moves the line of code where the state of the device is stored in the state controller after the 'last_seen' attribute is updated. With this fix the same message is later saved to 'state.json' then was sent out via mqtt.