### PR TITLE
Fix local_temperature_calibration in HA

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -277,6 +277,8 @@ export default class HomeAssistant extends Extension {
                         command_topic: true,
                         command_topic_prefix: endpoint,
                         command_topic_postfix: tempCalibration.property,
+                        min: -65535,
+                        max: 65535,
                         entity_category: 'config',
                         icon: 'mdi:math-compass',
                         ...(tempCalibration.unit && {unit_of_measurement: tempCalibration.unit}),


### PR DESCRIPTION
Revert magic min/max values, because the HA stops taking negative values and displays the input as a range slider.

<img width="300" src="https://user-images.githubusercontent.com/11841379/141367210-9ec0bc56-4a5f-41e2-98ea-b9f308328b9a.png">

[Described here.](https://github.com/Koenkk/zigbee2mqtt/pull/9595#issuecomment-966618820)