### PR TITLE
Async expose

### DIFF
--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -112,7 +112,8 @@ export default class Configure extends Extension {
 
         logger.info(`Configuring '${device.name}'`);
         try {
-            await device.definition.configure(device.zh, this.zigbee.firstCoordinatorEndpoint(), logger);
+            await device.definition.configure(device.zh, this.zigbee.firstCoordinatorEndpoint(), logger,
+                device.options);
             logger.info(`Successfully configured '${device.name}'`);
             device.zh.meta.configured = zhc.getConfigureKey(device.definition);
             device.zh.save();

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -143,7 +143,7 @@ export default class Groups extends Extension {
                 const groupsToPublish: Set<Group> = new Set();
                 for (const member of entity.zh.members) {
                     const device = this.zigbee.resolveEntity(member.getDevice()) as Device;
-                    const exposes = device.exposes();
+                    const exposes = await device.exposes();
                     const memberPayload: KeyValue = {};
                     Object.keys(payload).forEach((key) => {
                         if (stateProperties[key](payload[key], exposes)) {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -888,8 +888,9 @@ export default class HomeAssistant extends Extension {
 
         let configs: DiscoveryEntry[] = [];
         if (isDevice) {
-            for (const expose of await entity.exposes()) {
-                configs.push(...this.exposeToConfig([expose], 'device', entity.definition, await entity.exposes()));
+            const devExpose = await entity.exposes();
+            for (const expose of devExpose) {
+                configs.push(...this.exposeToConfig([expose], 'device', entity.definition, devExpose));
             }
 
             for (const mapping of legacyMapping) {

--- a/lib/extension/networkMap.ts
+++ b/lib/extension/networkMap.ts
@@ -267,7 +267,7 @@ export default class NetworkMap extends Extension {
                 model: device.definition.model,
                 vendor: device.definition.vendor,
                 description: device.definition.description,
-                supports: Array.from(new Set((device.exposes()).map((e) => {
+                supports: Array.from(new Set((await device.exposes()).map((e) => {
                     return e.hasOwnProperty('name') ? e.name :
                         `${e.type} (${e.features.map((f) => f.name).join(', ')})`;
                 }))).join(', '),

--- a/lib/model/device.ts
+++ b/lib/model/device.ts
@@ -23,7 +23,7 @@ export default class Device {
         this.zh = device;
     }
 
-    exposes(): zhc.DefinitionExpose[] {
+    async exposes(): Promise<zhc.DefinitionExpose[]> {
         /* istanbul ignore if */
         if (typeof this.definition.exposes == 'function') {
             return this.definition.exposes(this.zh, this.options);

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -115,7 +115,8 @@ declare global {
             options: zhc.DefinitionExpose[],
             vendor: string
             exposes: DefinitionExpose[] | ((device: zh.Device, options: KeyValue) => DefinitionExpose[])
-            configure?: (device: zh.Device, coordinatorEndpoint: zh.Endpoint, logger: Logger) => Promise<void>;
+            configure?: (device: zh.Device, coordinatorEndpoint: zh.Endpoint, logger: Logger,
+                options?: DeviceOptions) => Promise<void>;
             onEvent?: (type: string, data: KeyValue, device: zh.Device, settings: KeyValue) => Promise<void>;
             ota?: {
                 isUpdateAvailable: (device: zh.Device, logger: Logger, data?: KeyValue) => Promise<boolean>;

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -1129,31 +1129,31 @@ describe('Bridge', () => {
         const svg_icon = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo';
         const icon_link =  'https://www.zigbee2mqtt.io/images/devices/ZNCZ02LM.jpg';
         definition.icon = icon_link;
-        let payload = bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
+        let payload = await bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
         expect(payload).not.toBeUndefined()
         expect(payload['icon']).not.toBeUndefined()
         expect(payload.icon).toBe(icon_link);
 
         definition.icon = icon_link;
-        payload = bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {icon: svg_icon}});
+        payload = await bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {icon: svg_icon}});
         expect(payload).not.toBeUndefined()
         expect(payload['icon']).not.toBeUndefined()
         expect(payload.icon).toBe(svg_icon);
 
         definition.icon = '_${model}_';
-        payload = bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
+        payload = await bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
         expect(payload).not.toBeUndefined()
         expect(payload['icon']).not.toBeUndefined()
         expect(payload.icon).toBe('_lumi.plug_');
 
         definition.icon = '_${model}_${zigbeeModel}_';
-        payload = bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
+        payload = await bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
         expect(payload).not.toBeUndefined()
         expect(payload['icon']).not.toBeUndefined()
         expect(payload.icon).toBe('_lumi.plug_lumi.plug_');
 
         definition.icon = svg_icon;
-        payload = bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
+        payload = await bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
         expect(payload).not.toBeUndefined()
         expect(payload['icon']).not.toBeUndefined()
         expect(payload.icon).toBe(svg_icon);
@@ -1161,7 +1161,7 @@ describe('Bridge', () => {
         device.modelID = '?._Z\\NC+Z02*LM';
         definition.model = '&&&&*+';
         definition.icon = '_${model}_${zigbeeModel}_';
-        payload = bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
+        payload = await bridge.getDefinitionPayload({...device, zh: device, definition, exposes: () => definition.exposes, options: {}});
         expect(payload).not.toBeUndefined()
         expect(payload['icon']).not.toBeUndefined()
         expect(payload.icon).toBe('_------_-._Z-NC-Z02-LM_');

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -133,6 +133,7 @@ describe('Frontend', () => {
         expect(mockWSClient.implementation.send).toHaveBeenCalledWith(stringify({topic:"remote", payload:{brightness:255}}));
 
         // Message
+        await flushPromises();
         MQTT.publish.mockClear();
         mockWSClient.implementation.send.mockClear();
         mockWSClient.events.message(stringify({topic: 'bulb_color/set', payload: {state: 'ON'}}), false)


### PR DESCRIPTION
Hello,

Following the features of https://github.com/Koenkk/zigbee2mqtt/pull/10132, one of the things I need is able to read cluster/attributes at the very first stage, during the expose step.

There is a vendor specific attribute that give me the information of the operating mode of the device. And with that configuration, I can expose the correct labels to the end user.

However, it seems to me that reading from `exposes` directly doesn't work for some reason. Maybe I missing something...