### PR TITLE
homeassistant: expose pi_heating_demand on climate

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -288,6 +288,23 @@ export default class HomeAssistant extends Extension {
                 discoveryEntries.push(discoveryEntry);
             }
 
+            const piHeatingDemand = firstExpose.features.find((f) => f.name === 'pi_heating_demand');
+            if (piHeatingDemand) {
+                const discoveryEntry = {
+                    type: 'sensor',
+                    object_id: endpoint ? `${piHeatingDemand.name}_${endpoint}` : `${piHeatingDemand.name}`,
+                    mockProperties: [piHeatingDemand.property],
+                    discovery_payload: {
+                        value_template: `{{ value_json.${piHeatingDemand.property} }}`,
+                        ...(piHeatingDemand.unit && { unit_of_measurement: piHeatingDemand.unit }),
+                        entity_category: 'diagnostic', 
+                        icon: 'mdi:radiator',
+                    },
+                };
+
+                discoveryEntries.push(discoveryEntry);
+            }
+            
             discoveryEntries.push(discoveryEntry);
         } else if (firstExpose.type === 'lock') {
             assert(!endpoint, `Endpoint not supported for lock type`);

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -296,15 +296,15 @@ export default class HomeAssistant extends Extension {
                     mockProperties: [piHeatingDemand.property],
                     discovery_payload: {
                         value_template: `{{ value_json.${piHeatingDemand.property} }}`,
-                        ...(piHeatingDemand.unit && { unit_of_measurement: piHeatingDemand.unit }),
-                        entity_category: 'diagnostic', 
+                        ...(piHeatingDemand.unit && {unit_of_measurement: piHeatingDemand.unit}),
+                        entity_category: 'diagnostic',
                         icon: 'mdi:radiator',
                     },
                 };
 
                 discoveryEntries.push(discoveryEntry);
             }
-            
+
             discoveryEntries.push(discoveryEntry);
         } else if (firstExpose.type === 'lock') {
             assert(!endpoint, `Endpoint not supported for lock type`);


### PR DESCRIPTION
This allows homeassistant to access the actual percentage actuation currently used on thermostats.