### PR TITLE
Add `update_progress` & `update_finishes_at` sensors

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1011,10 +1011,13 @@ export default class HomeAssistant extends Extension {
         }
 
         if (isDevice && entity.definition.hasOwnProperty('ota')) {
+            const updateMock: MockProperty = {
+                property: 'update', value: {state: null, progress: null, remaining: null},
+            };
             const updateStateSensor: DiscoveryEntry = {
                 type: 'sensor',
                 object_id: 'update_state',
-                mockProperties: [{property: 'update', value: {state: null}}],
+                mockProperties: [updateMock],
                 discovery_payload: {
                     icon: 'mdi:update',
                     value_template: `{{ value_json['update']['state'] }}`,
@@ -1024,6 +1027,32 @@ export default class HomeAssistant extends Extension {
             };
 
             configs.push(updateStateSensor);
+            const updateProgressSensor: DiscoveryEntry = {
+                type: 'sensor',
+                object_id: 'update_progress',
+                mockProperties: [updateMock],
+                discovery_payload: {
+                    icon: 'mdi:update',
+                    value_template: `{{ value_json['update']['progress'] }}`,
+                    enabled_by_default: false,
+                    unit_of_measurement: '%',
+                    entity_category: 'diagnostic',
+                },
+            };
+            configs.push(updateProgressSensor);
+            const updateFinishesAtSensor: DiscoveryEntry = {
+                type: 'sensor',
+                object_id: 'update_finishes_at',
+                mockProperties: [updateMock],
+                discovery_payload: {
+                    icon: 'mdi:update',
+                    value_template: `{{ now() + timedelta(seconds=value_json['update']['remaining']) }}`,
+                    enabled_by_default: false,
+                    device_class: 'timestamp',
+                    entity_category: 'diagnostic',
+                },
+            };
+            configs.push(updateFinishesAtSensor);
             const updateAvailableSensor: DiscoveryEntry = {
                 type: 'binary_sensor',
                 object_id: 'update_available',
@@ -1038,32 +1067,6 @@ export default class HomeAssistant extends Extension {
                 },
             };
             configs.push(updateAvailableSensor);
-            const updateProgressSensor: DiscoveryEntry = {
-                type: 'sensor',
-                object_id: 'update_progress',
-                mockProperties: [{property: 'update', value: {progress: null}}],
-                discovery_payload: {
-                    icon: 'mdi:update',
-                    value_template: `{{ value_json['update']['progress'] if 'progress' in value_json['update'] else None }}`,
-                    enabled_by_default: false,
-                    unit_of_measurement: '%',
-                    entity_category: 'diagnostic',
-                },
-            };
-            configs.push(updateProgressSensor);
-            const updateFinishesAtSensor: DiscoveryEntry = {
-                type: 'sensor',
-                object_id: 'update_finishes_at',
-                mockProperties: [{property: 'update', value: {remaining: null}}],
-                discovery_payload: {
-                    icon: 'mdi:update',
-                    value_template: `{{ (now() + timedelta(seconds=value_json['update']['remaining'])) if 'remaining' in value_json['update'] else None }}`,
-                    enabled_by_default: false,
-                    device_class: 'timestamp',
-                    entity_category: 'diagnostic',
-                },
-            };
-            configs.push(updateFinishesAtSensor);
         }
 
         if (isDevice && entity.options.hasOwnProperty('legacy') && !entity.options.legacy) {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1038,6 +1038,32 @@ export default class HomeAssistant extends Extension {
                 },
             };
             configs.push(updateAvailableSensor);
+            const updateProgressSensor: DiscoveryEntry = {
+                type: 'sensor',
+                object_id: 'update_progress',
+                mockProperties: [{property: 'update', value: {progress: null}}],
+                discovery_payload: {
+                    icon: 'mdi:update',
+                    value_template: `{{ value_json['update']['progress'] if 'progress' in value_json['update'] else None }}`,
+                    enabled_by_default: false,
+                    unit_of_measurement: '%',
+                    entity_category: 'diagnostic',
+                },
+            };
+            configs.push(updateProgressSensor);
+            const updateFinishesAtSensor: DiscoveryEntry = {
+                type: 'sensor',
+                object_id: 'update_finishes_at',
+                mockProperties: [{property: 'update', value: {remaining: null}}],
+                discovery_payload: {
+                    icon: 'mdi:update',
+                    value_template: `{{ (now() + timedelta(seconds=value_json['update']['remaining'])) if 'remaining' in value_json['update'] else None }}`,
+                    enabled_by_default: false,
+                    device_class: 'timestamp',
+                    entity_category: 'diagnostic',
+                },
+            };
+            configs.push(updateFinishesAtSensor);
         }
 
         if (isDevice && entity.options.hasOwnProperty('legacy') && !entity.options.legacy) {

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -140,7 +140,7 @@ describe('Frontend', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-            stringify({state: 'ON', linkquality: null, update_available: null, update: {state: null}}),
+            stringify({state: 'ON', linkquality: null, update_available: null, update: {state: null, progress: null, remaining: null}}),
             { retain: false, qos: 0 },
             expect.any(Function)
         );
@@ -151,7 +151,7 @@ describe('Frontend', () => {
 
         // Received message on socket
         expect(mockWSClient.implementation.send).toHaveBeenCalledTimes(1);
-        expect(mockWSClient.implementation.send).toHaveBeenCalledWith(stringify({topic: 'bulb_color', payload: {state: 'ON', linkquality: null, update_available: null, update: {state: null}}}));
+        expect(mockWSClient.implementation.send).toHaveBeenCalledWith(stringify({topic: 'bulb_color', payload: {state: 'ON', linkquality: null, update_available: null, update: {state: null, progress: null, remaining: null}}}));
 
         // Shouldnt set when not ready
         mockWSClient.implementation.send.mockClear();

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -912,7 +912,7 @@ describe('HomeAssistant extension', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-            stringify({"color":{"hue": 0, "saturation": 100, "h": 0, "s": 100}, "color_mode": "hs", "linkquality": null, "state": null, "update_available": null, "update": {"state": null}}),
+            stringify({"color":{"hue": 0, "saturation": 100, "h": 0, "s": 100}, "color_mode": "hs", "linkquality": null, "state": null, "update_available": null, "update": {"state": null, "progress": null, "remaining": null}}),
             { retain: false, qos: 0 },
             expect.any(Function),
         );
@@ -928,7 +928,7 @@ describe('HomeAssistant extension', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-            stringify({"color": {"x": 0.4576,"y": 0.41}, "color_mode": "xy", "linkquality": null,"state": null, "update_available": null, "update": {"state": null}}),
+            stringify({"color": {"x": 0.4576,"y": 0.41}, "color_mode": "xy", "linkquality": null,"state": null, "update_available": null, "update": {"state": null, "progress": null, "remaining": null}}),
             { retain: false, qos: 0 },
             expect.any(Function),
         );
@@ -944,7 +944,7 @@ describe('HomeAssistant extension', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-            stringify({"linkquality": null,"state": "ON", "update_available": null, "update": {"state": null}}),
+            stringify({"linkquality": null,"state": "ON", "update_available": null, "update": {"state": null, "progress": null, "remaining": null}}),
             { retain: false, qos: 0 },
             expect.any(Function),
         );
@@ -1032,13 +1032,13 @@ describe('HomeAssistant extension', () => {
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb',
-            stringify({"state":"ON","brightness":50,"color_temp":370,"linkquality":99,"power_on_behavior":null, "update_available": null, "update": {"state": null}}),
+            stringify({"state":"ON","brightness":50,"color_temp":370,"linkquality":99,"power_on_behavior":null, "update_available": null, "update": {"state": null, "progress": null, "remaining": null}}),
             { retain: true, qos: 0 },
             expect.any(Function)
         );
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/remote',
-            stringify({"action":null,"action_duration":null,"battery":null,"brightness":255,"linkquality":null, "update_available": null, "update": {"state": null}}),
+            stringify({"action":null,"action_duration":null,"battery":null,"brightness":255,"linkquality":null, "update_available": null, "update": {"state": null, "progress": null, "remaining": null}}),
             { retain: true, qos: 0 },
             expect.any(Function)
         );
@@ -1056,13 +1056,13 @@ describe('HomeAssistant extension', () => {
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb',
-            stringify({"state":"ON","brightness":50,"color_temp":370,"linkquality":99,"power_on_behavior":null, "update_available": null, "update": {"state": null}}),
+            stringify({"state":"ON","brightness":50,"color_temp":370,"linkquality":99,"power_on_behavior":null, "update_available": null, "update": {"state": null, "progress": null, "remaining": null}}),
             { retain: true, qos: 0 },
             expect.any(Function)
         );
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/remote',
-            stringify({"action":null,"action_duration":null,"battery":null,"brightness":255,"linkquality":null, "update_available": null, "update": {"state": null}}),
+            stringify({"action":null,"action_duration":null,"battery":null,"brightness":255,"linkquality":null, "update_available": null, "update": {"state": null, "progress": null, "remaining": null}}),
             { retain: true, qos: 0 },
             expect.any(Function)
         );
@@ -1356,7 +1356,7 @@ describe('HomeAssistant extension', () => {
         const payload = {
             "payload_on":true,
             "payload_off":false,
-            "value_template":`{{ value_json['update']['progress'] if 'progress' in value_json['update'] else None }}`,
+            "value_template":`{{ value_json['update']['progress'] }}`,
             "enabled_by_default": true,
             "state_topic":"zigbee2mqtt/bulb",
             "json_attributes_topic":"zigbee2mqtt/bulb",
@@ -1388,7 +1388,7 @@ describe('HomeAssistant extension', () => {
         const payload = {
             "payload_on":true,
             "payload_off":false,
-            "value_template":`{{ (now() + timedelta(seconds=value_json['update']['remaining'])) if 'remaining' in value_json['update'] else None }}`,
+            "value_template":`{{ now() + timedelta(seconds=value_json['update']['remaining']) }}`,
             "enabled_by_default": true,
             "state_topic":"zigbee2mqtt/bulb",
             "json_attributes_topic":"zigbee2mqtt/bulb",

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -1352,6 +1352,70 @@ describe('HomeAssistant extension', () => {
         );
     });
 
+    it('Should discover update_progress sensor when device supports it', async () => {
+        const payload = {
+            "payload_on":true,
+            "payload_off":false,
+            "value_template":`{{ value_json['update']['progress'] if 'progress' in value_json['update'] else None }}`,
+            "enabled_by_default": true,
+            "state_topic":"zigbee2mqtt/bulb",
+            "json_attributes_topic":"zigbee2mqtt/bulb",
+            "name":"bulb update progress",
+            "unique_id":"0x000b57fffec6a5b2_update_progress_zigbee2mqtt",
+            "device":{
+                "identifiers":[
+                    "zigbee2mqtt_0x000b57fffec6a5b2"
+                ],
+                "name":"bulb",
+                'sw_version': null,
+                "model":"TRADFRI LED bulb E26/E27 980 lumen, dimmable, white spectrum, opal white (LED1545G12)",
+                "manufacturer":"IKEA"
+            },
+            'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
+            'unit_of_measurement': '%',
+            'entity_category': 'diagnostic'
+        };
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/sensor/0x000b57fffec6a5b2/update_progress/config',
+            stringify(payload),
+            { retain: true, qos: 0 },
+            expect.any(Function),
+        );
+    });
+
+    it('Should discover update_finishes_at sensor when device supports it', async () => {
+        const payload = {
+            "payload_on":true,
+            "payload_off":false,
+            "value_template":`{{ (now() + timedelta(seconds=value_json['update']['remaining'])) if 'remaining' in value_json['update'] else None }}`,
+            "enabled_by_default": true,
+            "state_topic":"zigbee2mqtt/bulb",
+            "json_attributes_topic":"zigbee2mqtt/bulb",
+            "name":"bulb update finishes at",
+            "unique_id":"0x000b57fffec6a5b2_update_finishes_at_zigbee2mqtt",
+            "device":{
+                "identifiers":[
+                    "zigbee2mqtt_0x000b57fffec6a5b2"
+                ],
+                "name":"bulb",
+                'sw_version': null,
+                "model":"TRADFRI LED bulb E26/E27 980 lumen, dimmable, white spectrum, opal white (LED1545G12)",
+                "manufacturer":"IKEA"
+            },
+            'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
+            'device_class': 'timestamp',
+            'entity_category': 'diagnostic'
+        };
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/sensor/0x000b57fffec6a5b2/update_finishes_at/config',
+            stringify(payload),
+            { retain: true, qos: 0 },
+            expect.any(Function),
+        );
+    });
+
     it('Should discover trigger when click is published', async () => {
         const discovered = MQTT.publish.mock.calls.filter((c) => c[0].includes('0x0017880104e45520')).map((c) => c[0]);
         expect(discovered.length).toBe(5);


### PR DESCRIPTION
Recently I set `homeassistant_legacy_entity_attributes` to `false` in my config to remove all the extraneous attributes from my sensors. When I did I noticed that there was no longer any way to get to the `update.progress` and `update.remaining` data that is published for devices with an OTA update in progress. Only `update.state` has it's own sensor.

This PR adds `update_progress` and `update_finishes_at` sensors so that data is available as well. 

Note that home assistant discourages reporting the number of seconds until something happens as state and instead prefers integrations specify a timestamp of when the event will happen. This is to reduce churn in the state machine since a counter in seconds changes every second whereas an end date time theoretically doesn't change.

So instead of setting the state of a sensor directly to the value of `update.remaining`, the template adds `update.remaining` to `now()` to make a true `timestamp` sensor for `update_finishes_at`. The name was picked based on the [timer](https://www.home-assistant.io/integrations/timer/) entity which has a `finishes_at` field for when the timer expires.