### PR TITLE
Always treat filtered_* as full matches

### DIFF
--- a/lib/state.ts
+++ b/lib/state.ts
@@ -8,9 +8,9 @@ import objectAssignDeep from 'object-assign-deep';
 const saveInterval = 1000 * 60 * 5; // 5 minutes
 
 const dontCacheProperties = [
-    '^action$', '^action_.*$', '^button$', '^button_left$', '^button_right$', '^click$', '^forgotten$', '^keyerror$',
-    '^step_size$', '^transition_time$', '^group_list$', '^group_capacity$', '^no_occupancy_since$',
-    '^step_mode$', '^transition_time$', '^duration$', '^elapsed$', '^from_side$', '^to_side$',
+    'action', 'action_.*', 'button', 'button_left', 'button_right', 'click', 'forgotten', 'keyerror',
+    'step_size', 'transition_time', 'group_list', 'group_capacity', 'no_occupancy_since',
+    'step_mode', 'transition_time', 'duration', 'elapsed', 'from_side', 'to_side',
 ];
 
 class State {

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -341,10 +341,10 @@ function publishLastSeen(data: eventdata.LastSeenChanged, settings: Settings, al
     }
 }
 
-function filterProperties(filterRegex: string[], data: KeyValue): void {
-    if (filterRegex) {
+function filterProperties(filter: string[], data: KeyValue): void {
+    if (filter) {
         for (const property of Object.keys(data)) {
-            if (filterRegex.find((p) => property.match(p))) {
+            if (filter.find((p) => property.match(`^${p}$`))) {
                 delete data[property];
             }
         }

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -465,7 +465,7 @@ describe('Controller', () => {
     it('Publish entity state attribute_json output filtered', async () => {
         await controller.start();
         settings.set(['experimental', 'output'], 'attribute_and_json');
-        settings.set(['devices', zigbeeHerdsman.devices.bulb.ieeeAddr, 'filtered_attributes'], ['^color_temp$', '^linkquality$']);
+        settings.set(['devices', zigbeeHerdsman.devices.bulb.ieeeAddr, 'filtered_attributes'], ['color_temp', 'linkquality']);
         MQTT.publish.mockClear();
         const device = controller.zigbee.resolveEntity('bulb');
         await controller.publishEntityState(device, {state: 'ON', brightness: 200, color_temp: 370, linkquality: 99});
@@ -479,7 +479,7 @@ describe('Controller', () => {
     it('Publish entity state attribute_json output filtered (device_options)', async () => {
         await controller.start();
         settings.set(['experimental', 'output'], 'attribute_and_json');
-        settings.set(['device_options', 'filtered_attributes'], ['^color_temp$', '^linkquality$']);
+        settings.set(['device_options', 'filtered_attributes'], ['color_temp', 'linkquality']);
         MQTT.publish.mockClear();
         const device = controller.zigbee.resolveEntity('bulb');
         await controller.publishEntityState(device, {state: 'ON', brightness: 200, color_temp: 370, linkquality: 99});
@@ -493,7 +493,7 @@ describe('Controller', () => {
     it('Publish entity state attribute_json output filtered cache', async () => {
         await controller.start();
         settings.set(['advanced', 'output'], 'attribute_and_json');
-        settings.set(['devices', zigbeeHerdsman.devices.bulb.ieeeAddr, 'filtered_cache'], ['^linkquality$']);
+        settings.set(['devices', zigbeeHerdsman.devices.bulb.ieeeAddr, 'filtered_cache'], ['linkquality']);
         MQTT.publish.mockClear();
 
         const device = controller.zigbee.resolveEntity('bulb');
@@ -513,7 +513,7 @@ describe('Controller', () => {
     it('Publish entity state attribute_json output filtered cache (device_options)', async () => {
         await controller.start();
         settings.set(['advanced', 'output'], 'attribute_and_json');
-        settings.set(['device_options', 'filtered_cache'], ['^linkquality$']);
+        settings.set(['device_options', 'filtered_cache'], ['linkquality']);
         MQTT.publish.mockClear();
 
         const device = controller.zigbee.resolveEntity('bulb');


### PR DESCRIPTION
As per the discussion here https://github.com/Koenkk/zigbee2mqtt.io/pull/1473 (which can just be closed after this lands)

- treat `filtered_attributes` and `filtered_optimistic` as a full match and not a regex (restoring behavior prior to https://github.com/Koenkk/zigbee2mqtt/pull/13047)
- treat `filtered_cache` as full match to bring those in line with the other `filtered_*` (this was accidentally added as regex)
- `utils.filterProperties()` now has extra parameter to enable 'regex' mode, as this is used internally by `state` to filter out properties based on a regex.