### PR TITLE
Add device notes (first draft)

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -28,12 +28,14 @@ import ExtensionOnEvent from './extension/onEvent';
 import ExtensionOTAUpdate from './extension/otaUpdate';
 import ExtensionExternalConverters from './extension/externalConverters';
 import ExtensionExternalExtension from './extension/externalExtension';
+import ExtensionDeviceNotes from './extension/deviceNotes';
 
 const AllExtensions = [
     ExtensionPublish, ExtensionReceive, ExtensionNetworkMap, ExtensionSoftReset, ExtensionHomeAssistant,
     ExtensionConfigure, ExtensionDeviceGroupMembership, ExtensionBridgeLegacy, ExtensionBridge, ExtensionGroups,
     ExtensionBind, ExtensionReport, ExtensionOnEvent, ExtensionOTAUpdate,
     ExtensionExternalConverters, ExtensionFrontend, ExtensionExternalExtension, ExtensionAvailability,
+    ExtensionDeviceNotes,
 ];
 
 type ExtensionArgs = [Zigbee, MQTT, State, PublishEntityState, EventBus,
@@ -78,6 +80,7 @@ class Controller {
             new ExtensionReport(...this.extensionArgs),
             new ExtensionExternalExtension(...this.extensionArgs),
             new ExtensionAvailability(...this.extensionArgs),
+            new ExtensionDeviceNotes(...this.extensionArgs),
             settings.get().frontend && new ExtensionFrontend(...this.extensionArgs),
             settings.get().advanced.legacy_api && new ExtensionBridgeLegacy(...this.extensionArgs),
             settings.get().external_converters.length && new ExtensionExternalConverters(...this.extensionArgs),

--- a/lib/extension/deviceNotes.ts
+++ b/lib/extension/deviceNotes.ts
@@ -63,24 +63,22 @@ export default class DeviceNotes extends Extension {
     }
 
     @bind async onMQTTMessage(data: eventdata.MQTTMessage): Promise<void> {
-        if (data.topic.match(requestRegex)) {
-            const match = data.topic.match(requestRegex);
-            if (match && this.requestLookup[match[1].toLowerCase()]) {
-                const message = utils.parseJSON(data.message, data.message) as KeyValue;
-                try {
-                    const {id} = message;
-                    const device = this.getDevice(id);
-                    if (device == null) {
-                        throw new Error(`Device '${id}' is unknown`);
-                    }
-
-                    const response = await this.requestLookup[match[1].toLowerCase()](device, message);
-                    await this.mqtt.publish(`bridge/response/device/notes/${match[1]}`, stringify(response));
-                } catch (error) {
-                    logger.error(`Request '${data.topic}' failed with error: '${error.message}'`);
-                    const response = utils.getResponse(message, {}, error.message);
-                    await this.mqtt.publish(`bridge/response/device/notes/${match[1]}`, stringify(response));
+        const match = data.topic.match(requestRegex);
+        if (match && this.requestLookup[match[1].toLowerCase()]) {
+            const message = utils.parseJSON(data.message, data.message) as KeyValue;
+            try {
+                const {id} = message;
+                const device = this.getDevice(id);
+                if (device == null) {
+                    throw new Error(`Device '${id}' is unknown`);
                 }
+
+                const response = await this.requestLookup[match[1].toLowerCase()](device, message);
+                await this.mqtt.publish(`bridge/response/device/notes/${match[1]}`, stringify(response));
+            } catch (error) {
+                logger.error(`Request '${data.topic}' failed with error: '${error.message}'`);
+                const response = utils.getResponse(message, {}, error.message);
+                await this.mqtt.publish(`bridge/response/device/notes/${match[1]}`, stringify(response));
             }
         }
     }

--- a/lib/extension/deviceNotes.ts
+++ b/lib/extension/deviceNotes.ts
@@ -1,0 +1,87 @@
+import * as settings from '../util/settings';
+import utils from '../util/utils';
+import fs from 'fs';
+import data from '../util/data';
+import path from 'path';
+import logger from '../util/logger';
+import stringify from 'json-stable-stringify-without-jsonify';
+import bind from 'bind-decorator';
+import Extension from './extension';
+
+const notesExtension = '.txt';
+const requestRegex = new RegExp(`${settings.get().mqtt.base_topic}/bridge/request/device/notes/(read|save)`);
+
+export default class DeviceNotes extends Extension {
+    private requestLookup: {[s: string]: (device: Device, message: KeyValue) => Promise<MQTTResponse>};
+
+    override async start(): Promise<void> {
+        this.requestLookup = {'read': this.getNotes, 'save': this.saveNotes};
+        this.eventBus.onMQTTMessage(this, this.onMQTTMessage);
+    }
+
+    private getExtensionsBasePath(): string {
+        return data.joinPath('notes');
+    }
+
+    private getDevice(id: string): Device {
+        const re = this.zigbee.resolveEntity(id);
+        if (re != null && re.isDevice()) {
+            return re;
+        }
+    }
+
+    @bind private async saveNotes(device: Device, message: KeyValue): Promise<MQTTResponse> {
+        const {notes} = message;
+        const basePath = this.getExtensionsBasePath();
+        const filePath = path.join(basePath, path.basename(`${device.ieeeAddr}${notesExtension}`));
+
+        if (!fs.existsSync(basePath)) {
+            fs.mkdirSync(basePath);
+        }
+
+        fs.writeFileSync(filePath, notes, 'utf-8');
+        logger.info(`Notes for ${device.name} updated`);
+        return utils.getResponse(message, {}, null);
+    }
+
+    @bind private async getNotes(device: Device, message: KeyValue): Promise<MQTTResponse> {
+        const basePath = this.getExtensionsBasePath();
+        const filePath = path.join(basePath, path.basename(`${device.ieeeAddr}${notesExtension}`));
+
+        let mtime: string;
+        let notes: string;
+        if (!fs.existsSync(filePath)) {
+            mtime = null;
+            notes = '';
+        } else {
+            mtime = fs.statSync(filePath).mtime.toISOString();
+            notes = fs.readFileSync(filePath, 'utf8');
+        }
+
+        logger.info(`Notes for ${device.name} requested`);
+        return utils.getResponse(message, {notes: notes, mtime: mtime}, null);
+    }
+
+    @bind async onMQTTMessage(data: eventdata.MQTTMessage): Promise<void> {
+        if (data.topic.match(requestRegex)) {
+            const match = data.topic.match(requestRegex);
+            if (match && this.requestLookup[match[1].toLowerCase()]) {
+                const message = utils.parseJSON(data.message, data.message) as KeyValue;
+                try {
+                    const {id} = message;
+                    const device = this.getDevice(id);
+                    if (device == null) {
+                        throw new Error(`Device '${id}' is unknown`);
+                    }
+
+                    const response = await this.requestLookup[match[1].toLowerCase()](device, message);
+                    await this.mqtt.publish(`bridge/response/device/notes/${match[1]}`, stringify(response));
+                } catch (error) {
+                    logger.error(`Request '${data.topic}' failed with error: '${error.message}'`);
+                    const response = utils.getResponse(message, {}, error.message);
+                    await this.mqtt.publish(`bridge/response/device/notes/${match[1]}`, stringify(response));
+                }
+            }
+        }
+    }
+}

--- a/test/deviceNotes.test.js
+++ b/test/deviceNotes.test.js
@@ -1,0 +1,231 @@
+const data = require('./stub/data');
+const logger = require('./stub/logger');
+const zigbeeHerdsman = require('./stub/zigbeeHerdsman');
+const MQTT = require('./stub/mqtt');
+const path = require('path');
+const rimraf = require('rimraf');
+const settings = require('../lib/util/settings');
+const Controller = require('../lib/controller');
+const stringify = require('json-stable-stringify-without-jsonify');
+const flushPromises = require('./lib/flushPromises');
+const mocksClear = [
+    zigbeeHerdsman.permitJoin, MQTT.end, zigbeeHerdsman.stop, logger.debug,
+    MQTT.publish, MQTT.connect, zigbeeHerdsman.devices.bulb_color.removeFromNetwork,
+    zigbeeHerdsman.devices.bulb.removeFromNetwork, logger.error,
+];
+
+const fs = require('fs');
+const notesExtension = '.txt';
+const notesDirectoryName = 'notes';
+const exampleNotes = 'Example notes with json symbols like { ", and utf-8 👍 and windows\r\n and unix\n line breaks'
+const mkdirSyncSpy = jest.spyOn(fs, 'mkdirSync');
+const writeSyncSpy = jest.spyOn(fs, 'writeFileSync');
+const readSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+describe('Device notes', () => {
+    let controller;
+
+    beforeAll(async () => {
+        jest.useFakeTimers();
+    });
+
+    beforeEach(async () => {
+        data.writeDefaultConfiguration();
+        settings.reRead();
+        mocksClear.forEach((m) => m.mockClear());
+    });
+
+    afterAll(async () => {
+        jest.useRealTimers();
+    });
+
+    beforeEach(() => {
+        zigbeeHerdsman.returnDevices.splice(0);
+        controller = new Controller(jest.fn(), jest.fn());
+        mocksClear.forEach((m) => m.mockClear());
+        data.writeDefaultConfiguration();
+        settings.reRead();
+        data.writeDefaultState();
+    });
+
+    afterEach(() => {
+        const notesDirectory = path.join(data.mockDir, notesDirectoryName);
+        rimraf.sync(notesDirectory);
+    });
+
+    it('Should read initial empty notes for ieee_address', async () => {
+        // Prepare
+        const id = zigbeeHerdsman.devices.bulb_color.ieeeAddr;
+        controller = new Controller(jest.fn(), jest.fn());
+        await controller.start();
+        await flushPromises();
+        MQTT.publish.mockClear();
+        mkdirSyncSpy.mockClear();
+        writeSyncSpy.mockClear();
+
+        // Test
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/notes/read', stringify({ id }));
+
+        // Expect
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/response/device/notes/read', stringify({ status: 'ok', data: { notes: '', mtime: null } }), { retain: false, qos: 0 }, expect.any(Function));
+        expect(mkdirSyncSpy).not.toHaveBeenCalled();
+        expect(writeSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it('Should read existing notes for friendly_name', async () => {
+        // Prepare
+        const device = zigbeeHerdsman.devices.bulb_color;
+        const notesDirectory = path.join(data.mockDir, notesDirectoryName);
+        const noteFilePath = path.join(notesDirectory, `${device.ieeeAddr}${notesExtension}`);
+        fs.mkdirSync(notesDirectory);
+        fs.writeFileSync(noteFilePath, exampleNotes, 'utf-8');
+
+        controller = new Controller(jest.fn(), jest.fn());
+        await controller.start();
+        await flushPromises();
+        MQTT.publish.mockClear();
+        mkdirSyncSpy.mockClear();
+        writeSyncSpy.mockClear();
+        readSyncSpy.mockClear();
+
+        // Test
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/notes/read', stringify({ id: 'bulb_color' }));
+
+        // Expect
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/response/device/notes/read', expect.any(String), { retain: false, qos: 0 }, expect.any(Function));
+        expect(JSON.parse(MQTT.publish.mock.calls[0][1])).toEqual({
+            status: 'ok',
+            data: expect.objectContaining({
+                notes: exampleNotes,
+                mtime: expect.any(String)
+            })
+        });
+        expect(mkdirSyncSpy).not.toHaveBeenCalled();
+        expect(writeSyncSpy).not.toHaveBeenCalled();
+        expect(writeSyncSpy).not.toHaveBeenCalledWith(noteFilePath);
+    });
+
+    it('Should read existing notes with transaction', async () => {
+        // Prepare
+        const id = zigbeeHerdsman.devices.bulb_color.ieeeAddr;
+        const transaction = '42'
+        const notesDirectory = path.join(data.mockDir, notesDirectoryName);
+        const noteFilePath = path.join(notesDirectory, `${id}${notesExtension}`);
+        fs.mkdirSync(notesDirectory);
+        fs.writeFileSync(noteFilePath, exampleNotes, 'utf-8');
+
+        controller = new Controller(jest.fn(), jest.fn());
+        await controller.start();
+        await flushPromises();
+        MQTT.publish.mockClear();
+
+        // Test
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/notes/read', stringify({ id, transaction }));
+
+        // Expect
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/response/device/notes/read', expect.any(String), { retain: false, qos: 0 }, expect.any(Function));
+        expect(JSON.parse(MQTT.publish.mock.calls[0][1])).toEqual({
+            status: 'ok',
+            transaction,
+            data: expect.objectContaining({
+                notes: exampleNotes,
+                mtime: expect.any(String)
+            })
+        });
+    });
+
+    it('Should fail saving for invalid id', async () => {
+        // Prepare
+        const notes = 'some notes';
+        const id = 'invalidNonExistingDeviceID';
+        controller = new Controller(jest.fn(), jest.fn());
+        await controller.start();
+        await flushPromises();
+        MQTT.publish.mockClear();
+        mkdirSyncSpy.mockClear();
+        writeSyncSpy.mockClear();
+
+        // Test
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/notes/save', stringify({ id, notes }));
+
+        // Expect
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/response/device/notes/save', stringify({ status: 'error', data: {}, error: `Device '${id}' is unknown` }), { retain: false, qos: 0 }, expect.any(Function));
+        expect(mkdirSyncSpy).not.toHaveBeenCalled();
+        expect(writeSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it('Should save first notes', async () => {
+        // Prepare
+        const notes = 'some notes';
+        const transaction = '3.141'
+        const id = zigbeeHerdsman.devices.bulb_color.ieeeAddr;
+        const notesDirectory = path.join(data.mockDir, notesDirectoryName);
+        const noteFilePath = path.join(notesDirectory, `${id}${notesExtension}`);
+
+        controller = new Controller(jest.fn(), jest.fn());
+        await controller.start();
+        await flushPromises();
+        MQTT.publish.mockClear();
+        mkdirSyncSpy.mockClear();
+        writeSyncSpy.mockClear();
+
+        // Test
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/notes/save', stringify({ id, notes, transaction }));
+
+        // Expect
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/response/device/notes/save', stringify({ status: 'ok', transaction, data: {}}), { retain: false, qos: 0 }, expect.any(Function));
+        expect(mkdirSyncSpy).toHaveBeenCalledWith(notesDirectory);
+        expect(writeSyncSpy).toHaveBeenCalledWith(noteFilePath, notes, 'utf-8');
+    });
+
+    it('Should overwrite notes and read back', async () => {
+        // Prepare
+        const id = zigbeeHerdsman.devices.bulb_color_2.ieeeAddr;
+        let transaction = '12345'
+        const notesDirectory = path.join(data.mockDir, notesDirectoryName);
+        const noteFilePath = path.join(notesDirectory, `${id}${notesExtension}`);
+        const newNotes = 'some other "notes"\r\nwith utf-8 😀 + non ascii symbols: Device=Gerät';
+
+        fs.mkdirSync(notesDirectory);
+        fs.writeFileSync(noteFilePath, exampleNotes, 'utf-8');
+
+        controller = new Controller(jest.fn(), jest.fn());
+        await controller.start();
+        await flushPromises();
+        MQTT.publish.mockClear();
+        mkdirSyncSpy.mockClear();
+        writeSyncSpy.mockClear();
+
+        // Test
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/notes/save', stringify({ id, transaction, notes: newNotes }));
+
+        // Expect
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/response/device/notes/save', stringify({ status: 'ok', transaction, data: {}}), { retain: false, qos: 0 }, expect.any(Function));
+        expect(mkdirSyncSpy).not.toHaveBeenCalledWith(notesDirectory);
+        expect(writeSyncSpy).toHaveBeenCalledWith(noteFilePath, newNotes, 'utf-8');
+        expect(fs.readFileSync(noteFilePath, 'utf-8')).toBe(newNotes);
+
+        // Test read back
+        MQTT.publish.mockClear();
+        transaction = 'read-back'
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/notes/read', stringify({ id, transaction }));
+
+        // Expect
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/response/device/notes/read', expect.any(String), { retain: false, qos: 0 }, expect.any(Function));
+        expect(JSON.parse(MQTT.publish.mock.calls[0][1])).toEqual({
+            status: 'ok',
+            transaction,
+            data: expect.objectContaining({
+                notes: newNotes,
+                mtime: expect.any(String)
+            })
+        });
+    });
+});


### PR DESCRIPTION
This implements and MQTT interface to save and read device notes (closing #7161).
The frontend also needs to be updated to support device notes see [this](https://github.com/nurikk/zigbee2mqtt-frontend/issues/1296) issue.

Some points:
- The notes are stored in subdirectory called "notes" with one file per device using the IEEE address with the extension ".txt".
  e.g: "0x000b57fffec6a5b3.txt"
- @nurikk: The response contains a `mtime` field with the last modification time alongside the notes.
    Currently it uses [toISOString()](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).
    This allows to distinguish between an empty note and one with does not exist (which still return notes='' but mtime=null).
    What is the best format here for the frontend to parse?
- @nurikk, @Koenkk: How should the MQTT API be shaped like this?
    Now this can still be changed easily with no existing installations requiring legacy handling: `zigbee2mqtt/bridge/(request|response)/device/notes/(read|save)`.
    Save message: 
    ```json
    {"id": "ieee address or friendly_name", "transaction": "optional", "notes": "the notes to save"}
    {"status": "ok", "transaction": "optional", "data": {}}
    ```

    Read message:
    ```json
    {"id": "ieee address or friendly_name", "transaction": "optional"}
    {"status": "ok", "transaction": "optional", "data": {"notes": "the notes", "mtime": "2038-01-19T03:14:08Z"}}
    ```

    It could also be exposed as a virtual property on the device itself `zigbee2mqtt/FRIENDLY_NAME/(get|set)`?
    
- @Koenkk: Should there be a setting to enable this feature or is it on by default?
- @nurikk Currently the implementation uses simple .txt files is a markup language like Markdown (.md) or reStructuredText (.rst) a better idea or will this take too much effort in the frontend? 
- I haven't written typescript before and I'm not quite sure what these `@bind` attributes really do.
- Documentation needs to be written.

Tobi