### PR TITLE
new device class GARAGE for garage door opener

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -499,6 +499,7 @@ export default class HomeAssistant extends Extension {
                 color_sync: {entity_category: 'config', icon: 'mdi:sync-circle'},
                 consumer_connected: {entity_category: 'diagnostic', device_class: 'connectivity'},
                 contact: {device_class: 'door'},
+                garage_door_contact: {device_class: 'garage'},
                 eco_mode: {entity_category: 'config', icon: 'mdi:leaf'},
                 expose_pin: {entity_category: 'config', icon: 'mdi:pin'},
                 gas: {device_class: 'gas'},


### PR DESCRIPTION
hi , new home assistant device class - garage: Control of a garage door that provides access to a garage.

https://www.home-assistant.io/integrations/cover/