### PR TITLE
Expose value_step to home assistant if it has been set on a numeric type

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -756,6 +756,7 @@ export default class HomeAssistant extends Extension {
                         command_topic_prefix: endpoint,
                         command_topic_postfix: firstExpose.property,
                         ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
+                        ...(firstExpose.value_step && {step: firstExpose.value_step}),
                         ...lookup[firstExpose.name],
                     },
                 };

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -100,7 +100,7 @@ declare global {
 
         interface DefinitionExpose {
             type: string, name?: string, features?: DefinitionExposeFeature[],
-            endpoint?: string, values?: string[], value_off?: string, value_on?: string,
+            endpoint?: string, values?: string[], value_off?: string, value_on?: string, value_step?: number,
             access: number, property: string, unit?: string,
             value_min?: number, value_max?: number}
 


### PR DESCRIPTION
Currently if you set the step on a numeric type, this doesn't get passed through to Home Assistant and HA uses the default step of 1. This passes the `value_step` on if it is present.