### PR TITLE
Add more settings to secrets

### DIFF
--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -326,13 +326,28 @@ function read(): Settings {
         }
     };
 
-    if (s.mqtt?.user && s.mqtt?.password) {
+    if (s.mqtt?.user) {
         s.mqtt.user = interpetValue(s.mqtt.user);
+    }
+
+    if (s.mqtt?.password) {
         s.mqtt.password = interpetValue(s.mqtt.password);
+    }
+
+    if (s.mqtt?.server) {
+        s.mqtt.server = interpetValue(s.mqtt.server);
     }
 
     if (s.advanced?.network_key) {
         s.advanced.network_key = interpetValue(s.advanced.network_key);
+    }
+
+    if (s.advanced?.pan_id) {
+        s.advanced.pan_id = interpetValue(s.advanced.pan_id);
+    }
+
+    if (s.advanced?.ext_pan_id) {
+        s.advanced.ext_pan_id = interpetValue(s.advanced.ext_pan_id);
     }
 
     if (s.frontend?.auth_token) {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -200,8 +200,6 @@ function write(): void {
         ['mqtt', 'user'],
         ['mqtt', 'password'],
         ['advanced', 'network_key'],
-        ['advanced', 'pan_id'],
-        ['advanced', 'ext_pan_id'],
         ['frontend', 'auth_token'],
     ]) {
         if (actual[path[0]] && actual[path[0]][path[1]]) {
@@ -340,14 +338,6 @@ function read(): Settings {
 
     if (s.advanced?.network_key) {
         s.advanced.network_key = interpetValue(s.advanced.network_key);
-    }
-
-    if (s.advanced?.pan_id) {
-        s.advanced.pan_id = interpetValue(s.advanced.pan_id);
-    }
-
-    if (s.advanced?.ext_pan_id) {
-        s.advanced.ext_pan_id = interpetValue(s.advanced.ext_pan_id);
     }
 
     if (s.frontend?.auth_token) {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -196,9 +196,12 @@ function write(): void {
 
     // In case the setting is defined in a separte file (e.g. !secret network_key) update it there.
     for (const path of [
+        ['mqtt', 'server'],
         ['mqtt', 'user'],
         ['mqtt', 'password'],
         ['advanced', 'network_key'],
+        ['advanced', 'pan_id'],
+        ['advanced', 'ext_pan_id'],
         ['frontend', 'auth_token'],
     ]) {
         if (actual[path[0]] && actual[path[0]][path[1]]) {

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -179,9 +179,9 @@ describe('Settings', () => {
                 password: '!secret password',
             },
             advanced: {
-                network_key: '!secret network_key'
-                pan_id: '!secret pan_id'
-                ext_pan_id: '!secret ext_pan_id'
+                network_key: '!secret network_key',
+                pan_id: '!secret pan_id',
+                ext_pan_id: '!secret ext_pan_id',
             }
         };
 

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -39,6 +39,7 @@ describe('Settings', () => {
 
     beforeEach(() => {
         remove(configurationFile);
+        remove(secretFile);
         remove(devicesFile);
         remove(groupsFile);
         clearEnvironmentVariables();

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -181,8 +181,6 @@ describe('Settings', () => {
             },
             advanced: {
                 network_key: '!secret network_key',
-                pan_id: '!secret pan_id',
-                ext_pan_id: '!secret ext_pan_id',
             }
         };
 
@@ -191,8 +189,6 @@ describe('Settings', () => {
             username: 'mysecretusername',
             password: 'mysecretpassword',
             network_key: [1,2,3],
-            pan_id: 12345,
-            ext_pan_id: [1,2,3,4,5],
         };
 
         write(secretFile, contentSecret, false);
@@ -209,18 +205,14 @@ describe('Settings', () => {
 
         expect(settings.get().mqtt).toStrictEqual(expected);
         expect(settings.get().advanced.network_key).toStrictEqual([1,2,3]);
-        expect(settings.get().advanced.pan_id).toStrictEqual(12345);
-        expect(settings.get().advanced.ext_pan_id).toStrictEqual([1,2,3,4,5]);
 
         settings.testing.write();
         expect(read(configurationFile)).toStrictEqual(contentConfiguration);
         expect(read(secretFile)).toStrictEqual(contentSecret);
 
         settings.set(['mqtt', 'server'], 'not.secret.server');
-        settings.set(['advanced', 'pan_id'], '23456');
-        settings.set(['advanced', 'ext_pan_id'], [1,2,3,4,5, 6]);
         expect(read(configurationFile)).toStrictEqual(contentConfiguration);
-        expect(read(secretFile)).toStrictEqual({...contentSecret, server: 'not.secret.server', pan_id: '23456', ext_pan_id: [1,2,3,4,5,6]});
+        expect(read(secretFile)).toStrictEqual({...contentSecret, server: 'not.secret.server'});
     });
 
     it('Should read devices form a separate file', () => {


### PR DESCRIPTION
In case of public configuration (or when just requiring sensitive settings to be separated) add the following to the optional `secrets.yaml`

* Add `server` in `mqtt` section
* Add `pan_id` in `advanced` section - related to zigbee networking
* Add `ext_pan_id` in `advanced` section - related to zigbee networking

Main reason for the change is that when setting up i  assumed mqtt server will also be read (and that failed quite strangely).

Docs will be fixed in separate PR