### PR TITLE
HA Discover when user change option

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -95,8 +95,7 @@ export default class HomeAssistant extends Extension {
         this.eventBus.onDeviceJoined(this, this.onZigbeeEvent);
         this.eventBus.onDeviceInterview(this, this.onZigbeeEvent);
         this.eventBus.onDeviceMessage(this, this.onZigbeeEvent);
-        this.eventBus.onEntityOptionsChanged(this,
-            (data) => this.discover(data.entity, true));
+        this.eventBus.onEntityOptionsChanged(this, (data) => this.discover(data.entity, true));
 
         this.mqtt.subscribe(this.statusTopic);
         this.mqtt.subscribe(defaultStatusTopic);

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -897,9 +897,9 @@ export default class HomeAssistant extends Extension {
 
         let configs: DiscoveryEntry[] = [];
         if (isDevice) {
-            const exp = entity.exposes(); // avoid calling it hundred of times/s
-            for (const expose of exp) {
-                configs.push(...this.exposeToConfig([expose], 'device', entity.definition, exp));
+            const exposes = entity.exposes(); // avoid calling it hundred of times/s
+            for (const expose of exposes) {
+                configs.push(...this.exposeToConfig([expose], 'device', entity.definition, exposes));
             }
 
             for (const mapping of legacyMapping) {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -95,6 +95,8 @@ export default class HomeAssistant extends Extension {
         this.eventBus.onDeviceJoined(this, this.onZigbeeEvent);
         this.eventBus.onDeviceInterview(this, this.onZigbeeEvent);
         this.eventBus.onDeviceMessage(this, this.onZigbeeEvent);
+        this.eventBus.onEntityOptionsChanged(this,
+            (data) => this.discover(data.entity, true));
 
         this.mqtt.subscribe(this.statusTopic);
         this.mqtt.subscribe(defaultStatusTopic);
@@ -896,8 +898,9 @@ export default class HomeAssistant extends Extension {
 
         let configs: DiscoveryEntry[] = [];
         if (isDevice) {
-            for (const expose of entity.exposes()) {
-                configs.push(...this.exposeToConfig([expose], 'device', entity.definition, entity.exposes()));
+            const exp = entity.exposes(); // avoid calling it hundred of times/s
+            for (const expose of exp) {
+                configs.push(...this.exposeToConfig([expose], 'device', entity.definition, exp));
             }
 
             for (const mapping of legacyMapping) {


### PR DESCRIPTION
Sorry, I'm not sure how to set correctly the unit test for coverage. This PR doesn't clear the old entities dynamically (was not able to make it work properly), so it requires a restart.

Required for https://github.com/Koenkk/zigbee-herdsman-converters/pull/3493#issuecomment-1025989470