### PR TITLE
Mark min_temperature_limit as a config variable for HA

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -665,6 +665,7 @@ export default class HomeAssistant extends Extension {
                 local_temperature: {device_class: 'temperature', state_class: 'measurement'},
                 max_temperature: {entity_category: 'config', icon: 'mdi:thermometer'},
                 max_temperature_limit: {entity_category: 'config', icon: 'mdi:thermometer'},
+                min_temperature_limit: {entity_category: 'config', icon: 'mdi:thermometer'},
                 min_temperature: {entity_category: 'config', icon: 'mdi:thermometer'},
                 measurement_poll_interval: {entity_category: 'config', icon: 'mdi:clock-out'},
                 occupancy_timeout: {entity_category: 'config', icon: 'mdi:timer'},


### PR DESCRIPTION
Exposes `min_temperature_limit` as a config variable - supplements https://github.com/Koenkk/zigbee-herdsman-converters/pull/4744