### PR TITLE
Add poll for updates after bound remote command for TuYa device TS0501B

### DIFF
--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -99,6 +99,7 @@ const pollOnMessage: PollOnMessage = [
             zigbeeHersdman.Zcl.ManufacturerCode.ATMEL,
             zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
             zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
+            zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
         ],
     },
     {
@@ -129,6 +130,7 @@ const pollOnMessage: PollOnMessage = [
             zigbeeHersdman.Zcl.ManufacturerCode.ATMEL,
             zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
             zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
+            zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
         ],
     },
     {
@@ -155,6 +157,7 @@ const pollOnMessage: PollOnMessage = [
             zigbeeHersdman.Zcl.ManufacturerCode.ATMEL,
             zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
             zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
+            zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
         ],
     },
 ];


### PR DESCRIPTION
This change add manufacturer ID to list of devices, polled for changes after receive command bound from bound remote.
Device zigbee model TS0501B, zigbee manufacturer _TZ3210_9q49basr
Device "manufId" from database.db is 4417
