### PR TITLE
Revert "Add support for unit of measurement to HA number entities"

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -617,7 +617,6 @@ export default class HomeAssistant extends Extension {
                         command_topic_postfix: firstExpose.property,
                         min: firstExpose.value_min ? firstExpose.value_min : -65535,
                         max: firstExpose.value_max ? firstExpose.value_max : 65535,
-                        ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
                         ...lookup[firstExpose.name],
                     },
                 };


### PR DESCRIPTION
Reverts #9312 since it throws errors for HA < 2021.11 (which has not been released yet)

After the release of HA 2021.11:
- This revert should be reverted
- Merge #9309 #9306 #9305