### PR TITLE
add search before issue create requirement

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_device_support.yaml
+++ b/.github/ISSUE_TEMPLATE/new_device_support.yaml
@@ -8,6 +8,7 @@ body:
       value: |
         **IMPORTANT:** Before submitting:
         - Make sure this device is not already supported in the [dev branch](https://www.zigbee2mqtt.io/advanced/more/switch-to-dev-branch.html)
+        - Make sure there is no existing issue or PR for this device already, search for your device here: https://github.com/Koenkk/zigbee2mqtt/issues
         - Follow this [guide](https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html)
         - If you are using the Home Assistant addon and are still on 1.18.1, check the first point of [this](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.19.0)
   - type: input


### PR DESCRIPTION
For some reason people do not search before creating new device support requests. This leads to fragmented information as well as overhead for the contributor(s).

This adds a requirement to search existing issues before creating a new one. Next step is for someone with proper permissions to start marking the issues as duplicates and (automatically) locking them.