### PR TITLE
Fix EnvVar parsing of settings scheme with 'oneOf'.

### DIFF
--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -390,7 +390,7 @@ function applyEnvironmentVariables(settings: Partial<Settings>): void {
 
                 if (typeof obj[key] === 'object' && obj[key]) {
                     const newPath = [...path];
-                    if (key !== 'properties') {
+                    if (key !== 'properties' && key !== 'oneOf' && !Number.isInteger(Number(key))) {
                         newPath.push(key);
                     }
                     iterate(obj[key], newPath);


### PR DESCRIPTION
Fixes #12911.

Tested it locally. AFAIK there are no unintended side-effects.
This allows correctly overriding settings with environment variables that have a 'oneOf' option in their scheme tree structure.

I.e. it checks for `ZIGBEE2MQTT_CONFIG_FRONTEND_URL` i.s.o. `ZIGBEE2MQTT_CONFIG_FRONTEND_ONEOF_1_URL`.