### PR TITLE
Add group `off_state` option

### DIFF
--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -129,11 +129,10 @@ export default class Groups extends Extension {
             if (entity instanceof Device) {
                 for (const group of groups) {
                     if (group.zh.hasMember(entity.endpoint(endpointName)) &&
-                        !equals(this.lastOptimisticState[group.ID], payload)) {
-                        if (!payload || payload.state !== 'OFF' || this.areAllMembersOff(group)) {
-                            this.lastOptimisticState[group.ID] = payload;
-                            await this.publishEntityState(group, payload, reason);
-                        }
+                        !equals(this.lastOptimisticState[group.ID], payload) &&
+                        this.shouldPublishPayloadForGroup(group, payload)) {
+                        this.lastOptimisticState[group.ID] = payload;
+                        await this.publishEntityState(group, payload, reason);
                     }
                 }
             } else {
@@ -161,10 +160,9 @@ export default class Groups extends Extension {
 
                     await this.publishEntityState(device, memberPayload, reason);
                     for (const zigbeeGroup of groups) {
-                        if (zigbeeGroup.zh.hasMember(member)) {
-                            if (!payload || payload.state !== 'OFF' || this.areAllMembersOff(zigbeeGroup)) {
-                                groupsToPublish.add(zigbeeGroup);
-                            }
+                        if (zigbeeGroup.zh.hasMember(member) &&
+                            this.shouldPublishPayloadForGroup(zigbeeGroup, payload)) {
+                            groupsToPublish.add(zigbeeGroup);
                         }
                     }
                 }
@@ -174,6 +172,13 @@ export default class Groups extends Extension {
                 }
             }
         }
+    }
+
+    private shouldPublishPayloadForGroup(group: Group, payload: KeyValue): boolean {
+        if (group.options.off_state === 'last_member_state') return true;
+        if (!payload || payload.state !== 'OFF') return true;
+        if (this.areAllMembersOff(group)) return true;
+        return false;
     }
 
     private areAllMembersOff(group: Group): boolean {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -294,6 +294,7 @@ declare global {
         devices?: string[],
         ID?: number,
         optimistic?: boolean,
+        off_state?: 'all_members_off' | 'last_member_state'
         filtered_optimistic?: string[],
         retrieve_state?: boolean,
         homeassistant?: KeyValue,

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -870,6 +870,14 @@
         "qos": {
           "type": "number"
         },
+        "off_state": {
+          "type": ["string"],
+          "enum": ["all_members_off", "last_member_state"],
+          "title": "Group off state",
+          "default": "auto",
+          "requiresRestart": true,
+          "description": "Control when to publish state OFF for a group. 'all_members_off': only publish state OFF when all group memebers are in state OFF, 'last_member_state': publish state OFF whenever one of its members changes to OFF"
+        },
         "filtered_attributes": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Rationale: while the current group state `OFF` behaviour sounds ideal (group state is only `OFF` when all members in it are `OFF`) it is not always practical. I see at least two possible cases where this doesn't work well:
- Given that you have e.g. 5 lights in the group controlled by 1 remote, when the remote turns off the lights; all light `OFF` report have to be received by the coordinator. If one of the messages is dropped (e.g. due to interference) the coordinator considers the group on. In my use case when using the flux integration, flux will turn the group on again (by changing the color temperature) since it still thinks the group is on.
- If one of the devices in the group doesn't support state reporting (e.g. a Philips Hue bulb) the similar problem as above will occur.

