### PR TITLE
Add support for unit of measurement to HA number entities

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -617,6 +617,7 @@ export default class HomeAssistant extends Extension {
                         command_topic_postfix: firstExpose.property,
                         min: firstExpose.value_min ? firstExpose.value_min : -65535,
                         max: firstExpose.value_max ? firstExpose.value_max : 65535,
+                        ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
                         ...lookup[firstExpose.name],
                     },
                 };


### PR DESCRIPTION
Currently, the number entities exposed to Home Assistant are lacking the unit of measurement.

This makes these look very weird:

![image](https://user-images.githubusercontent.com/195327/138605319-360bfb78-e75a-4cdc-9ffd-40748f599ef2.png)

120 of wat? hours, minutes, second? :)

This PR adds support for sending over the unit of measurement with the number entities.

Home Assistant has default support for this, however, it seems like the parameter was never exposed to MQTT. Support on the Home Assistant end is being added here: <https://github.com/home-assistant/core/pull/58343>
