### PR TITLE
Respect climate system_mode access bit

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -245,7 +245,9 @@ export default class HomeAssistant extends Extension {
                 discoveryEntry.discovery_payload.mode_state_topic = true;
                 discoveryEntry.discovery_payload.mode_state_template = `{{ value_json.${mode.property} }}`;
                 discoveryEntry.discovery_payload.modes = mode.values;
-                discoveryEntry.discovery_payload.mode_command_topic = true;
+                if (mode.access & ACCESS_SET) {
+                    discoveryEntry.discovery_payload.mode_command_topic = true;
+                }
             }
 
             const state = firstExpose.features.find((f) => f.name === 'running_state');


### PR DESCRIPTION
Address the small issue brought up in https://github.com/Koenkk/zigbee-herdsman-converters/pull/4832#discussion_r1004920204: in the Home Assistant extension, the `mode_command_topic` should appear only if `system_mode` has the `ACCESS_SET` bit set. Otherwise, Home Assistant will try to use `set` and cause unnecessary error messages.