### PR TITLE
Remove core-js polyfills

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-require('core-js/features/object/from-entries');
-require('core-js/features/array/flat');
 const semver = require('semver');
 const engines = require('./package.json').engines;
 const fs = require('fs');

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "ajv": "^8.11.0",
         "bind-decorator": "^1.0.11",
         "connect-gzip-static": "2.1.1",
-        "core-js": "^3.26.0",
         "debounce": "^1.2.1",
         "deep-object-diff": "^1.1.7",
         "fast-deep-equal": "^3.1.3",
@@ -4228,16 +4227,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
-      "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {
@@ -13017,11 +13006,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "core-js": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
-      "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
     },
     "core-js-compat": {
       "version": "3.25.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ajv": "^8.11.0",
     "bind-decorator": "^1.0.11",
     "connect-gzip-static": "2.1.1",
-    "core-js": "^3.26.0",
     "debounce": "^1.2.1",
     "deep-object-diff": "^1.1.7",
     "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
According to engines.node in package.json, the minimal supported version of Node.js is 14.

* `Object.fromEntries()` is supported by Node.js since 12.0.0
* `Array.prototype.flat()` is supported by Node.js since 11.0.0

These polyfills were added in #9085, but the minimum supported Node.js version has since been raised to 14.