### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ghcr_cleanup.yml
+++ b/.github/workflows/ghcr_cleanup.yml
@@ -3,6 +3,7 @@ on:
 
 name: GHCR cleanup
 
+permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_frontend.yml
+++ b/.github/workflows/update_frontend.yml
@@ -3,8 +3,13 @@ on:
   repository_dispatch:
     types: update_frontend
 
+permissions: {}
 jobs:
   update_frontend:
+    permissions:
+      contents: write  #  to create branch (peter-evans/create-pull-request)
+      pull-requests: write  #  to create a PR (peter-evans/create-pull-request)
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update_zh.yml
+++ b/.github/workflows/update_zh.yml
@@ -3,8 +3,13 @@ on:
   repository_dispatch:
     types: update_zh
 
+permissions: {}
 jobs:
   update_zh:
+    permissions:
+      contents: write  #  to create branch (peter-evans/create-pull-request)
+      pull-requests: write  #  to create a PR (peter-evans/create-pull-request)
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update_zhc.yml
+++ b/.github/workflows/update_zhc.yml
@@ -3,8 +3,13 @@ on:
   repository_dispatch:
     types: update_zhc
 
+permissions: {}
 jobs:
   update_zhc:
+    permissions:
+      contents: write  #  to create branch (peter-evans/create-pull-request)
+      pull-requests: write  #  to create a PR (peter-evans/create-pull-request)
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.