### PR TITLE
Add default on all HA templates for attributes

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -178,9 +178,10 @@ class HomeAssistant extends Extension {
                     const state = expose.features.find((f) => f.name === 'running_state');
                     if (state) {
                         discoveryEntry.discovery_payload.action_topic = true;
-                        discoveryEntry.discovery_payload.action_template = `{% set values = ` +
+                        discoveryEntry.discovery_payload.action_template = 
+                                `{% if '${state.property}' in value_json %}{% set values = ` +
                                 `{'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'}` +
-                                ` %}{{ values[value_json.${state.property} ${safeDefault}] }}`;
+                                ` %}{{ values[value_json.${state.property}] }}{% endif %}`;
                     }
 
                     const coolingSetpoint = expose.features.find((f) => f.name === 'occupied_cooling_setpoint');

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -6,7 +6,7 @@ const Extension = require('./extension');
 const stringify = require('json-stable-stringify-without-jsonify');
 const zigbeeHerdsmanConverters = require('zigbee-herdsman-converters');
 const assert = require('assert');
-const safeDefault = "| default('', true)";
+const safeDefault = `| default('', true)`;
 
 const sensorClick = {
     type: 'sensor',
@@ -170,7 +170,8 @@ class HomeAssistant extends Extension {
                             mode.values.splice(mode.values.indexOf('sleep'), 1);
                         }
                         discoveryEntry.discovery_payload.mode_state_topic = true;
-                        discoveryEntry.discovery_payload.mode_state_template = `{{ value_json.${mode.property} ${safeDefault} }}`;
+                        discoveryEntry.discovery_payload.mode_state_template = 
+                            `{{ value_json.${mode.property} ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.modes = mode.values;
                         discoveryEntry.discovery_payload.mode_command_topic = true;
                     }
@@ -178,7 +179,7 @@ class HomeAssistant extends Extension {
                     const state = expose.features.find((f) => f.name === 'running_state');
                     if (state) {
                         discoveryEntry.discovery_payload.action_topic = true;
-                        discoveryEntry.discovery_payload.action_template = 
+                        discoveryEntry.discovery_payload.action_template =
                                 `{% if '${state.property}' in value_json %}{% set values = ` +
                                 `{'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'}` +
                                 ` %}{{ values[value_json.${state.property}] }}{% endif %}`;
@@ -316,7 +317,8 @@ class HomeAssistant extends Extension {
                     if (speed) {
                         discoveryEntry.discovery_payload.speed_state_topic = true;
                         discoveryEntry.discovery_payload.speed_command_topic = true;
-                        discoveryEntry.discovery_payload.speed_value_template = `{{ value_json.fan_mode ${safeDefault} }}`;
+                        discoveryEntry.discovery_payload.speed_value_template = 
+                            `{{ value_json.fan_mode ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.speeds = speed.values;
                     }
                 } else if (expose.type === 'binary') {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -170,7 +170,7 @@ class HomeAssistant extends Extension {
                             mode.values.splice(mode.values.indexOf('sleep'), 1);
                         }
                         discoveryEntry.discovery_payload.mode_state_topic = true;
-                        discoveryEntry.discovery_payload.mode_state_template = 
+                        discoveryEntry.discovery_payload.mode_state_template =
                             `{{ value_json.${mode.property} ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.modes = mode.values;
                         discoveryEntry.discovery_payload.mode_command_topic = true;
@@ -317,7 +317,7 @@ class HomeAssistant extends Extension {
                     if (speed) {
                         discoveryEntry.discovery_payload.speed_state_topic = true;
                         discoveryEntry.discovery_payload.speed_command_topic = true;
-                        discoveryEntry.discovery_payload.speed_value_template = 
+                        discoveryEntry.discovery_payload.speed_value_template =
                             `{{ value_json.fan_mode ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.speeds = speed.values;
                     }

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -6,13 +6,14 @@ const Extension = require('./extension');
 const stringify = require('json-stable-stringify-without-jsonify');
 const zigbeeHerdsmanConverters = require('zigbee-herdsman-converters');
 const assert = require('assert');
+const safeDefault = "| default('', true)";
 
 const sensorClick = {
     type: 'sensor',
     object_id: 'click',
     discovery_payload: {
         icon: 'mdi:toggle-switch',
-        value_template: '{{ value_json.click }}',
+        value_template: `{{ value_json.click ${safeDefault} }}`,
     },
 };
 
@@ -72,7 +73,7 @@ class HomeAssistant extends Extension {
                     discovery_payload: {
                         unit_of_measurement: 'brightness',
                         icon: 'mdi:brightness-5',
-                        value_template: '{{ value_json.brightness }}',
+                        value_template: `{{ value_json.brightness ${safeDefault} }}`,
                     },
                 });
             }
@@ -118,7 +119,7 @@ class HomeAssistant extends Extension {
                         discovery_payload: {
                             payload_off: state.value_off,
                             payload_on: state.value_on,
-                            value_template: `{{ value_json.${state.property} }}`,
+                            value_template: `{{ value_json.${state.property} ${safeDefault} }}`,
                             command_topic: true,
                             command_topic_prefix: expose.endpoint ? expose.endpoint : undefined,
                         },
@@ -156,7 +157,7 @@ class HomeAssistant extends Extension {
                             max_temp: setpoint.value_max.toString(),
                             // Temperature
                             current_temperature_topic: true,
-                            current_temperature_template: `{{ value_json.${temperature.property} }}`,
+                            current_temperature_template: `{{ value_json.${temperature.property} ${safeDefault} }}`,
                         },
                     };
 
@@ -169,7 +170,7 @@ class HomeAssistant extends Extension {
                             mode.values.splice(mode.values.indexOf('sleep'), 1);
                         }
                         discoveryEntry.discovery_payload.mode_state_topic = true;
-                        discoveryEntry.discovery_payload.mode_state_template = `{{ value_json.${mode.property} }}`;
+                        discoveryEntry.discovery_payload.mode_state_template = `{{ value_json.${mode.property} ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.modes = mode.values;
                         discoveryEntry.discovery_payload.mode_command_topic = true;
                     }
@@ -179,23 +180,23 @@ class HomeAssistant extends Extension {
                         discoveryEntry.discovery_payload.action_topic = true;
                         discoveryEntry.discovery_payload.action_template = `{% set values = ` +
                                 `{'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'}` +
-                                ` %}{{ values[value_json.${state.property}] }}`;
+                                ` %}{{ values[value_json.${state.property} ${safeDefault}] }}`;
                     }
 
                     const coolingSetpoint = expose.features.find((f) => f.name === 'occupied_cooling_setpoint');
                     if (coolingSetpoint) {
                         discoveryEntry.discovery_payload.temperature_low_command_topic = setpoint.name;
                         discoveryEntry.discovery_payload.temperature_low_state_template =
-                            `{{ value_json.${setpoint.property} }}`;
+                            `{{ value_json.${setpoint.property} ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.temperature_low_state_topic = true;
                         discoveryEntry.discovery_payload.temperature_high_command_topic = coolingSetpoint.name;
                         discoveryEntry.discovery_payload.temperature_high_state_template =
-                            `{{ value_json.${coolingSetpoint.property} }}`;
+                            `{{ value_json.${coolingSetpoint.property} ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.temperature_high_state_topic = true;
                     } else {
                         discoveryEntry.discovery_payload.temperature_command_topic = setpoint.name;
                         discoveryEntry.discovery_payload.temperature_state_template =
-                            `{{ value_json.${setpoint.property} }}`;
+                            `{{ value_json.${setpoint.property} ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.temperature_state_topic = true;
                     }
 
@@ -204,7 +205,7 @@ class HomeAssistant extends Extension {
                         discoveryEntry.discovery_payload.fan_modes = fanMode.values;
                         discoveryEntry.discovery_payload.fan_mode_command_topic = true;
                         discoveryEntry.discovery_payload.fan_mode_state_template =
-                            `{{ value_json.${fanMode.property} }}`;
+                            `{{ value_json.${fanMode.property} ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.fan_mode_state_topic = true;
                     }
 
@@ -213,7 +214,7 @@ class HomeAssistant extends Extension {
                         discoveryEntry.discovery_payload.hold_modes = preset.values;
                         discoveryEntry.discovery_payload.hold_command_topic = true;
                         discoveryEntry.discovery_payload.hold_state_template =
-                            `{{ value_json.${preset.property} }}`;
+                            `{{ value_json.${preset.property} ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.hold_state_topic = true;
                     }
 
@@ -222,7 +223,7 @@ class HomeAssistant extends Extension {
                         discoveryEntry.discovery_payload.away_mode_command_topic = true;
                         discoveryEntry.discovery_payload.away_mode_state_topic = true;
                         discoveryEntry.discovery_payload.away_mode_state_template =
-                            `{{ value_json.${awayMode.property} }}`;
+                            `{{ value_json.${awayMode.property} ${safeDefault} }}`;
                     }
 
                     if (expose.endpoint) {
@@ -237,7 +238,7 @@ class HomeAssistant extends Extension {
                         object_id: 'lock',
                         discovery_payload: {
                             command_topic: true,
-                            value_template: `{{ value_json.${state.property} }}`,
+                            value_template: `{{ value_json.${state.property} ${safeDefault} }}`,
                         },
                     };
 
@@ -283,7 +284,7 @@ class HomeAssistant extends Extension {
 
                     if (hasPosition) {
                         discoveryEntry.discovery_payload = {...discoveryEntry.discovery_payload,
-                            position_template: '{{ value_json.position }}',
+                            position_template: `{{ value_json.position ${safeDefault} }}`,
                             set_position_template: '{ "position": {{ position }} }',
                             set_position_topic: true,
                             position_topic: true,
@@ -294,7 +295,7 @@ class HomeAssistant extends Extension {
                         discoveryEntry.discovery_payload = {...discoveryEntry.discovery_payload,
                             tilt_command_topic: true,
                             tilt_status_topic: true,
-                            tilt_status_template: '{{ value_json.tilt }}',
+                            tilt_status_template: `{{ value_json.tilt ${safeDefault} }}`,
                         };
                     }
                 } else if (expose.type === 'fan') {
@@ -304,7 +305,7 @@ class HomeAssistant extends Extension {
                         object_id: 'fan',
                         discovery_payload: {
                             state_topic: true,
-                            state_value_template: '{{ value_json.fan_state }}',
+                            state_value_template: `{{ value_json.fan_state ${safeDefault} }}`,
                             command_topic: true,
                             command_topic_postfix: 'fan_state',
                         },
@@ -314,7 +315,7 @@ class HomeAssistant extends Extension {
                     if (speed) {
                         discoveryEntry.discovery_payload.speed_state_topic = true;
                         discoveryEntry.discovery_payload.speed_command_topic = true;
-                        discoveryEntry.discovery_payload.speed_value_template = '{{ value_json.fan_mode }}';
+                        discoveryEntry.discovery_payload.speed_value_template = `{{ value_json.fan_mode ${safeDefault} }}`;
                         discoveryEntry.discovery_payload.speeds = speed.values;
                     }
                 } else if (expose.type === 'binary') {
@@ -334,7 +335,7 @@ class HomeAssistant extends Extension {
                         type: 'binary_sensor',
                         object_id: expose.endpoint ? `${expose.name}_${expose.endpoint}` : `${expose.name}`,
                         discovery_payload: {
-                            value_template: `{{ value_json.${expose.property} }}`,
+                            value_template: `{{ value_json.${expose.property} ${safeDefault} }}`,
                             payload_on: expose.value_on,
                             payload_off: expose.value_off,
                             ...(lookup[expose.name] || {}),
@@ -380,7 +381,7 @@ class HomeAssistant extends Extension {
                         type: 'sensor',
                         object_id: expose.endpoint ? `${expose.name}_${expose.endpoint}` : `${expose.name}`,
                         discovery_payload: {
-                            value_template: `{{ value_json.${expose.property} }}`,
+                            value_template: `{{ value_json.${expose.property} ${safeDefault} }}`,
                             ...(expose.unit && {unit_of_measurement: expose.unit}),
                             ...lookup[expose.name],
                         },
@@ -396,7 +397,7 @@ class HomeAssistant extends Extension {
                             type: 'sensor',
                             object_id: expose.property,
                             discovery_payload: {
-                                value_template: `{{ value_json.${expose.property} }}`,
+                                value_template: `{{ value_json.${expose.property} ${safeDefault} }}`,
                                 ...lookup[expose.name],
                             },
                         };
@@ -563,7 +564,7 @@ class HomeAssistant extends Extension {
                 object_id: 'update_state',
                 discovery_payload: {
                     icon: 'mdi:update',
-                    value_template: `{{ value_json['update']['state'] }}`,
+                    value_template: `{% if 'update' in value_json %}{{ value_json['update']['state'] }}{% endif %}`,
                 },
             };
 
@@ -575,7 +576,7 @@ class HomeAssistant extends Extension {
                     discovery_payload: {
                         payload_on: true,
                         payload_off: false,
-                        value_template: '{{ value_json.update_available}}',
+                        value_template: `{{ value_json.update_available ${safeDefault} }}`,
                     },
                 };
                 configs.push(updateAvailableSensor);

--- a/test/assets/mock-external-converter-multiple.js
+++ b/test/assets/mock-external-converter-multiple.js
@@ -4,7 +4,7 @@ const homeassistantSwitch = {
     discovery_payload: {
         payload_off: 'OFF',
         payload_on: 'ON',
-        value_template: '{{ value_json.state }}',
+        value_template: "{{ value_json.state | default('', true) }}",
         command_topic: true,
     },
 };

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const HomeAssistant = require('../lib/extension/homeassistant');
 
-const safeDefault = "| default('', true)";
+const safeDefault = `| default('', true)`;
 const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
 
 describe('HomeAssistant extension', () => {

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -604,7 +604,7 @@ describe('HomeAssistant extension', () => {
         await flushPromises();
 
         payload = {
-            "action_template":`{% set values = {'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'} %}{{ values[value_json.running_state ${safeDefault}] }}`,
+            "action_template":`{% if 'running_state' in value_json %}{% set values = {'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'} %}{{ values[value_json.running_state] }}{% endif %}`,
             "action_topic":"zigbee2mqtt/TS0601_thermostat",
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
             "away_mode_command_topic":"zigbee2mqtt/TS0601_thermostat/set/away_mode",

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const HomeAssistant = require('../lib/extension/homeassistant');
 
+const safeDefault = "| default('', true)";
 const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
 
 describe('HomeAssistant extension', () => {
@@ -54,7 +55,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': '{{ value_json.temperature }}',
+            'value_template': `{{ value_json.temperature ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
@@ -79,7 +80,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '%',
             'device_class': 'humidity',
-            'value_template': '{{ value_json.humidity }}',
+            'value_template': `{{ value_json.humidity ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_humidity',
@@ -104,7 +105,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': 'hPa',
             'device_class': 'pressure',
-            'value_template': '{{ value_json.pressure }}',
+            'value_template': `{{ value_json.pressure ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_pressure',
@@ -129,7 +130,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '%',
             'device_class': 'battery',
-            'value_template': '{{ value_json.battery }}',
+            'value_template': `{{ value_json.battery ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_battery',
@@ -154,7 +155,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'icon': 'mdi:signal',
             'unit_of_measurement': 'lqi',
-            'value_template': '{{ value_json.linkquality }}',
+            'value_template': `{{ value_json.linkquality ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_linkquality',
@@ -198,7 +199,7 @@ describe('HomeAssistant extension', () => {
             "payload_on":"ON",
             "state_topic":"zigbee2mqtt/wall_switch_double",
             "unique_id":"0x0017880104e45542_switch_left_zigbee2mqtt",
-            "value_template":"{{ value_json.state_left }}"
+            "value_template":`{{ value_json.state_left ${safeDefault} }}`
         };
 
         expect(MQTT.publish).toHaveBeenCalledWith(
@@ -230,7 +231,7 @@ describe('HomeAssistant extension', () => {
             "payload_on":"ON",
             "state_topic":"zigbee2mqtt/wall_switch_double",
             "unique_id":"0x0017880104e45542_switch_right_zigbee2mqtt",
-            "value_template":"{{ value_json.state_right }}"
+            "value_template":`{{ value_json.state_right ${safeDefault} }}`
         };
 
         expect(MQTT.publish).toHaveBeenCalledWith(
@@ -305,7 +306,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': "{{ value_json.temperature }}",
+            'value_template': `{{ value_json.temperature ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
@@ -330,7 +331,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '%',
             'device_class': 'humidity',
-            'value_template': '{{ value_json.humidity }}',
+            'value_template': `{{ value_json.humidity ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_humidity',
@@ -355,7 +356,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': 'hPa',
             'device_class': 'pressure',
-            'value_template': '{{ value_json.pressure }}',
+            'value_template': `{{ value_json.pressure ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_pressure',
@@ -411,7 +412,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': '{{ value_json.temperature }}',
+            'value_template': `{{ value_json.temperature ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
@@ -438,7 +439,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '%',
             'device_class': 'humidity',
-            'value_template': '{{ value_json.humidity }}',
+            'value_template': `{{ value_json.humidity ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_humidity',
@@ -502,7 +503,7 @@ describe('HomeAssistant extension', () => {
             "payload_on": "ON",
             "state_topic": "zigbee2mqtt/my_switch",
             "unique_id": "0x0017880104e45541_light_zigbee2mqtt",
-            "value_template": "{{ value_json.state }}"
+            "value_template": `{{ value_json.state ${safeDefault} }}`
         }
 
         expect(MQTT.publish).toHaveBeenCalledWith(
@@ -558,11 +559,11 @@ describe('HomeAssistant extension', () => {
 
         payload = {
             "state_topic":"zigbee2mqtt/fan",
-            "state_value_template":"{{ value_json.fan_state }}",
+            "state_value_template":`{{ value_json.fan_state ${safeDefault} }}`,
             "command_topic":"zigbee2mqtt/fan/set/fan_state",
             "speed_state_topic":"zigbee2mqtt/fan",
             "speed_command_topic":"zigbee2mqtt/fan/set/fan_mode",
-            "speed_value_template":"{{ value_json.fan_mode }}",
+            "speed_value_template":`{{ value_json.fan_mode ${safeDefault} }}`,
             "speeds":[
                "off",
                "low",
@@ -603,13 +604,13 @@ describe('HomeAssistant extension', () => {
         await flushPromises();
 
         payload = {
-            "action_template":"{% set values = {'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'} %}{{ values[value_json.running_state] }}",
+            "action_template":`{% set values = {'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'} %}{{ values[value_json.running_state ${safeDefault}] }}`,
             "action_topic":"zigbee2mqtt/TS0601_thermostat",
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
             "away_mode_command_topic":"zigbee2mqtt/TS0601_thermostat/set/away_mode",
-            "away_mode_state_template":"{{ value_json.away_mode }}",
+            "away_mode_state_template":`{{ value_json.away_mode ${safeDefault} }}`,
             "away_mode_state_topic":"zigbee2mqtt/TS0601_thermostat",
-            "current_temperature_template":"{{ value_json.local_temperature }}",
+            "current_temperature_template":`{{ value_json.local_temperature ${safeDefault} }}`,
             "current_temperature_topic":"zigbee2mqtt/TS0601_thermostat",
             "device":{
                "identifiers":[
@@ -629,13 +630,13 @@ describe('HomeAssistant extension', () => {
                "comfort",
                "eco"
             ],
-            "hold_state_template":"{{ value_json.preset }}",
+            "hold_state_template":`{{ value_json.preset ${safeDefault} }}`,
             "hold_state_topic":"zigbee2mqtt/TS0601_thermostat",
             "json_attributes_topic":"zigbee2mqtt/TS0601_thermostat",
             "max_temp":"35",
             "min_temp":"5",
             "mode_command_topic":"zigbee2mqtt/TS0601_thermostat/set/system_mode",
-            "mode_state_template":"{{ value_json.system_mode }}",
+            "mode_state_template":`{{ value_json.system_mode ${safeDefault} }}`,
             "mode_state_topic":"zigbee2mqtt/TS0601_thermostat",
             "modes":[
                "heat", "auto", "off"
@@ -643,7 +644,7 @@ describe('HomeAssistant extension', () => {
             "name":"TS0601_thermostat",
             "temp_step":0.5,
             "temperature_command_topic":"zigbee2mqtt/TS0601_thermostat/set/current_heating_setpoint",
-            "temperature_state_template":"{{ value_json.current_heating_setpoint }}",
+            "temperature_state_template":`{{ value_json.current_heating_setpoint ${safeDefault} }}`,
             "temperature_state_topic":"zigbee2mqtt/TS0601_thermostat",
             "temperature_unit":"C",
             "unique_id":"0x0017882104a44559_climate_zigbee2mqtt"
@@ -669,7 +670,7 @@ describe('HomeAssistant extension', () => {
             position_topic: 'zigbee2mqtt/smart vent',
             set_position_topic: 'zigbee2mqtt/smart vent/set',
             set_position_template: '{ "position": {{ position }} }',
-            position_template: '{{ value_json.position }}',
+            position_template: `{{ value_json.position ${safeDefault} }}`,
             json_attributes_topic: 'zigbee2mqtt/smart vent',
             name: 'smart vent',
             unique_id: '0x0017880104e45551_cover_zigbee2mqtt',
@@ -703,7 +704,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': '{{ value_json.temperature }}',
+            'value_template': `{{ value_json.temperature ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
@@ -768,7 +769,7 @@ describe('HomeAssistant extension', () => {
         const payloadHA = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': '{{ value_json.temperature }}',
+            'value_template': `{{ value_json.temperature ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
@@ -894,7 +895,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': '{{ value_json.temperature }}',
+            'value_template': `{{ value_json.temperature ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
@@ -980,7 +981,7 @@ describe('HomeAssistant extension', () => {
         const payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': '{{ value_json.temperature }}',
+            'value_template': `{{ value_json.temperature ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor_renamed',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor_renamed',
             'name': 'weather_sensor_renamed_temperature',
@@ -1050,7 +1051,7 @@ describe('HomeAssistant extension', () => {
         const payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
-            'value_template': '{{ value_json.temperature }}',
+            'value_template': `{{ value_json.temperature ${safeDefault} }}`,
             'state_topic': 'zigbee2mqtt/weather_sensor_renamed',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor_renamed',
             'name': 'weather_sensor_renamed_temperature',
@@ -1080,7 +1081,7 @@ describe('HomeAssistant extension', () => {
         const payload = {
             "payload_on":true,
             "payload_off":false,
-            "value_template":"{{ value_json.update_available}}",
+            "value_template":`{{ value_json.update_available ${safeDefault} }}`,
             "state_topic":"zigbee2mqtt/bulb",
             "json_attributes_topic":"zigbee2mqtt/bulb",
             "name":"bulb update available",
@@ -1418,7 +1419,7 @@ describe('HomeAssistant extension', () => {
             discovery_payload: {
                 payload_off: 'OFF',
                 payload_on: 'ON',
-                value_template: '{{ value_json.state }}',
+                value_template: `{{ value_json.state ${safeDefault} }}`,
                 command_topic: true,
             },
         };


### PR DESCRIPTION
Implemented the fix I suggested in #6987 . I blindly added the `| default('', true)` syntax to every template as I do not know the ins and outs of all these situations. If some discovery payloads should not have this added because they should always be reporting in that state let me know which and I will update.

Can also change the mechanism for defaulting or the value if desired. As I said in the issue, I picked `''` because that is what used to happen prior to `2021.4.0`. But now that we have control over the default, can switch it to `None` if that's preferred.