### PR TITLE
Add settings to set db and backup path

### DIFF
--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -247,6 +247,8 @@ declare global {
             log_file: string,
             log_level: 'debug' | 'info' | 'error' | 'warn',
             log_syslog: KeyValue,
+            db_directory: string,
+            backup_directory: string,
             pan_id: number | 'GENERATE',
             ext_pan_id: number[],
             channel: number,

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -554,6 +554,20 @@
             }
           }
         },
+        "db_directory": {
+          "type": "string",
+          "title": "Database directory",
+          "requiresRestart": true,
+          "description": "Location of database directory",
+          "examples": ["data/"]
+        },
+        "backup_directory": {
+          "type": "string",
+          "title": "Backup directory",
+          "requiresRestart": true,
+          "description": "Location of backup directory",
+          "examples": ["data/"]
+        },
         "pan_id": {
           "oneOf": [{
               "type": "string",

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -80,6 +80,8 @@ const defaults: RecursivePartial<Settings> = {
         log_file: 'log.txt',
         log_level: /* istanbul ignore next */ process.env.DEBUG ? 'debug' : 'info',
         log_syslog: {},
+        db_directory: data.getPath(),
+        backup_directory: data.getPath(),
         pan_id: 0x1a62,
         ext_pan_id: [0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD],
         channel: 11,

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -32,9 +32,9 @@ export default class Zigbee {
                 networkKey: settings.get().advanced.network_key === 'GENERATE' ?
                     this.generateNetworkKey() : settings.get().advanced.network_key as number[],
             },
-            databasePath: settings.get().advanced.db_directory.joinPath('database.db'),
-            databaseBackupPath: settings.get().advanced.backup_directory.joinPath('database.db.backup'),
-            backupPath: settings.get().advanced.backup_directory.joinPath('coordinator_backup.json'),
+            databasePath: path.join(settings.get().advanced.db_directory, 'database.db'),
+            databaseBackupPath: path.join(settings.get().advanced.backup_directory, 'database.db.backup'),
+            backupPath: path.join(settings.get().advanced.backup_directory, 'coordinator_backup.json'),
             serialPort: {
                 baudRate: settings.get().serial.baudrate,
                 rtscts: settings.get().serial.rtscts,

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -9,6 +9,7 @@ import Device from './model/device';
 import Group from './model/group';
 import * as ZHEvents from 'zigbee-herdsman/dist/controller/events';
 import bind from 'bind-decorator';
+import path from 'path';
 
 export default class Zigbee {
     private herdsman: Controller;

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -32,9 +32,9 @@ export default class Zigbee {
                 networkKey: settings.get().advanced.network_key === 'GENERATE' ?
                     this.generateNetworkKey() : settings.get().advanced.network_key as number[],
             },
-            databasePath: data.joinPath('database.db'),
-            databaseBackupPath: data.joinPath('database.db.backup'),
-            backupPath: data.joinPath('coordinator_backup.json'),
+            databasePath: settings.get().advanced.db_directory.joinPath('database.db'),
+            databaseBackupPath: settings.get().advanced.backup_directory.joinPath('database.db.backup'),
+            backupPath: settings.get().advanced.backup_directory.joinPath('coordinator_backup.json'),
             serialPort: {
                 baudRate: settings.get().serial.baudrate,
                 rtscts: settings.get().serial.rtscts,


### PR DESCRIPTION
In addition to the comment https://github.com/Koenkk/zigbee2mqtt/issues/34#issuecomment-388556882 in #34 db path is currently not configurable independent from path to `configuration.yaml` and `database.db.backup`.

There are usecases where `configuration.yaml` is generated using other software, but paired devices should be stored in other directories. Currently this is not even possible using symlinks, as `database.db` is removed and recreated by zigbee2mqtt.