### PR TITLE
Upgrade zigbee-herdsman-converters

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "winston-syslog": "^2.4.4",
     "ws": "^8.2.1",
     "zigbee-herdsman": "0.13.138",
-    "zigbee-herdsman-converters": "14.0.238",
+    "zigbee-herdsman-converters": "14.0.248",
     "zigbee2mqtt-frontend": "0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade zigbee-herdsman-converters to the latest version available in https://npm.io/package/zigbee-herdsman-converters