### PR TITLE
Publish both Alpine and Debian based images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,26 +40,55 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: latest
-    - name: Docker build dev
+    - name: Docker build dev (alpine)
       if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
       run: |
         docker buildx build \
           --build-arg COMMIT=$(git rev-parse --short HEAD) \
+          --build-arg base=alpine \
           --platform linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7 \
+          --target release \
           -f docker/Dockerfile \
           --push \
           -t koenkk/zigbee2mqtt:latest-dev -t ghcr.io/koenkk/zigbee2mqtt:latest-dev \
           .
-    - name: Docker build release
+    - name: Docker build dev (debian)
+      if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+      run: |
+        docker buildx build \
+          --build-arg COMMIT=$(git rev-parse --short HEAD) \
+          --build-arg base=debian \
+          --platform linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7 \
+          --target release \
+          -f docker/Dockerfile \
+          --push \
+          -t koenkk/zigbee2mqtt:latest-dev-debian -t ghcr.io/koenkk/zigbee2mqtt:latest-dev-debian \
+          .
+    - name: Docker build release (alpine)
       if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
       run: |
         TAG="$(git describe --tags)"
         docker buildx build \
           --build-arg COMMIT=$(git rev-parse --short HEAD) \
+          --build-arg base=alpine \
           --platform linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7 \
+          --target release \
           -f docker/Dockerfile \
           --push \
           -t koenkk/zigbee2mqtt:latest -t "koenkk/zigbee2mqtt:$TAG" -t ghcr.io/koenkk/zigbee2mqtt:latest -t "ghcr.io/koenkk/zigbee2mqtt:$TAG" \
+          .
+    - name: Docker build release (debian)
+      if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
+      run: |
+        TAG="$(git describe --tags)"
+        docker buildx build \
+          --build-arg COMMIT=$(git rev-parse --short HEAD) \
+          --build-arg base=debian \
+          --platform linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7 \
+          --target release \
+          -f docker/Dockerfile \
+          --push \
+          -t koenkk/zigbee2mqtt:latest-debian -t "koenkk/zigbee2mqtt:$TAG" -t ghcr.io/koenkk/zigbee2mqtt:latest-debian -t "ghcr.io/koenkk/zigbee2mqtt:$TAG" \
           .
     - name: Publish to npm
       if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,30 @@
-FROM node:18-alpine3.16 as base
+# set base to "alpine" or "debian" to set the base os
+ARG base=alpine
 
+# The following is a multi-stage build that builds the image in 5 stages:
+# release -> entrypoint-${base} -> app -> build -> base-${base}
+
+# base-alpine and base-debian both install the same packages
+FROM node:18-alpine3.16 AS base-alpine
 WORKDIR /app
-RUN apk add --no-cache tzdata eudev tini
+RUN apk add --no-cache tzdata eudev tini make gcc g++ python3 linux-headers git
 
-# Dependencies and build
-FROM base as dependencies_and_build
+FROM node:18-bullseye-slim AS base-debian
+WORKDIR /app
+RUN apt-get update && apt-get install -y udev build-essential python3 git
 
+# build is base layer agnostic
+FROM base-${base} AS build
 COPY package*.json tsconfig.json index.js ./
 COPY lib ./lib
+RUN npm rebuild --build-from-source
+RUN npm ci --production --no-audit --no-optional --no-update-notifier
 
-RUN apk add --no-cache --virtual .buildtools make gcc g++ python3 linux-headers git && \
-    npm ci --production --no-audit --no-optional --no-update-notifier && \
-    apk del .buildtools
+# app is base layer agnostic
+FROM base-${base} AS app
 
-# Release
-FROM base as release
+COPY --from=build /app/node_modules ./node_modules
 
-COPY --from=dependencies_and_build /app/node_modules ./node_modules
 COPY dist ./dist
 COPY package.json LICENSE index.js data/configuration.yaml ./
 
@@ -30,5 +38,13 @@ RUN echo "$COMMIT" > dist/.hash
 
 ENV NODE_ENV production
 
+FROM app AS entrypoint-alpine
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD [ "/sbin/tini", "--", "node", "index.js"]
+CMD [ "/usr/bin/tini", "--", "node", "index.js"]
+
+FROM app AS entrypoint-debian
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD [ "node", "index.js"]
+
+FROM entrypoint-${base} AS release
+# This is our final layer! :-)


### PR DESCRIPTION
Use multi-stage docker builds to support building both Alpine and Debian based images. Use `--build-arg base=debian` to build a Debian based image.

This fixes #15380 (introduced in https://github.com/Koenkk/zigbee-herdsman/pull/607).

The upgrade of serialport seems to be worth doing at this point, so I figured that building Debian images for usage on arm/v7 (and maybe other arm devices) would be the best alternative. 