### PR TITLE
Disable less common Home Assistant entities by default

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -358,7 +358,7 @@ class HomeAssistant extends Extension {
                         temperature: {device_class: 'temperature', state_class: 'measurement'},
                         humidity: {device_class: 'humidity', state_class: 'measurement'},
                         illuminance_lux: {device_class: 'illuminance', state_class: 'measurement'},
-                        illuminance: {device_class: 'illuminance', state_class: 'measurement'},
+                        illuminance: {device_class: 'illuminance', enabled_by_default: false, state_class: 'measurement'},
                         soil_moisture: {icon: 'mdi:water-percent', state_class: 'measurement'},
                         position: {icon: 'mdi:valve', state_class: 'measurement'},
                         pressure: {device_class: 'pressure', state_class: 'measurement'},

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -363,13 +363,13 @@ class HomeAssistant extends Extension {
                         position: {icon: 'mdi:valve', state_class: 'measurement'},
                         pressure: {device_class: 'pressure', state_class: 'measurement'},
                         power: {device_class: 'power', state_class: 'measurement'},
-                        linkquality: {icon: 'mdi:signal', state_class: 'measurement'},
+                        linkquality: {enabled_by_default: false, icon: 'mdi:signal', state_class: 'measurement'},
                         current: {device_class: 'current', state_class: 'measurement'},
-                        voltage: {device_class: 'voltage', state_class: 'measurement'},
+                        voltage: {device_class: 'voltage', enabled_by_default: false, state_class: 'measurement'},
                         current_phase_b: {device_class: 'current', state_class: 'measurement'},
-                        voltage_phase_b: {device_class: 'voltage', state_class: 'measurement'},
+                        voltage_phase_b: {device_class: 'voltage', enabled_by_default: false, state_class: 'measurement'},
                         current_phase_c: {device_class: 'current', state_class: 'measurement'},
-                        voltage_phase_c: {device_class: 'voltage', state_class: 'measurement'},
+                        voltage_phase_c: {device_class: 'voltage', enabled_by_default: false, state_class: 'measurement'},
                         energy: {device_class: 'energy'},
                         smoke_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
                         gas_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
@@ -378,8 +378,8 @@ class HomeAssistant extends Extension {
                         voc: {icon: 'mdi:air-filter', state_class: 'measurement'},
                         aqi: {icon: 'mdi:air-filter', state_class: 'measurement'},
                         hcho: {icon: 'mdi:air-filter', state_class: 'measurement'},
-                        requested_brightness_level: {icon: 'mdi:brightness-5'},
-                        requested_brightness_percent: {icon: 'mdi:brightness-5'},
+                        requested_brightness_level: {enabled_by_default: false, icon: 'mdi:brightness-5'},
+                        requested_brightness_percent: {enabled_by_default: false, icon: 'mdi:brightness-5'},
                         eco2: {icon: 'mdi:molecule-co2', state_class: 'measurement'},
                         co2: {icon: 'mdi:molecule-co2', state_class: 'measurement'},
                         local_temperature: {device_class: 'temperature', state_class: 'measurement'},
@@ -543,6 +543,7 @@ class HomeAssistant extends Extension {
                 discovery_payload: {
                     icon: 'mdi:update',
                     value_template: `{{ value_json['update']['state'] }}`,
+                    enabled_by_default: false,
                 },
             };
 
@@ -555,6 +556,7 @@ class HomeAssistant extends Extension {
                         payload_on: true,
                         payload_off: false,
                         value_template: '{{ value_json.update_available}}',
+                        enabled_by_default: false,
                     },
                 };
                 configs.push(updateAvailableSensor);

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -358,7 +358,9 @@ class HomeAssistant extends Extension {
                         temperature: {device_class: 'temperature', state_class: 'measurement'},
                         humidity: {device_class: 'humidity', state_class: 'measurement'},
                         illuminance_lux: {device_class: 'illuminance', state_class: 'measurement'},
-                        illuminance: {device_class: 'illuminance', enabled_by_default: false, state_class: 'measurement'},
+                        illuminance: {
+                            device_class: 'illuminance', enabled_by_default: false, state_class: 'measurement',
+                        },
                         soil_moisture: {icon: 'mdi:water-percent', state_class: 'measurement'},
                         position: {icon: 'mdi:valve', state_class: 'measurement'},
                         pressure: {device_class: 'pressure', state_class: 'measurement'},
@@ -367,9 +369,13 @@ class HomeAssistant extends Extension {
                         current: {device_class: 'current', state_class: 'measurement'},
                         voltage: {device_class: 'voltage', enabled_by_default: false, state_class: 'measurement'},
                         current_phase_b: {device_class: 'current', state_class: 'measurement'},
-                        voltage_phase_b: {device_class: 'voltage', enabled_by_default: false, state_class: 'measurement'},
+                        voltage_phase_b: {
+                            device_class: 'voltage', enabled_by_default: false, state_class: 'measurement',
+                        },
                         current_phase_c: {device_class: 'current', state_class: 'measurement'},
-                        voltage_phase_c: {device_class: 'voltage', enabled_by_default: false, state_class: 'measurement'},
+                        voltage_phase_c: {
+                            device_class: 'voltage', enabled_by_default: false, state_class: 'measurement',
+                        },
                         energy: {device_class: 'energy'},
                         smoke_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
                         gas_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -157,6 +157,7 @@ describe('HomeAssistant extension', () => {
 
         payload = {
             'icon': 'mdi:signal',
+            'enabled_by_default': false,
             'unit_of_measurement': 'lqi',
             'state_class': 'measurement',
             'value_template': '{{ value_json.linkquality }}',
@@ -1168,6 +1169,7 @@ describe('HomeAssistant extension', () => {
             "payload_on":true,
             "payload_off":false,
             "value_template":"{{ value_json.update_available}}",
+            "enabled_by_default": false,
             "state_topic":"zigbee2mqtt/bulb",
             "json_attributes_topic":"zigbee2mqtt/bulb",
             "name":"bulb update available",


### PR DESCRIPTION
This PR disabled less commonly used Home Assistant entities by default.

Reasoning:

- Less clutter for the end-user for sensors they are most likely will not use for creating stuff with; like automations.
- If a user still wants these sensors, they can be enabled in the Home Assistant UI.
- Less unnecessary state changes and recordings for things most people won't need. Thus reducing database sizes and reducing disk writes.

This change is not breaking. Existing entities on existing installations are not affected by this; this setting only applies to new entities.

![image](https://user-images.githubusercontent.com/195327/120625521-14383880-c462-11eb-9aa1-0da1b9d71a3e.png)