### PR TITLE
Replace serve-static with connect-gzip-static

### DIFF
--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -1,5 +1,5 @@
 import http from 'http';
-import gzipStatic, { RequestHandler } from 'connect-gzip-static';
+import gzipStatic, {RequestHandler} from 'connect-gzip-static';
 import finalhandler from 'finalhandler';
 import logger from '../util/logger';
 import frontend from 'zigbee2mqtt-frontend';
@@ -37,13 +37,14 @@ export default class Frontend extends Extension {
         this.server = http.createServer(this.onRequest);
         this.server.on('upgrade', this.onUpgrade);
 
-        /* istanbul ignore next */ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        /* istanbul ignore next */
         const options = {
-            setHeaders: (res: any, path: any): void => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            setHeaders: (res: any, path: string): void => {
                 if (path.endsWith('index.html')) {
                     res.setHeader('Cache-Control', 'no-store');
                 }
-            }
+            },
         };
         this.fileServer = gzipStatic(frontend.getPath(), options);
         this.wss = new WebSocket.Server({noServer: true});

--- a/lib/types/zigbee2mqtt-frontend.d.ts
+++ b/lib/types/zigbee2mqtt-frontend.d.ts
@@ -3,6 +3,7 @@ declare module 'zigbee2mqtt-frontend' {
 }
 
 declare module 'connect-gzip-static' {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export type RequestHandler = (req: any, res: any) => void;
-    export default function gzipStatic(root: string, options?: {}): RequestHandler;
+    export default function gzipStatic(root: string, options?: Record<string, unknown>): RequestHandler;
 }

--- a/lib/types/zigbee2mqtt-frontend.ts
+++ b/lib/types/zigbee2mqtt-frontend.ts
@@ -1,3 +1,8 @@
 declare module 'zigbee2mqtt-frontend' {
     export function getPath(): string;
 }
+
+declare module 'connect-gzip-static' {
+    export type RequestHandler = (req: any, res: any) => void;
+    export default function gzipStatic(root: string, options?: {}): RequestHandler;
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2031,12 +2031,6 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
-    "@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -2068,16 +2062,6 @@
       "dev": true,
       "requires": {
         "@types/glob": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/serve-static": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
-      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "dev": true,
-      "requires": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -2814,6 +2798,18 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "connect-gzip-static": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/connect-gzip-static/-/connect-gzip-static-2.1.1.tgz",
+      "integrity": "sha512-Ipf0aLx4MmLNMgwBuH8Cv3mk+O2KxshGN9E5I9RsWJObYiMJwC9JVZn9S+PTFpggRnig25WCOkYdFHZJP8vZ6Q==",
+      "requires": {
+        "debug": "~2",
+        "find": "~0",
+        "parseurl": "~1",
+        "send": "~0",
+        "serve-static": "~1"
       }
     },
     "convert-source-map": {
@@ -3584,6 +3580,14 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
+      }
+    },
+    "find": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find/-/find-0.3.0.tgz",
+      "integrity": "sha512-iSd+O4OEYV/I36Zl8MdYJO0xD82wH528SaCieTVHhclgiYNe9y+yPKSwK+A7/WsmHL1EZ+pYUJBXWTL5qofksw==",
+      "requires": {
+        "traverse-chain": "~0.1.0"
       }
     },
     "find-up": {
@@ -6525,6 +6529,11 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "traverse-chain": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE="
     },
     "triple-beam": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "ajv": "^8.8.2",
     "bind-decorator": "^1.0.11",
+    "connect-gzip-static": "^2.1.1",
     "core-js": "^3.19.1",
     "debounce": "^1.2.1",
     "deep-object-diff": "^1.1.0",
@@ -52,7 +53,6 @@
     "object-assign-deep": "^0.4.0",
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
-    "serve-static": "^1.14.1",
     "source-map-support": "^0.5.21",
     "winston": "^3.3.3",
     "winston-syslog": "^2.4.4",
@@ -73,7 +73,6 @@
     "@types/js-yaml": "^4.0.5",
     "@types/object-assign-deep": "^0.4.0",
     "@types/rimraf": "^3.0.2",
-    "@types/serve-static": "^1.13.10",
     "@types/ws": "^8.2.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -50,7 +50,7 @@ jest.mock('http', () => ({
     }),
 }));
 
-jest.mock("serve-static", () =>
+jest.mock("connect-gzip-static", () =>
     jest.fn().mockImplementation((path) => {
         mockNodeStatic.variables.path = path
         return mockNodeStatic.implementation


### PR DESCRIPTION
Replace serve-static with [connect-gzip-static](https://github.com/pirxpilot/connect-gzip-static/blob/master/lib/gzip-static.js) in order to serve pre compressed .gz files with js and css files.

Frontend already bundles .gz files in npm package

