### PR TITLE
HA discovery changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,8 @@ data/extension
 # MacOS indexing file
 .DS_Store
 
+# IDE specific folders
+.idea
+
 # Ignore config
 data/*.yaml

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -476,6 +476,22 @@ class HomeAssistant extends Extension {
                 z_axis: {icon: 'mdi:axis-z-arrow'},
             };
 
+            const discoveryEntry = {
+                type: 'sensor',
+                object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
+                discovery_payload: {
+                    value_template: `{{ value_json.${firstExpose.property} }}`,
+                    enabled_by_default: !(firstExpose.access & ACCESS_SET),
+                    ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
+                    ...lookup[firstExpose.name],
+                },
+            };
+            discoveryEntries.push(discoveryEntry);
+
+            /**
+             * If enum attribute has SET access then expose as SELECT entity too.
+             * This is to avoid breaking changes.
+             */
             if (firstExpose.access & ACCESS_SET) {
                 const discoveryEntry = {
                     type: 'number',
@@ -487,17 +503,6 @@ class HomeAssistant extends Extension {
                         command_topic_postfix: firstExpose.property,
                         min: firstExpose.value_min ? firstExpose.value_min : -65535,
                         max: firstExpose.value_max ? firstExpose.value_max : 65535,
-                        ...lookup[firstExpose.name],
-                    },
-                };
-                discoveryEntries.push(discoveryEntry);
-            } else {
-                const discoveryEntry = {
-                    type: 'sensor',
-                    object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
-                    discovery_payload: {
-                        value_template: `{{ value_json.${firstExpose.property} }}`,
-                        ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
                         ...lookup[firstExpose.name],
                     },
                 };
@@ -537,6 +542,7 @@ class HomeAssistant extends Extension {
 
                 /**
                  * If enum attribute has SET access then expose as SELECT entity too.
+                 * This is to avoid breaking changes.
                  */
                 if ((firstExpose.access & ACCESS_SET)) {
                     discoveryEntries.push({

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -396,7 +396,6 @@ class HomeAssistant extends Extension {
              * There is also a check on the values for typeof boolean to prevent invalid values and commands
              * silently failing - commands work fine but some devices won't reject unexpected values.
              * https://github.com/Koenkk/zigbee2mqtt/issues/7740
-             * Dont expose boolean values for now: https://github.com/Koenkk/zigbee2mqtt/issues/7797
              */
             if (firstExpose.access & ACCESS_SET) {
                 const discoveryEntry = {

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -476,12 +476,14 @@ class HomeAssistant extends Extension {
                 z_axis: {icon: 'mdi:axis-z-arrow'},
             };
 
+            const allowsSet = firstExpose.access & ACCESS_SET;
+
             const discoveryEntry = {
                 type: 'sensor',
                 object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
                 discovery_payload: {
                     value_template: `{{ value_json.${firstExpose.property} }}`,
-                    enabled_by_default: !(firstExpose.access & ACCESS_SET),
+                    enabled_by_default: !allowsSet,
                     ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
                     ...lookup[firstExpose.name],
                 },
@@ -489,10 +491,11 @@ class HomeAssistant extends Extension {
             discoveryEntries.push(discoveryEntry);
 
             /**
-             * If enum attribute has SET access then expose as SELECT entity too.
-             * This is to avoid breaking changes for attributes already existing in HA.
+             * If numeric attribute has SET access then expose as SELECT entity too.
+             * Note: currently both sensor and number are discoverd, this is to avoid
+             * breaking changes for sensors already existing in HA (legacy).
              */
-            if (firstExpose.access & ACCESS_SET) {
+            if (allowsSet) {
                 const discoveryEntry = {
                     type: 'number',
                     object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
@@ -542,7 +545,8 @@ class HomeAssistant extends Extension {
 
                 /**
                  * If enum attribute has SET access then expose as SELECT entity too.
-                 * This is to avoid breaking changes for attributes already existing in HA.
+                 * Note: currently both sensor and select are discoverd, this is to avoid
+                 * breaking changes for sensors already existing in HA (legacy).
                  */
                 if ((firstExpose.access & ACCESS_SET)) {
                     discoveryEntries.push({

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -490,7 +490,7 @@ class HomeAssistant extends Extension {
 
             /**
              * If enum attribute has SET access then expose as SELECT entity too.
-             * This is to avoid breaking changes.
+             * This is to avoid breaking changes for attributes already existing in HA.
              */
             if (firstExpose.access & ACCESS_SET) {
                 const discoveryEntry = {
@@ -542,7 +542,7 @@ class HomeAssistant extends Extension {
 
                 /**
                  * If enum attribute has SET access then expose as SELECT entity too.
-                 * This is to avoid breaking changes.
+                 * This is to avoid breaking changes for attributes already existing in HA.
                  */
                 if ((firstExpose.access & ACCESS_SET)) {
                     discoveryEntries.push({

--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -477,16 +477,33 @@ class HomeAssistant extends Extension {
                 z_axis: {icon: 'mdi:axis-z-arrow'},
             };
 
-            const discoveryEntry = {
-                type: 'sensor',
-                object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
-                discovery_payload: {
-                    value_template: `{{ value_json.${firstExpose.property} }}`,
-                    ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
-                    ...lookup[firstExpose.name],
-                },
-            };
-            discoveryEntries.push(discoveryEntry);
+            if (firstExpose.access & ACCESS_SET) {
+                const discoveryEntry = {
+                    type: 'number',
+                    object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
+                    discovery_payload: {
+                        value_template: `{{ value_json.${firstExpose.property} }}`,
+                        command_topic: true,
+                        command_topic_prefix: endpoint,
+                        command_topic_postfix: firstExpose.property,
+                        min: firstExpose.value_min ? firstExpose.value_min : -65535,
+                        max: firstExpose.value_max ? firstExpose.value_max : 65535,
+                        ...lookup[firstExpose.name],
+                    },
+                };
+                discoveryEntries.push(discoveryEntry);
+            } else {
+                const discoveryEntry = {
+                    type: 'sensor',
+                    object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
+                    discovery_payload: {
+                        value_template: `{{ value_json.${firstExpose.property} }}`,
+                        ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
+                        ...lookup[firstExpose.name],
+                    },
+                };
+                discoveryEntries.push(discoveryEntry);
+            }
         } else if (firstExpose.type === 'enum') {
             const lookup = {
                 action: {icon: 'mdi:gesture-double-tap'},

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -53,7 +53,7 @@ describe('HomeAssistant extension', () => {
         expect(duplicated).toHaveLength(0);
     });
 
-    it('onlythisShould discover devices and groups', async () => {
+    it('Should discover devices and groups', async () => {
         const controller = new Controller(false);
         await controller.start();
 
@@ -367,6 +367,7 @@ describe('HomeAssistant extension', () => {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
             'state_class': 'measurement',
+            'enabled_by_default': true,
             'value_template': "{{ value_json.temperature }}",
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
@@ -398,6 +399,7 @@ describe('HomeAssistant extension', () => {
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_humidity',
             'unique_id': '0x0017880104e45522_humidity_zigbee2mqtt',
+            'enabled_by_default': true,
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
                 'name': 'weather_sensor',
@@ -423,6 +425,7 @@ describe('HomeAssistant extension', () => {
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_pressure',
+            'enabled_by_default': true,
             'unique_id': '0x0017880104e45522_pressure_zigbee2mqtt',
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
@@ -480,6 +483,7 @@ describe('HomeAssistant extension', () => {
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
+            'enabled_by_default': true,
             'unique_id': '0x0017880104e45522_temperature_zigbee2mqtt',
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
@@ -508,6 +512,7 @@ describe('HomeAssistant extension', () => {
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_humidity',
+            'enabled_by_default': true,
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
                 'name': 'weather_sensor',
@@ -771,6 +776,7 @@ describe('HomeAssistant extension', () => {
             'value_template': '{{ value_json.temperature }}',
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
+            'enabled_by_default': true,
             'name': 'weather_sensor_temperature',
             'unique_id': '0x0017880104e45522_temperature_zigbee2mqtt',
             'device': {
@@ -910,6 +916,7 @@ describe('HomeAssistant extension', () => {
         const payloadHA = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
+            'enabled_by_default': true,
             'state_class': 'measurement',
             'value_template': '{{ value_json.temperature }}',
             'state_topic': 'zigbee2mqtt/weather_sensor',
@@ -1033,6 +1040,7 @@ describe('HomeAssistant extension', () => {
         payload = {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
+            'enabled_by_default': true,
             'state_class': 'measurement',
             'value_template': '{{ value_json.temperature }}',
             'state_topic': 'zigbee2mqtt/weather_sensor',
@@ -1121,6 +1129,7 @@ describe('HomeAssistant extension', () => {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
             'state_class': 'measurement',
+            'enabled_by_default': true,
             'value_template': '{{ value_json.temperature }}',
             'state_topic': 'zigbee2mqtt/weather_sensor_renamed',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor_renamed',
@@ -1192,6 +1201,7 @@ describe('HomeAssistant extension', () => {
             'unit_of_measurement': '°C',
             'device_class': 'temperature',
             'state_class': 'measurement',
+            'enabled_by_default': true,
             'value_template': '{{ value_json.temperature }}',
             'state_topic': 'zigbee2mqtt/weather_sensor_renamed',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor_renamed',
@@ -1678,6 +1688,7 @@ describe('HomeAssistant extension', () => {
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_temperature',
             'unique_id': '0x0017880104e45522_temperature_zigbee2mqtt',
+            'enabled_by_default': true,
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
                 'name': 'weather_sensor',

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -53,7 +53,7 @@ describe('HomeAssistant extension', () => {
         expect(duplicated).toHaveLength(0);
     });
 
-    it('Should discover devices and groups', async () => {
+    it('onlythisShould discover devices and groups', async () => {
         const controller = new Controller(false);
         await controller.start();
 
@@ -132,6 +132,7 @@ describe('HomeAssistant extension', () => {
                 'manufacturer': 'Xiaomi',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
+            'enabled_by_default': true,
         };
 
         expect(MQTT.publish).toHaveBeenCalledWith(
@@ -150,6 +151,7 @@ describe('HomeAssistant extension', () => {
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_humidity',
             'unique_id': '0x0017880104e45522_humidity_zigbee2mqtt',
+            'enabled_by_default': true,
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
                 'name': 'weather_sensor',
@@ -176,6 +178,7 @@ describe('HomeAssistant extension', () => {
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_pressure',
             'unique_id': '0x0017880104e45522_pressure_zigbee2mqtt',
+            'enabled_by_default': true,
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
                 'name': 'weather_sensor',
@@ -202,6 +205,7 @@ describe('HomeAssistant extension', () => {
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
             'name': 'weather_sensor_battery',
             'unique_id': '0x0017880104e45522_battery_zigbee2mqtt',
+            'enabled_by_default': true,
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
                 'name': 'weather_sensor',


### PR DESCRIPTION
Hi @Koenkk and @sjorge 

A couple of things committed, plus another not yet because I wanted to talk to you before.

1. .gitignore .idea IDE folder (get this out the way)
2. remove redundant comment. This is from when we have split the binary attributes by SET access.
3. split the numeric attribute from sensor only to sensor and number, if the attribute supports SET.
One thing to ask you:
![image](https://user-images.githubusercontent.com/9019306/132096378-26c47321-d918-48be-a6ce-76574df402a8.png)

I have set the min and max values (otherwise they default to 0 and 100) as defined in the expose (withValueMin/Max), but I had to also do a fallback for attributes that do not use fixed limits, or they actually use the last available hex. For example:
![image](https://user-images.githubusercontent.com/9019306/132096433-311bc9ff-bfd9-4725-bcdd-195b9c42f302.png)

Do you have any issues with that?

~~On top, it should not affect any of the devices in `lookup` as I think they do not support get anyway. But maybe I am overseeing sth?~~ scrap that. I was referring to unit of measurements etc which belongs to a device class, which is not supported by number entities, but I don't see that being a problem

I have tested it and it behaves as expected, both read and write work fine, both non-set and set attributes gets exposed correctly. Here is my TRV:
![image](https://user-images.githubusercontent.com/9019306/132096462-88587ddb-8385-4918-bf70-d4e7909bf514.png)

As you can see battery or load_extimate are sensors while others are numbers.


And now onto what I have not done yet, but I think i should?

enum attributes currently get a duplicate if they allow SET. This is the current state of the code:
![image](https://user-images.githubusercontent.com/9019306/132096490-3e06b3be-a1dc-453d-a13e-8915683c935c.png)


As you can see, the sensor entity is disabled by default if the attribute supports set, and a new attribute is created instead as a `select`.

Which you can see in my TRV screenshot above where i have day_of_week as a select but also disabled at the bottom.

Is there any reason why this has this approach instead of either sensor or select?

Thanks