### PR TITLE
Flush logger before exiting process

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -104,14 +104,7 @@ class Controller {
             logger.error('Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start.html for possible solutions'); /* eslint-disable-line max-len */
             logger.error('Exiting...');
             logger.error(error.stack);
-
-            // Workaround for https://github.com/winstonjs/winston/issues/1629
-            await new Promise<void>((resolve, reject) => {
-                logger.winston.on('finish', () => {
-                    setTimeout(() => resolve(), 1000);
-                });
-                logger.winston.end();
-				    });
+            await logger.end();
             this.exitCallback(1);
         }
 

--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -104,6 +104,14 @@ class Controller {
             logger.error('Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start.html for possible solutions'); /* eslint-disable-line max-len */
             logger.error('Exiting...');
             logger.error(error.stack);
+
+            // Workaround for https://github.com/winstonjs/winston/issues/1629
+            await new Promise<void>((resolve, reject) => {
+                logger.winston.on('finish', () => {
+                    setTimeout(() => resolve(), 1000);
+                });
+                logger.winston.end();
+				    });
             this.exitCallback(1);
         }
 

--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -104,8 +104,7 @@ class Controller {
             logger.error('Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start.html for possible solutions'); /* eslint-disable-line max-len */
             logger.error('Exiting...');
             logger.error(error.stack);
-            await logger.end();
-            this.exitCallback(1);
+            await this.exit(1);
         }
 
         // Disable some legacy options on new network creation
@@ -146,7 +145,7 @@ class Controller {
             logger.error(`MQTT failed to connect: ${error.message}`);
             logger.error('Exiting...');
             await this.zigbee.stop();
-            this.exitCallback(1);
+            await this.exit(1);
         }
 
         // Call extensions
@@ -198,11 +197,16 @@ class Controller {
         try {
             await this.zigbee.stop();
             logger.info('Stopped Zigbee2MQTT');
-            this.exitCallback(0);
+            await this.exit(0);
         } catch (error) {
             logger.error('Failed to stop Zigbee2MQTT');
-            this.exitCallback(1);
+            await this.exit(1);
         }
+    }
+
+    async exit(code: number): Promise<void> {
+        await logger.end();
+        this.exitCallback(code);
     }
 
     @bind async onZigbeeAdapterDisconnected(): Promise<void> {

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -184,24 +184,23 @@ function error(message: string): void {
 }
 
 // Workaround for https://github.com/winstonjs/winston/issues/1629.
+// https://github.com/Koenkk/zigbee2mqtt/pull/10905
+/* istanbul ignore next */
 async function end(): Promise<void> {
     logger.end();
 
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve) => {
         if (!fileTransport) {
-          process.nextTick(resolve);
-          return;
-        }
-
-        // @ts-ignore
-        if (fileTransport._dest) {
-            // @ts-ignore
-            fileTransport._dest.on('finish', resolve);
+            process.nextTick(resolve);
         } else {
-            fileTransport.on('open', () => {
+            // @ts-ignore
+            if (fileTransport._dest) {
                 // @ts-ignore
                 fileTransport._dest.on('finish', resolve);
-            });
+            } else {
+                // @ts-ignore
+                fileTransport.on('open', () => fileTransport._dest.on('finish', resolve));
+            }
         }
     });
 }

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -181,6 +181,16 @@ function error(message: string): void {
     logger.error(message);
 }
 
+// Workaround for https://github.com/winstonjs/winston/issues/1629.
+async function end(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        logger.on('finish', () => {
+            setTimeout(() => resolve(), 1000);
+        });
+        logger.end();
+    });
+}
+
 export default {
-    logOutput, warn, warning, error, info, debug, setLevel, getLevel, cleanup, addTransport, winston: logger,
+    logOutput, warn, warning, error, info, debug, setLevel, getLevel, cleanup, addTransport, end, winston: logger,
 };

--- a/test/stub/logger.js
+++ b/test/stub/logger.js
@@ -23,7 +23,7 @@ const mock = {
     setLevel: (newLevel) => {level = newLevel},
     getLevel: () => level,
     setTransportsEnabled: (value) => {transportsEnabled = value},
-    on: jest.fn(),
+    end: jest.fn(),
 };
 
 jest.mock('../../lib/util/logger', () => (mock));

--- a/test/stub/logger.js
+++ b/test/stub/logger.js
@@ -23,6 +23,7 @@ const mock = {
     setLevel: (newLevel) => {level = newLevel},
     getLevel: () => level,
     setTransportsEnabled: (value) => {transportsEnabled = value},
+    on: jest.fn(),
 };
 
 jest.mock('../../lib/util/logger', () => (mock));


### PR DESCRIPTION
I am using the `file` logger without the `console` logger and if Z2M is unable to start then nothing is logged because `process.exit(1)` is calling and WInston doesn't flush async logs when this happens (see winstonjs/winston#1629).

With console logging enabled:

```
Zigbee2MQTT:info  2022-01-20 05:01:21: Logging to console and directory: '/app/data' filename: z2m.log
Zigbee2MQTT:info  2022-01-20 05:01:21: Starting Zigbee2MQTT version 1.22.2-dev (commit #)
Zigbee2MQTT:info  2022-01-20 05:01:21: Starting zigbee-herdsman (0.14.1)
Zigbee2MQTT:error 2022-01-20 05:01:21: Error while starting zigbee-herdsman
Zigbee2MQTT:error 2022-01-20 05:01:21: Failed to start zigbee
Zigbee2MQTT:error 2022-01-20 05:01:21: Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start.html for possible solutions
Zigbee2MQTT:error 2022-01-20 05:01:21: Exiting...
Zigbee2MQTT:error 2022-01-20 05:01:21: Error: Error while opening serialport 'Error: Error: No such file or directory, cannot open /dev/ttyACM0'
    at SerialPort.<anonymous> (/app/node_modules/zigbee-herdsman/src/adapter/z-stack/znp/znp.ts:146:28)
    at SerialPort._error (/app/node_modules/zigbee-herdsman/node_modules/@serialport/stream/lib/index.js:198:14)
    at /app/node_modules/zigbee-herdsman/node_modules/@serialport/stream/lib/index.js:242:12
```

With file logging:

```
info  2022-01-20 05:03:36: Logging to directory: '/app/data' filename: z2m.log
info  2022-01-20 05:03:36: Starting Zigbee2MQTT version 1.22.2-dev (commit #)
info  2022-01-20 05:03:36: Starting zigbee-herdsman (0.14.1)
error 2022-01-20 05:03:36: Error while starting zigbee-herdsman
```