### PR TITLE
Revert "Respect climate system_mode access bit"

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -245,9 +245,7 @@ export default class HomeAssistant extends Extension {
                 discoveryEntry.discovery_payload.mode_state_topic = true;
                 discoveryEntry.discovery_payload.mode_state_template = `{{ value_json.${mode.property} }}`;
                 discoveryEntry.discovery_payload.modes = mode.values;
-                if (mode.access & ACCESS_SET) {
-                    discoveryEntry.discovery_payload.mode_command_topic = true;
-                }
+                discoveryEntry.discovery_payload.mode_command_topic = true;
             }
 
             const state = firstExpose.features.find((f) => f.name === 'running_state');


### PR DESCRIPTION
Reverts Koenkk/zigbee2mqtt#14715

Once you expose the mode over MQTT, Home Assistant *expects* there to be a mode command. So better to expose it, and have error messages in Z2M in case one makes a mistake like I did (I guess?).

It might be even better to enforce the `ACCESS_SET` bit within `withSystemMode`.