### PR TITLE
Add support for Home Assistant energy statistics

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -458,7 +458,12 @@ class HomeAssistant extends Extension {
                 voltage_phase_c: {
                     device_class: 'voltage', enabled_by_default: false, state_class: 'measurement',
                 },
-                energy: {device_class: 'energy'},
+                energy: {
+                    device_class: 'energy',
+                    state_class: 'measurement',
+                    last_reset_topic: true,
+                    last_reset_value_template: "1970-01-01T00:00:00+00:00,"
+                },
                 smoke_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
                 gas_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
                 pm25: {icon: 'mdi:air-filter', state_class: 'measurement'},
@@ -819,6 +824,10 @@ class HomeAssistant extends Extension {
                 if (payload.hasOwnProperty('state_topic')) {
                     delete payload.state_topic;
                 }
+            }
+
+            if (payload.last_reset_topic) {
+                payload.last_reset_topic = stateTopic;
             }
 
             if (payload.position_topic) {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -462,7 +462,7 @@ class HomeAssistant extends Extension {
                     device_class: 'energy',
                     state_class: 'measurement',
                     last_reset_topic: true,
-                    last_reset_value_template: "1970-01-01T00:00:00+00:00"
+                    last_reset_value_template: '1970-01-01T00:00:00+00:00',
                 },
                 smoke_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
                 gas_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -462,7 +462,7 @@ class HomeAssistant extends Extension {
                     device_class: 'energy',
                     state_class: 'measurement',
                     last_reset_topic: true,
-                    last_reset_value_template: "1970-01-01T00:00:00+00:00,"
+                    last_reset_value_template: "1970-01-01T00:00:00+00:00"
                 },
                 smoke_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
                 gas_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},


### PR DESCRIPTION
Adds support for Home Assistant energy statistics.

Support for the MQTT part @ Home Assistant has been added in the previous release already, so this does not depend on a future release (and should be backward compatible anyways).

Statistics support for other sensors with current values, already has been added in a previous PR / Zigbee2MQTT release. This only affects "energy" sensors at this point.

See:
- <https://www.home-assistant.io/integrations/sensor.mqtt/#last_reset_topic>
- <https://developers.home-assistant.io/blog/2021/05/25/sensor_attributes/>

As the Zigbee energy sensors should not be resettable, it sets the `last_reset_topic` to satisfy the configuration and `last_reset_value_template` contains a static string with an iso formatted epoch 0 timestamp. It is not a template, Home Assistant will recognize that, skip the template parsing and just use the string as the result directly.

I have not been able to test this in real life, as I do not own any Zigbee devices that provide this data.