### PR TITLE
Update homeassistant.ts

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -968,7 +968,7 @@ export default class HomeAssistant extends Extension {
             }
 
             if (payload.temperature_command_topic) {
-                payload.temperature_command_topic = `${stateTopic}/set/${payload.temperature_command_topic}`;
+                payload.temperature_command_topic = `${stateTopic}/set`;
             }
 
             if (payload.temperature_low_command_topic) {


### PR DESCRIPTION
Fix issue where temperature_command_topic is defined as payload.temperature_command_topic = ${stateTopic}/set/${payload.temperature_command_topic} but sending ${stateTopic}/set/occupied_heating_setpoint results in an error as occupied_heating_setpoint should be part of the payload, not the topic.
Changing it to just "${stateTopic}/set/" results in correct behaviour for the eurotronic thermostat valve.