### PR TITLE
Allow to specify full file name in value reference '!'

### DIFF
--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -187,6 +187,15 @@ function loadSettingsWithDefaults(): void {
     _settingsWithDefaults.whitelist && _settingsWithDefaults.passlist.push(..._settingsWithDefaults.whitelist);
 }
 
+function parseValueRef(text: string): {filename: string, key: string} | null {
+    const match = /!(.*) (.*)/g.exec(text);
+    if (match) {
+        return {filename: match[1], key: match[2]};
+    } else {
+        return null;
+    }
+}
+
 function write(): void {
     const settings = getInternalSettings();
     const toWrite: KeyValue = objectAssignDeep({}, settings);
@@ -203,9 +212,9 @@ function write(): void {
         ['frontend', 'auth_token'],
     ]) {
         if (actual[path[0]] && actual[path[0]][path[1]]) {
-            const match = /!(.*) (.*)/g.exec(actual[path[0]][path[1]]);
-            if (match) {
-                yaml.updateIfChanged(data.joinPath(`${match[1]}.yaml`), match[2], toWrite[path[0]][path[1]]);
+            const ref = parseValueRef(actual[path[0]][path[1]]);
+            if (ref) {
+                yaml.updateIfChanged(data.joinPath(ref.filename), ref.key, toWrite[path[0]][path[1]]);
                 toWrite[path[0]][path[1]] = actual[path[0]][path[1]];
             }
         }
@@ -314,12 +323,9 @@ function read(): Settings {
     // Read !secret MQTT username and password if set
     // eslint-disable-next-line
     const interpetValue = (value: any): any => {
-        const re = /!(.*) (.*)/g;
-        const match = re.exec(value);
-        if (match) {
-            const file = data.joinPath(`${match[1]}.yaml`);
-            const key = match[2];
-            return yaml.read(file)[key];
+        const ref = parseValueRef(value);
+        if (ref) {
+            return yaml.read(data.joinPath(ref.filename))[ref.key];
         } else {
             return value;
         }

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -190,7 +190,12 @@ function loadSettingsWithDefaults(): void {
 function parseValueRef(text: string): {filename: string, key: string} | null {
     const match = /!(.*) (.*)/g.exec(text);
     if (match) {
-        return {filename: match[1], key: match[2]};
+        let filename = match[1];
+        // This is mainly for backward compatibility.
+        if (!filename.endsWith('.yaml') && !filename.endsWith('.yml')) {
+            filename += '.yaml';
+        }
+        return {filename, key: match[2]};
     } else {
         return null;
     }

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -199,7 +199,7 @@ describe('Settings', () => {
             mqtt: {
                 server: '!secret server',
                 user: '!secret username',
-                password: '!secret password',
+                password: '!secret.yaml password',
             },
             advanced: {
                 network_key: '!secret network_key',


### PR DESCRIPTION
This `network_key: '!secret network_key'` is really confusing because it looks like a YAML tag named 'secret' and a value "network_key".
When we write `network_key: '!secret.yaml network_key'` instead, it's a little clearer what's going on. Also, it's more consistent with file references in 'devices' and 'groups'.