### PR TITLE
Use path.resolve instead of path.join in data.joinPath

### DIFF
--- a/lib/util/data.ts
+++ b/lib/util/data.ts
@@ -14,7 +14,7 @@ function load(): void {
 load();
 
 function joinPath(file: string): string {
-    return path.join(dataPath, file);
+    return path.resolve(dataPath, file);
 }
 
 function getPath(): string {

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -19,6 +19,7 @@ describe('Data', () => {
             const actual = data.getPath();
             expect(actual).toBe(expected);
             expect(data.joinPath('test')).toStrictEqual(path.join(expected, 'test'));
+            expect(data.joinPath('/test')).toStrictEqual(path.resolve(expected, '/test'));
             delete process.env.ZIGBEE2MQTT_DATA;
             data.testingOnlyReload();
         });


### PR DESCRIPTION
This allows specifying a path outside of the data directory using an absolute path (e.g. /path/to/devices.yaml) or a path relative to the data directory (e.g. devices.yaml, foo/devices.yaml, ../../devices.yaml, ...). This change is backward compatible because file names and nested paths are just a special case of a relative path.