### PR TITLE
Fix Home Assistant `installed_version` error

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1463,6 +1463,7 @@ export default class HomeAssistant extends Extension {
 
         if (entity.isDevice() && entity.definition?.ota && message.hasOwnProperty('update')) {
             message['update']['installed_version'] = entity.zh.softwareBuildID ?
+                // Prepend with v: https://github.com/Koenkk/zigbee2mqtt/pull/15369
                 `v${entity.zh.softwareBuildID}` : 'unknown';
         }
     }

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1462,7 +1462,8 @@ export default class HomeAssistant extends Extension {
         }
 
         if (entity.isDevice() && entity.definition?.ota && message.hasOwnProperty('update')) {
-            message['update']['installed_version'] = entity.zh.softwareBuildID || 'unknown';
+            message['update']['installed_version'] = entity.zh.softwareBuildID ?
+                `v${entity.zh.softwareBuildID}` : 'unknown';
         }
     }
 

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -197,7 +197,7 @@ describe('Frontend', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-             stringify({state: 'ON', power_on_behavior:null, linkquality: null, update_available: null, update: {state: null, installed_version: "unknown"}}),
+             stringify({state: 'ON', power_on_behavior:null, linkquality: null, update_available: null, update: {state: null, installed_version: "v20.9"}}),
             { retain: false, qos: 0 },
             expect.any(Function)
         );
@@ -208,7 +208,7 @@ describe('Frontend', () => {
 
         // Received message on socket
         expect(mockWSClient.implementation.send).toHaveBeenCalledTimes(1);
-        expect(mockWSClient.implementation.send).toHaveBeenCalledWith(stringify({topic: 'bulb_color', payload: {state: 'ON', power_on_behavior:null, linkquality: null, update_available: null, update: {state: null, installed_version: "unknown"}}}));
+        expect(mockWSClient.implementation.send).toHaveBeenCalledWith(stringify({topic: 'bulb_color', payload: {state: 'ON', power_on_behavior:null, linkquality: null, update_available: null, update: {state: null, installed_version: "v20.9"}}}));
 
         // Shouldnt set when not ready
         mockWSClient.implementation.send.mockClear();

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -956,7 +956,7 @@ describe('HomeAssistant extension', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-            stringify({"color":{"hue": 0, "saturation": 100, "h": 0, "s": 100}, "color_mode": "hs", "linkquality": null, "state": null, "update_available": null, "power_on_behavior":null, "update": {"state": null, "installed_version": "unknown"}}),
+            stringify({"color":{"hue": 0, "saturation": 100, "h": 0, "s": 100}, "color_mode": "hs", "linkquality": null, "state": null, "update_available": null, "power_on_behavior":null, "update": {"state": null, "installed_version": "v20.9"}}),
             { retain: false, qos: 0 },
             expect.any(Function),
         );
@@ -972,7 +972,7 @@ describe('HomeAssistant extension', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-            stringify({"color": {"x": 0.4576,"y": 0.41}, "color_mode": "xy", "linkquality": null,"state": null, "update_available": null, "power_on_behavior":null, "update": {"state": null, "installed_version": "unknown"}}),
+            stringify({"color": {"x": 0.4576,"y": 0.41}, "color_mode": "xy", "linkquality": null,"state": null, "update_available": null, "power_on_behavior":null, "update": {"state": null, "installed_version": "v20.9"}}),
             { retain: false, qos: 0 },
             expect.any(Function),
         );
@@ -988,7 +988,7 @@ describe('HomeAssistant extension', () => {
         expect(MQTT.publish).toHaveBeenCalledTimes(1);
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb_color',
-            stringify({"linkquality": null,"state": "ON", "update_available": null, "power_on_behavior": null, "update": {"state": null, "installed_version": "unknown"}}),
+            stringify({"linkquality": null,"state": "ON", "update_available": null, "power_on_behavior": null, "update": {"state": null, "installed_version": "v20.9"}}),
             { retain: false, qos: 0 },
             expect.any(Function),
         );

--- a/test/stub/zigbeeHerdsman.js
+++ b/test/stub/zigbeeHerdsman.js
@@ -130,7 +130,7 @@ class Device {
 
 const returnDevices = [];
 
-const bulb_color = new Device('Router', '0x000b57fffec6a5b3', 40399, 4107, [new Endpoint(1, [0,3,4,5,6,8,768,2821,4096], [5,25,32,4096], '0x000b57fffec6a5b3', [], {lightingColorCtrl: {colorCapabilities: 254}})], true, "Mains (single phase)", "LLC020");
+const bulb_color = new Device('Router', '0x000b57fffec6a5b3', 40399, 4107, [new Endpoint(1, [0,3,4,5,6,8,768,2821,4096], [5,25,32,4096], '0x000b57fffec6a5b3', [], {lightingColorCtrl: {colorCapabilities: 254}})], true, "Mains (single phase)", "LLC020", false, undefined, null, '20.9');
 const bulb_color_2 = new Device('Router', '0x000b57fffec6a5b4', 401292, 4107, [new Endpoint(1, [0,3,4,5,6,8,768,2821,4096], [5,25,32,4096], '0x000b57fffec6a5b4', [], {lightingColorCtrl: {colorCapabilities: 254}}, [], null, null, {'scenes': {'1_0': {name: 'Chill scene', state: {state: 'ON'}}, '4_9': {state: {state: 'OFF'}}}})], true, "Mains (single phase)", "LLC020", false, 'Philips', '2019.09', '5.127.1.26581');
 const bulb_2 =  new Device('Router', '0x000b57fffec6a5b7', 40369, 4476, [new Endpoint(1, [0,3,4,5,6,8,768,2821,4096], [5,25,32,4096], '0x000b57fffec6a5b7', [], {lightingColorCtrl: {colorCapabilities: 17}})], true, "Mains (single phase)", "TRADFRI bulb E27 WS opal 980lm");
 const TS0601_thermostat =  new Device('EndDevice', '0x0017882104a44559', 6544,4151, [new Endpoint(1, [], [], '0x0017882104a44559')], true, "Mains (single phase)", 'kud7u2l');


### PR DESCRIPTION
Fixes #15304, #15290 and #15347.

Example HA error message:

```
Exception in handle_state_message_received when handling msg on 'zigbee2mqtt/Sala': '{"battery":127.5,"battery_low":false,"boost":false,"child_protection":false,"current_heating_setpoint":7,"error_status":0,"linkquality":0,"local_temperature":18,"local_temperature_calibration":null,"mirror_display":false,"occupied_heating_setpoint":7,"pi_heating_demand":100,"running_state":"heat","system_mode":"auto","trv_mode":null,"unoccupied_heating_setpoint":16,"update":{"installed_version":"22190930","state":null},"update_available":null,"valve_position":null,"window_open":false}' Traceback (most recent call last): File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/components/mqtt/debug_info.py", line 44, in wrapper msg_callback(msg) File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/components/mqtt/update.py", line 191, in handle_state_message_received if "installed_version" in json_payload: TypeError: argument of type 'int' is not iterable
```

HA [MQTT update integration](https://www.home-assistant.io/integrations/update.mqtt/) cannot deal with numerical version numbers that don't have 2 dot separators, e.g.:
- `1.0.0` -> works
- `1.0` -> fails
- `1` -> fails
- `v1` -> works

This fix ensures the `installed_version` is always a string by prepending it with a `v`.


@emontnemery can you check this?
- Either this is unexpected behaviour and this should be fixed in HA
- OR the example in the [docs](https://www.home-assistant.io/integrations/update.mqtt/#examples) is wrong (under `If the device/service sends data as JSON but the schema differs, value_template can be use to reformat the JSON.` it shows `"installed_ver": "2022.11",`)