### PR TITLE
Allow non systemctl systems to use update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -7,8 +7,12 @@ if [ -d data-backup ]; then
    exit 1
 fi
 
-echo "Stopping Zigbee2MQTT..."
-sudo systemctl stop zigbee2mqtt
+if which systemctl 2> /dev/null > /dev/null; then
+       echo "Stopping Zigbee2MQTT..."
+       sudo systemctl stop zigbee2mqtt
+else
+       echo "Skipped stopping Zigbee2MQTT, no systemctl found"
+fi
 
 echo "Creating backup of configuration..."
 cp -R data data-backup
@@ -24,7 +28,11 @@ echo "Restore configuration..."
 cp -R data-backup/* data
 rm -rf data-backup
 
-echo "Starting Zigbee2MQTT..."
-sudo systemctl start zigbee2mqtt
+if which systemctl 2> /dev/null > /dev/null; then
+       echo "Starting Zigbee2MQTT..."
+       sudo systemctl start zigbee2mqtt
+else
+       echo "Skipped starting Zigbee2MQTT, no systemctl found"
+fi
 
 echo "Done!"


### PR DESCRIPTION
With this change update.sh works on systems that do not use systemctl.
I can update z2m on my illumos machine by running `svcadm disable zigbee2mqtt; ./update.sh ; svcadm enable zigbee2mqtt`