### PR TITLE
write state.json every 15 seconds

### DIFF
--- a/lib/state.ts
+++ b/lib/state.ts
@@ -4,7 +4,7 @@ import * as settings from './util/settings';
 import fs from 'fs';
 import objectAssignDeep from 'object-assign-deep';
 
-const saveInterval = 1000 * 60 * 5; // 5 minutes
+const saveInterval = 15 * 1000; // 15 seconds
 
 const dontCacheProperties = [
     '^action$', '^action_.*$', '^button$', '^button_left$', '^button_right$', '^click$', '^forgotten$', '^keyerror$',


### PR DESCRIPTION
Hi - and thanks for your work around zigbee2mqtt !

I've been toying with a setup using docker and docker-compose recently so that sensor monitoring can be done through grafana/prometheus, and so that any kind logic can be setup locally through code ([it's here](https://github.com/pldubouilh/zigbee2grafana)).

Would it be acceptable to write the `state.json` file every 15 seconds instead of 5 minutes ? I don't think it should have a too negative impact on perfs, but it'd align the write time to prometheus' default scraping value. It's the only [single change](https://github.com/pldubouilh/zigbee2grafana/blob/main/dockers/zigbee/run.sh#L2) I'm doing to zigbee2mqtt - and it seems fairly transparent :)

Cheers !