### PR TITLE
Expose local_temperature_calibration in HA as numeric

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -267,7 +267,7 @@ export default class HomeAssistant extends Extension {
 
             const tempCalibration = firstExpose.features.find((f) => f.name === 'local_temperature_calibration');
             if (tempCalibration) {
-                const discoveryEntry = {
+                const discoveryEntry: DiscoveryEntry = {
                     type: 'number',
                     object_id: endpoint ? `${tempCalibration.name}_${endpoint}` : `${tempCalibration.name}`,
                     mockProperties: [tempCalibration.property],
@@ -276,16 +276,14 @@ export default class HomeAssistant extends Extension {
                         command_topic: true,
                         command_topic_prefix: endpoint,
                         command_topic_postfix: tempCalibration.property,
+                        entity_category: 'config',
+                        icon: 'mdi:math-compass',
+                        ...(tempCalibration.unit && {unit_of_measurement: tempCalibration.unit}),
                     },
                 };
 
-                if (tempCalibration.value_min != null) {
-                    discoveryEntry.discovery_payload.min = tempCalibration.value_min;
-                }
-                if (tempCalibration.value_max != null) {
-                    discoveryEntry.discovery_payload.max = tempCalibration.value_max;
-                }
-
+                if (tempCalibration.value_min != null) discoveryEntry.discovery_payload.min = tempCalibration.value_min;
+                if (tempCalibration.value_max != null) discoveryEntry.discovery_payload.max = tempCalibration.value_max;
                 discoveryEntries.push(discoveryEntry);
             }
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -278,7 +278,7 @@ export default class HomeAssistant extends Extension {
                         command_topic_prefix: endpoint,
                         command_topic_postfix: tempCalibration.property,
                         min: -65535,
-                        max: 65535
+                        max: 65535,
                     },
                 };
                 discoveryEntries.push(discoveryEntry);

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -281,6 +281,14 @@ export default class HomeAssistant extends Extension {
                         max: 65535,
                     },
                 };
+
+                if (tempCalibration.value_min != null) {
+                    discoveryEntry.discovery_payload.min = tempCalibration.value_min;
+                }
+                if (tempCalibration.value_max != null) {
+                    discoveryEntry.discovery_payload.max = tempCalibration.value_max;
+                }
+
                 discoveryEntries.push(discoveryEntry);
             }
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -266,6 +266,24 @@ export default class HomeAssistant extends Extension {
                     `{{ value_json.${awayMode.property} }}`;
             }
 
+            const tempCalibration = firstExpose.features.find((f) => f.name === 'local_temperature_calibration');
+            if (tempCalibration) {
+                const discoveryEntry = {
+                    type: 'number',
+                    object_id: endpoint ? `${tempCalibration.name}_${endpoint}` : `${tempCalibration.name}`,
+                    mockProperties: [tempCalibration.property],
+                    discovery_payload: {
+                        value_template: `{{ value_json.${tempCalibration.property} }}`,
+                        command_topic: true,
+                        command_topic_prefix: endpoint,
+                        command_topic_postfix: tempCalibration.property,
+                        min: -65535,
+                        max: 65535
+                    },
+                };
+                discoveryEntries.push(discoveryEntry);
+            }
+
             discoveryEntries.push(discoveryEntry);
         } else if (firstExpose.type === 'lock') {
             assert(!endpoint, `Endpoint not supported for lock type`);

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -277,8 +277,6 @@ export default class HomeAssistant extends Extension {
                         command_topic: true,
                         command_topic_prefix: endpoint,
                         command_topic_postfix: tempCalibration.property,
-                        min: -65535,
-                        max: 65535,
                     },
                 };
 

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -95,7 +95,7 @@ declare global {
         }
 
         interface DefinitionExposeFeature {name: string, endpoint?: string,
-            property: string, value_max?: number, value_min?: number,
+            property: string, value_max?: number, value_min?: number, unit?: string,
             value_off?: string, value_on?: string, value_step?: number, values: string[], access: number}
 
         interface DefinitionExpose {


### PR DESCRIPTION
Hello! 

This PR will enable discovery a climate `local_temperature_calibration` in Home Assistant as `Number` entity.

This will close: #9543 and #9269