### PR TITLE
Handle enabled by default for enum types / select|sensor entities

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -489,6 +489,7 @@ class HomeAssistant extends Extension {
         } else if (firstExpose.type === 'enum') {
             const lookup = {
                 action: {icon: 'mdi:gesture-double-tap'},
+                power_on_behavior: {enabled_by_default: false, icon: 'mdi:power-settings'},
             };
 
             if (firstExpose.access & ACCESS_STATE) {
@@ -497,6 +498,7 @@ class HomeAssistant extends Extension {
                     object_id: firstExpose.property,
                     discovery_payload: {
                         value_template: `{{ value_json.${firstExpose.property} }}`,
+                        enabled_by_default: !(firstExpose.access & ACCESS_SET),
                         ...lookup[firstExpose.name],
                     },
                 });
@@ -506,7 +508,6 @@ class HomeAssistant extends Extension {
                  */
                 if ((firstExpose.access & ACCESS_SET)) {
                     // Make the sensor disabled by default for new entities.
-                    discoveryEntries[discoveryEntries.length - 1].discovery_payload.enabled_by_default = false;
                     discoveryEntries.push({
                         type: 'select',
                         object_id: firstExpose.property,
@@ -525,7 +526,6 @@ class HomeAssistant extends Extension {
         } else if (firstExpose.type === 'text' || firstExpose.type === 'composite') {
             if (firstExpose.access & ACCESS_STATE) {
                 const lookup = {
-                    action: {icon: 'mdi:gesture-double-tap'},
                 };
 
                 const discoveryEntry = {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -522,7 +522,6 @@ class HomeAssistant extends Extension {
                  * If enum attribute has SET access then expose as SELECT entity too.
                  */
                 if ((firstExpose.access & ACCESS_SET)) {
-                    // Make the sensor disabled by default for new entities.
                     discoveryEntries.push({
                         type: 'select',
                         object_id: firstExpose.property,

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -489,7 +489,22 @@ class HomeAssistant extends Extension {
         } else if (firstExpose.type === 'enum') {
             const lookup = {
                 action: {icon: 'mdi:gesture-double-tap'},
+                backlight_auto_dim: {enabled_by_default: false, icon: 'mdi:brightness-auto'},
+                backlight_mode: {enabled_by_default: false, icon: 'mdi:lightbulb'},
+                color_power_on_behavior: {enabled_by_default: false, icon: 'mdi:palette'},
+                device_mode: {enabled_by_default: false, icon: 'mdi:tune'},
+                keep_time: {enabled_by_default: false, icon: 'mdi:av-timer'},
+                melody: {icon: 'mdi:music-note'},
+                mode_phase_control: {enabled_by_default: false, icon: 'mdi:tune'},
+                mode: {enabled_by_default: false, icon: 'mdi:tune'},
+                motion_sensitivity: {enabled_by_default: false, icon: 'mdi:tune'},
+                operation_mode: {enabled_by_default: false, icon: 'mdi:tune'},
                 power_on_behavior: {enabled_by_default: false, icon: 'mdi:power-settings'},
+                power_outage_memory: {enabled_by_default: false, icon: 'mdi:power-settings'},
+                sensitivity: {enabled_by_default: false, icon: 'mdi:tune'},
+                sensors_type: {enabled_by_default: false, icon: 'mdi:tune'},
+                switch_type: {enabled_by_default: false, icon: 'mdi:tune'},
+                volume: {icon: 'mdi: volume-high'},
             };
 
             if (firstExpose.access & ACCESS_STATE) {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -541,6 +541,7 @@ class HomeAssistant extends Extension {
         } else if (firstExpose.type === 'text' || firstExpose.type === 'composite') {
             if (firstExpose.access & ACCESS_STATE) {
                 const lookup = {
+                    action: {icon: 'mdi:gesture-double-tap'},
                 };
 
                 const discoveryEntry = {


### PR DESCRIPTION
This PR is to get some contents in the lookup table of enum types exposing neater entities to Home Assistant by providing icons and disabling them by default if less common.

Note: this is a backward compatible change, existing entities of devices are not disabled, only new ones.

fixes #8083
closes #8084