### PR TITLE
Home Assistant: set unknown values to null #6987

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -334,6 +334,12 @@ class Controller {
             resolvedEntity.settings.filtered_attributes.forEach((a) => delete messagePayload[a]);
         }
 
+        for (const extension of this.extensions) {
+            if (extension.adjustMessagePayloadBeforePublish) {
+                extension.adjustMessagePayloadBeforePublish(resolvedEntity, messagePayload);
+            }
+        }
+
         if (Object.entries(messagePayload).length) {
             const output = settings.get().experimental.output;
             if (output === 'attribute_and_json' || output === 'json') {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -16,6 +16,7 @@ const sensorClick = {
     },
 };
 
+const ACCESS_STATE = 1;
 const defaultStatusTopic = 'homeassistant/status';
 
 /**
@@ -386,7 +387,6 @@ class HomeAssistant extends Extension {
                         },
                     };
                 } else if (expose.type === 'enum' || expose.type === 'text' || expose.type === 'composite') {
-                    const ACCESS_STATE = 1;
                     if (expose.access & ACCESS_STATE) {
                         const lookup = {
                             action: {icon: 'mdi:gesture-double-tap'},
@@ -875,6 +875,29 @@ class HomeAssistant extends Extension {
             model: `${resolvedEntity.definition.description} (${resolvedEntity.definition.model})`,
             manufacturer: resolvedEntity.definition.vendor,
         };
+    }
+
+    adjustMessagePayloadBeforePublish(resolvedEntity, messagePayload) {
+        // Set missing values of state to 'null': https://github.com/Koenkk/zigbee2mqtt/issues/6987
+        if (!resolvedEntity || !resolvedEntity.definition) return null;
+
+        const add = (expose) => {
+            if (!messagePayload.hasOwnProperty(expose.property) && expose.access & ACCESS_STATE) {
+                messagePayload[expose.property] = null;
+            }
+        };
+
+        for (const expose of resolvedEntity.definition.exposes) {
+            if (expose.hasOwnProperty('features')) {
+                for (const feature of expose.features) {
+                    if (feature.name === 'state') {
+                        add(feature);
+                    }
+                }
+            } else {
+                add(expose);
+            }
+        }
     }
 
     getDiscoveryTopic(config, device) {

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -130,7 +130,7 @@ describe('Frontend', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(4);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-            stringify({state: 'ON'}),
+            stringify({state: 'ON', linkquality: null}),
             { retain: false, qos: 0 },
             expect.any(Function)
         );
@@ -141,7 +141,7 @@ describe('Frontend', () => {
 
         // Received message on socket
         expect(mockWSClient.implementation.send).toHaveBeenCalledTimes(4);
-        expect(mockWSClient.implementation.send).toHaveBeenCalledWith(stringify({topic: 'bulb_color', payload: {state: 'ON'}}));
+        expect(mockWSClient.implementation.send).toHaveBeenCalledWith(stringify({topic: 'bulb_color', payload: {state: 'ON', linkquality: null}}));
 
         // Shouldnt set when not ready
         mockWSClient.implementation.send.mockClear();


### PR DESCRIPTION
Fixes #6987
Alternative for https://github.com/Koenkk/zigbee2mqtt/pull/6988

Home Assistant 2021.4 => throws warnings when values are missing from the state. This PR sets all unknown values to null.

E.g. given that we have a temperature/humidity sensor where the humidity and temperature is unknown yet. Next the sensor reports the temperature so `{"temperature": 20}` is published. Now HA will generate a warning that the `humidity` property is missing. With this pr `{"temperature": 20, "humidity": null}` would be published.

@mdegat01 @frenck can you take a look at this?