### PR TITLE
Make all entities for enums, text and composite exposes disabled by default. Fixes #8083

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -495,6 +495,7 @@ class HomeAssistant extends Extension {
                 discoveryEntries.push({
                     type: 'sensor',
                     object_id: firstExpose.property,
+                    enabled_by_default: false,
                     discovery_payload: {
                         value_template: `{{ value_json.${firstExpose.property} }}`,
                         ...lookup[firstExpose.name],
@@ -506,7 +507,6 @@ class HomeAssistant extends Extension {
                  */
                 if ((firstExpose.access & ACCESS_SET)) {
                     // Make the sensor disabled by default for new entities.
-                    discoveryEntries[discoveryEntries.length - 1].discovery_payload.enabled_by_default = false;
                     discoveryEntries.push({
                         type: 'select',
                         object_id: firstExpose.property,
@@ -517,6 +517,7 @@ class HomeAssistant extends Extension {
                             command_topic: true,
                             command_topic_postfix: firstExpose.property,
                             options: firstExpose.values,
+                            enabled_by_default: false,
                             ...lookup[firstExpose.name],
                         },
                     });
@@ -533,6 +534,7 @@ class HomeAssistant extends Extension {
                     object_id: firstExpose.property,
                     discovery_payload: {
                         value_template: `{{ value_json.${firstExpose.property} }}`,
+                        enabled_by_default: false,
                         ...lookup[firstExpose.name],
                     },
                 };


### PR DESCRIPTION
As per #8083, make all entities resulting from enum, text and composite expose types disabled by default.

I'm not exactly sure if these 3 entire expose types can be classified as uncommonly used though.

Perhaps this is something that should be specified as something on the expose definition?