### PR TITLE
Allow to read advanced.pan_id from a different file

### DIFF
--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -214,6 +214,7 @@ function write(): void {
         ['mqtt', 'user'],
         ['mqtt', 'password'],
         ['advanced', 'network_key'],
+        ['advanced', 'pan_id'],
         ['frontend', 'auth_token'],
     ]) {
         if (actual[path[0]] && actual[path[0]][path[1]]) {
@@ -350,6 +351,10 @@ function read(): Settings {
 
     if (s.advanced?.network_key) {
         s.advanced.network_key = interpetValue(s.advanced.network_key);
+    }
+
+    if (s.advanced?.pan_id) {
+        s.advanced.pan_id = interpetValue(s.advanced.pan_id);
     }
 
     if (s.frontend?.auth_token) {

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -203,6 +203,7 @@ describe('Settings', () => {
             },
             advanced: {
                 network_key: '!secret network_key',
+                pan_id: '!secret.yaml pan_id',
             }
         };
 
@@ -211,6 +212,7 @@ describe('Settings', () => {
             username: 'mysecretusername',
             password: 'mysecretpassword',
             network_key: [1,2,3],
+            pan_id: 0x1a66,
         };
 
         write(secretFile, contentSecret, false);
@@ -227,6 +229,7 @@ describe('Settings', () => {
 
         expect(settings.get().mqtt).toStrictEqual(expected);
         expect(settings.get().advanced.network_key).toStrictEqual([1,2,3]);
+        expect(settings.get().advanced.pan_id).toStrictEqual(0x1a66);
 
         settings.testing.write();
         expect(read(configurationFile)).toStrictEqual(contentConfiguration);


### PR DESCRIPTION
The goal is to allow moving all GENERATEable settings to a separate file.