### PR TITLE
#7571 Add `filtered_optimistic` device option

### DIFF
--- a/lib/extension/publish.js
+++ b/lib/extension/publish.js
@@ -237,6 +237,11 @@ class EntityPublish extends Extension {
                             }
                         }
 
+                        // filter out attribute listed in filtered_optimistic
+                        if (options.hasOwnProperty('filtered_optimistic')) {
+                            options.filtered_optimistic.forEach((a) => delete msg[a]);
+                        }
+
                         this.publishEntityState(resolvedEntity.settings.ID, msg);
                     }
 

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -701,6 +701,15 @@
           "description": "Publish optimistic state after set",
           "default": true
         },
+        "filtered_optimistic": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": ["color_mode", "color_temp", "color"],
+          "title": "Filtered attributes",
+          "description": "Skip optimistic state after set for certain attributes, this has no effect if optimistic is set to false."
+        },
         "filtered_attributes": {
           "type": "array",
           "items": {

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -422,6 +422,18 @@ describe('Publish', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(0);
     });
 
+    it('Shouldnt publish new brightness state when filtered_optimistic is used', async () => {
+        const device = zigbeeHerdsman.devices.bulb_color;
+        const endpoint = device.getEndpoint(1);
+        settings.set(['devices', device.ieeeAddr, 'filtered_optimistic'], ["brightness"]);
+        await MQTT.events.message('zigbee2mqtt/bulb_color/set', stringify({brightness: '200'}));
+        await flushPromises();
+        expect(endpoint.command).toHaveBeenCalledTimes(1);
+        expect(endpoint.command).toHaveBeenCalledWith("genLevelCtrl", "moveToLevelWithOnOff", {"level": 200, "transtime": 0}, {});
+        expect(MQTT.publish).toHaveBeenCalledTimes(1);
+        expect(JSON.parse(MQTT.publish.mock.calls[0][1])).toStrictEqual({state: 'ON'});
+    });
+
     it('Shouldnt publish new state when optimistic = false for group', async () => {
         settings.set(['groups', '2', 'optimistic'], false);
         await MQTT.events.message('zigbee2mqtt/group_2/set', stringify({brightness: '200'}));


### PR DESCRIPTION
As discussed in #7571 this introduce a `filtered_optimistic` analogously to `filtered_attributes`.

I  tested this by insert a console.log() before and after the forEach and updating one of my bulbs color, while filtering out color and color_temp.

```
XXX: pre filtering optimistic - {"color_mode":"color_temp","color_temp":370}
XXX: post filtering optimistic - {"color_mode":"color_temp"}
XXX: pre filtering optimistic - {"color_mode":"xy","color":{"x":0.2962962962962963,"y":0.5925925925925926}}
XXX: post filtering optimistic - {"color_mode":"xy"}
```

I also wrote a test case to cover this.