### PR TITLE
Fix homeassistant discovery message for Centralite thermostat fan_only runningstate

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -219,7 +219,7 @@ export default class HomeAssistant extends Extension {
                 discoveryEntry.mockProperties.push(state.property);
                 discoveryEntry.discovery_payload.action_topic = true;
                 discoveryEntry.discovery_payload.action_template = `{% set values = ` +
-                        `{None:None,'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'}` +
+                        `{None:None,'idle':'off','heat':'heating','cool':'cooling','fan_only':'fan'}` +
                         ` %}{{ values[value_json.${state.property}] }}`;
             }
 


### PR DESCRIPTION
There is a mismatch between the Centralite's running state of "fan_only" and what is sent in the discovery payload to Home Assistant as the value to match on "fan only". This PR is to correct the discovery message sent to Home Assistant so it uses the correct value of "fan_only". As far as I can tell, only the Centralite thermostats even use this value.