### PR TITLE
WIP: Add support for more settings in secrets

### DIFF
--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -199,6 +199,8 @@ function write(): void {
         ['mqtt', 'server'],
         ['mqtt', 'user'],
         ['mqtt', 'password'],
+        ['mqtt', 'client_id'],
+        ['serial', 'port'],
         ['advanced', 'network_key'],
         ['frontend', 'auth_token'],
     ]) {
@@ -334,6 +336,14 @@ function read(): Settings {
 
     if (s.mqtt?.server) {
         s.mqtt.server = interpetValue(s.mqtt.server);
+    }
+
+    if (s.mqtt?.client_id) {
+        s.mqtt.client_id = interpetValue(s.mqtt.client_id);
+    }
+
+    if (s.serial?.port) {
+        s.serial.port = interpetValue(s.serial.port);
     }
 
     if (s.advanced?.network_key) {

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -180,6 +180,7 @@ describe('Settings', () => {
                 server: '!secret server',
                 user: '!secret username',
                 password: '!secret password',
+                client_id: '!secret client_id',
             },
             advanced: {
                 network_key: '!secret network_key',
@@ -190,6 +191,7 @@ describe('Settings', () => {
             server: 'my.mqtt.server',
             username: 'mysecretusername',
             password: 'mysecretpassword',
+            client_id: 'mqtt.client.id',
             network_key: [1,2,3],
         };
 
@@ -203,6 +205,7 @@ describe('Settings', () => {
             password: "mysecretpassword",
             server: "my.mqtt.server",
             user: "mysecretusername",
+            client_id: "mqtt.client.id",
         };
 
         expect(settings.get().mqtt).toStrictEqual(expected);
@@ -212,9 +215,39 @@ describe('Settings', () => {
         expect(read(configurationFile)).toStrictEqual(contentConfiguration);
         expect(read(secretFile)).toStrictEqual(contentSecret);
 
-        settings.set(['mqtt', 'server'], 'not.secret.server');
+        settings.set(['mqtt', 'client_id'], 'new.client.id');
         expect(read(configurationFile)).toStrictEqual(contentConfiguration);
-        expect(read(secretFile)).toStrictEqual({...contentSecret, server: 'not.secret.server'});
+        expect(read(secretFile)).toStrictEqual({...contentSecret, client_id: 'new.client.id'});
+    });
+
+    it('Should read serial config from separate file', () => {
+        const contentConfiguration = {
+            serial: {
+                port: '!secret serial_port'
+            }
+        };
+
+        const contentSecret = {
+            serial_port: 'tcp://secret.host:port'
+        };
+
+        write(secretFile, contentSecret, false);
+        write(configurationFile, contentConfiguration);
+
+        const expected = {
+            "disable_led": false,
+            port: "tcp://secret.host:port",
+        };
+
+        expect(settings.get().serial).toStrictEqual(expected);
+
+        settings.testing.write();
+        expect(read(configurationFile)).toStrictEqual(contentConfiguration);
+        expect(read(secretFile)).toStrictEqual(contentSecret);
+
+        settings.set(['serial', 'port'], '/dev/ttyACM0');
+        expect(read(configurationFile)).toStrictEqual(contentConfiguration);
+        expect(read(secretFile)).toStrictEqual({...contentSecret, serial_port: '/dev/ttyACM0'});
     });
 
     it('Should read devices form a separate file', () => {


### PR DESCRIPTION
As a security conscious person i would like to not expose secrets to the outside world if i publish my configurations. As such i consider `mqtt.client_id` and `serial.port` as sensitive values.

 * Add `mqtt.client_id` (might be sensitive) - Rationale being that MQTT acl's can require speciffic (sensitive) value for client_id. Currently i do not have a public example of this, but am using it privately
 * Add `serial.port` - can be sensitive in case of network based bridge (especially if outside of net). Currently this is being used to monitor some sensors at my parents home. And yes i know it is a bad idea to publicly expose such devices to the internet.

This PR follows #12904 and PR for docs will follow