### PR TITLE
Handle cover running state in HA

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -396,8 +396,10 @@ export default class HomeAssistant extends Extension {
             // - https://github.com/Koenkk/zigbee-herdsman-converters/pull/2663
             if (!tilt || (tilt && position)) {
                 discoveryEntry.discovery_payload.command_topic = true;
-                discoveryEntry.discovery_payload.state_topic = !position;
+                discoveryEntry.discovery_payload.state_topic = true;
                 discoveryEntry.discovery_payload.command_topic_prefix = endpoint;
+                discoveryEntry.discovery_payload.value_template = `{% if not value_json.running %} stopped {% else %}` +
+                    `{% if value_json.position > 0 %} closing {% else %} opening {% endif %} {% endif %}`;
             }
 
             if (!position && !tilt) {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -380,7 +380,7 @@ export default class HomeAssistant extends Extension {
         } else if (firstExpose.type === 'cover') {
             const position = exposes.find((expose) => expose.features.find((e) => e.name === 'position'));
             const tilt = exposes.find((expose) => expose.features.find((e) => e.name === 'tilt'));
-            const running = exposes.find((expose) => expose.features.find((e) => e.name === 'running'));
+            const running = definitionExposes?.find((e) => e.type === 'binary' && e.name === 'running');
 
             const discoveryEntry: DiscoveryEntry = {
                 type: 'cover',

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -809,8 +809,6 @@ describe('HomeAssistant extension', () => {
         let payload;
 
         payload = {
-            state_topic: 'zigbee2mqtt/smart vent',
-            value_template: "{% if not value_json.running %} stopped {% else %}{% if value_json.position > 0 %} closing {% else %} opening {% endif %} {% endif %}",
             command_topic: 'zigbee2mqtt/smart vent/set',
             position_topic: 'zigbee2mqtt/smart vent',
             set_position_topic: 'zigbee2mqtt/smart vent/set',

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -809,6 +809,8 @@ describe('HomeAssistant extension', () => {
         let payload;
 
         payload = {
+            state_topic: 'zigbee2mqtt/smart vent',
+            value_template: "{% if not value_json.running %} stopped {% else %}{% if value_json.position > 0 %} closing {% else %} opening {% endif %} {% endif %}",
             command_topic: 'zigbee2mqtt/smart vent/set',
             position_topic: 'zigbee2mqtt/smart vent',
             set_position_topic: 'zigbee2mqtt/smart vent/set',


### PR DESCRIPTION
Hello!

I found that Z2M doesn't give HA the information that the cover is moving even though it knows it from `running` value. Without this data, HA [cannot stop the cover](https://github.com/home-assistant/core/blob/62e3563752c237898fa240659fb0122bc26e1a91/homeassistant/components/cover/__init__.py#L398-L401) when using `cover.toggle` service. And because of this, it is impossible to adjust the curtain with one button controller.

This PR proposes a possible solution to this problem. 
This is not breaking change - covers without `running` value should work ok. 