### PR TITLE
Fix endpoint match

### DIFF
--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -10,7 +10,7 @@ import Device from '../model/device';
 import bind from 'bind-decorator';
 
 const topicRegex = new RegExp(`^(.+?)(?:/(${utils.endpointNames.join('|')}|\\d+))?/(get|set)(?:/(.+))?`);
-const propertyEndpointRegex = new RegExp(`^(.*)_(${utils.endpointNames.join('|')})$`);
+const propertyEndpointRegex = new RegExp(`^([^_]*)_(${utils.endpointNames.join('|')})$`);
 const stateValues = ['on', 'off', 'toggle', 'open', 'close', 'stop', 'lock', 'unlock'];
 const sceneConverterKeys = ['scene_store', 'scene_add', 'scene_remove', 'scene_remove_all'];
 


### PR DESCRIPTION
https://github.com/Koenkk/zigbee2mqtt/discussions/9504

For this case property is 'state_top_left', 'state_bottom_left' and etc..,
Old pattern it is match as: [state_top_left, state_top, left]
New pattern it is match as: [state_top_left, state, top_left]