### PR TITLE
Add support for local OTA firmware images

### DIFF
--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -43,6 +43,7 @@ export default class OTAUpdate extends Extension {
             tradfriOTA.useTestURL();
         }
 
+        // Let zigbeeOTA module know if the override index file is provided
         let overrideOTAIndex = settings.get().ota.zigbee_ota_override_index_location;
         if (overrideOTAIndex) {
             // If the file name is not a full path, then treat it as a relative to the data directory
@@ -53,9 +54,12 @@ export default class OTAUpdate extends Extension {
             zigbeeOTA.useIndexOverride(overrideOTAIndex);
         }
 
+        // In order to support local firmware files we need to let zigbeeOTA know where the data directory is
+        zigbeeOTA.setDataDir(dataDir.getPath());
+
+        // In case Zigbee2MQTT is restared during an update, progress and remaining values are still in state.
+        // remove them.
         for (const device of this.zigbee.devices(false)) {
-            // In case Zigbee2MQTT is restared during an update, progress and remaining values are still in state.
-            // remove them.
             this.removeProgressAndRemainingFromState(device);
         }
     }

--- a/lib/types/zigbee-herdsman-converters.d.ts
+++ b/lib/types/zigbee-herdsman-converters.d.ts
@@ -13,5 +13,5 @@ declare module 'zigbee-herdsman-converters/lib/ota/tradfri' {
 
 declare module 'zigbee-herdsman-converters/lib/ota/zigbeeOTA' {
     export function useIndexOverride(indexFileName: string): void;
+    export function setDataDir(dataDir: string): void;
 }
-


### PR DESCRIPTION
This is an accompanying change for https://github.com/Koenkk/zigbee-herdsman-converters/pull/3652 . See motivation and implementation details there. This change lets herdsman-converters know where the data directory is located, so that herdsman-converters can use paths relative to the data directory.