### PR TITLE
Check tty before colorizing output

### DIFF
--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -62,7 +62,12 @@ const transportsToUse: winston.transport[] = [
             winston.format.printf(/* istanbul ignore next */(info) => {
                 const {timestamp, level, message} = info;
                 const l = winstonToZ2mLevel(level as WinstonLogLevel);
-                const prefix = colorizer.colorize(l, `Zigbee2MQTT:${levelWithCompensatedLength[l]}`);
+
+                const plainPrefix = `Zigbee2MQTT:${levelWithCompensatedLength[l]}`;
+                let prefix = plainPrefix;
+                if (process.stdout.isTTY) {
+                    prefix = colorizer.colorize(l, plainPrefix);
+                }
                 return `${prefix} ${timestamp.split('.')[0]}: ${message}`;
             }),
         ),


### PR DESCRIPTION
I'm forwarding all logs from the host zigbee2mqtt is installed on over syslog to a graylog instance. As is, that means that terminal colours are being shown:

`zigbee2mqtt npm[8991]: #033[32mZigbee2MQTT:info #033[39m 2022-02-27 17:07:06: Stopping zigbee-herdsman...`

This checks if output is a TTY, and applies colorization as needed.

Strangely, the new code is still showing 100% test coverage. There must be something calling this branch without asserting. Perhaps there's coverage markers that need to be added?