### PR TITLE
receive: Add genPollCtrl to ignored clusters

### DIFF
--- a/lib/extension/receive.ts
+++ b/lib/extension/receive.ts
@@ -114,7 +114,7 @@ export default class Receive extends Extension {
         });
 
         // Check if there is an available converter, genOta messages are not interesting.
-        const ignoreClusters: (string | number)[] = ['genOta', 'genTime', 'genBasic'];
+        const ignoreClusters: (string | number)[] = ['genOta', 'genTime', 'genBasic', 'genPollCtrl'];
         if (converters.length == 0 && !ignoreClusters.includes(data.cluster)) {
             logger.debug(`No converter available for '${data.device.definition.model}' with ` +
                 `cluster '${data.cluster}' and type '${data.type}' and data '${stringify(data.data)}'`);


### PR DESCRIPTION
zigbee-herdsman may bind genPollCtrl for poll control integration, but
that does not mean that there will be a converter available further up
the stack.