### PR TITLE
GitHub issue templates: : Remove leading "[Problem]" in the title and the requirements to fill out all fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem_report.yaml
+++ b/.github/ISSUE_TEMPLATE/problem_report.yaml
@@ -1,6 +1,5 @@
 name: Problem report
 description: Create a report to help us improve
-title: "[Problem]: "
 labels: [problem]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/problem_report.yaml
+++ b/.github/ISSUE_TEMPLATE/problem_report.yaml
@@ -25,14 +25,14 @@ body:
       label: What did you expect to happen?
       placeholder: I expected that ...
     validations:
-      required: true
+      required: false
   - type: textarea
     id: reproduce
     attributes:
       label: How to reproduce it (minimal and precise)
       placeholder: First do this, than this..
     validations:
-      required: true
+      required: false
   - type: input
     id: z2m_version
     attributes:
@@ -64,4 +64,4 @@ body:
       description: After enabling [debug logging](https://www.zigbee2mqtt.io/guide/usage/debug.html) the log can be found under `data/log`. Attach the file below
       placeholder: Click here and drag the file into it or click on "Attach files by.." below
     validations:
-      required: true
+      required: false


### PR DESCRIPTION
## Motivation 

- The leading "[Problem]" makes it harder to visually parse a list of issues IMHO and is redundant as we already set a label "problem"
- Three fields feel pretty obnoxious to fill out. I know it's good to have all information available, but in some cases, there's absolutely no need to pressure users to fill those out with nonsense, just to let them edit the nonsense and the headline out again, after filing the issue.

## Changes

- Remove leading "[Problem] " preset for the issue reports
- Remove "What did you expect to happen?" fillin requirement
- Remove "How to reproduce it (minimal and precise)" fillin requirement
- Remove "Debug log" fillin requirement