### PR TITLE
Fix log commit hash newline

### DIFF
--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -70,8 +70,7 @@ async function getZigbee2MQTTVersion(includeCommitHash=true): Promise<{commitHas
                 commitHash = commit.shortHash;
             }
 
-            commitHash = commitHash.trim()
-
+            commitHash = commitHash.trim();
             resolve({commitHash, version});
         });
     });

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -70,6 +70,8 @@ async function getZigbee2MQTTVersion(includeCommitHash=true): Promise<{commitHas
                 commitHash = commit.shortHash;
             }
 
+            commitHash = commitHash.trim()
+
             resolve({commitHash, version});
         });
     });


### PR DESCRIPTION
Hello,

This simple change removes \r & \n characters from the commit hash. I don't know how they ended there but this makes sure that even if they do, they are removed before logging.
Before the change:
![obraz](https://user-images.githubusercontent.com/68441479/143786366-363d13f2-1341-429d-b48b-54e544acbc42.png)
After the change:
![obraz](https://user-images.githubusercontent.com/68441479/143786375-07bd824d-420b-49d3-b3ed-8ded13749097.png)

This would cause some syslog servers freak out and treat all logs as one message.
Submitting third time (the charm) due to my mistakes.
Possible relation to #9872 