### PR TITLE
Disable by default `update_available` sensor in HA

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1076,7 +1076,7 @@ export default class HomeAssistant extends Extension {
                     payload_on: true,
                     payload_off: false,
                     value_template: `{{ value_json['update']['state'] == "available" }}`,
-                    enabled_by_default: true,
+                    enabled_by_default: false,
                     device_class: 'update',
                     entity_category: 'diagnostic',
                 },

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -1388,7 +1388,7 @@ describe('HomeAssistant extension', () => {
             "payload_on":true,
             "payload_off":false,
             "value_template":`{{ value_json['update']['state'] == "available" }}`,
-            "enabled_by_default": true,
+            "enabled_by_default": false,
             "state_topic":"zigbee2mqtt/bulb",
             "json_attributes_topic":"zigbee2mqtt/bulb",
             "name":"bulb update available",


### PR DESCRIPTION
Hello!

As follow-up of #14905: disable by default `update_available` sensor in HA in favour of update entity.