### PR TITLE
added moving state to home assistant for TS130F Curtain/blind switch

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -393,6 +393,7 @@ export default class HomeAssistant extends Extension {
             const motorState = allExposes?.find((e) => e.type === 'enum' && e.name === 'motor_state' &&
                 e.access === ACCESS_STATE);
             const running = allExposes?.find((e) => e.type === 'binary' && e.name === 'running');
+            const moving = allExposes?.find((e) => e.type === 'enum' && e.name === 'moving');
 
             const discoveryEntry: DiscoveryEntry = {
                 type: 'cover',
@@ -406,24 +407,38 @@ export default class HomeAssistant extends Extension {
                 },
             };
 
-            // For curtains that have `motor_state` lookup a possible state names and make this
+            // For curtains that have `motor_state` or `moving` lookup a possible state names and make this
             // available for discovery. If the curtains only support the `running` value,
             // then we use it anyway. The movement direction is calculated (assumed) in this case.
-            if (motorState) {
+            if (motorState || moving) {
                 const openingLookup = ['opening', 'open', 'forward', 'up', 'rising'];
                 const closingLookup = ['closing', 'close', 'backward', 'back', 'reverse', 'down', 'declining'];
                 const stoppedLookup = ['stopped', 'stop', 'pause', 'paused'];
 
-                const openingState = motorState.values.find((s) => openingLookup.includes(s.toLowerCase()));
-                const closingState = motorState.values.find((s) => closingLookup.includes(s.toLowerCase()));
-                const stoppedState = motorState.values.find((s) => stoppedLookup.includes(s.toLowerCase()));
+                const movingState = motorState ? motorState : moving;
+
+                const openState = state.values.find((s) => openingLookup.includes(s.toLowerCase()));
+                const closeState = state.values.find((s) => closingLookup.includes(s.toLowerCase()));
+                const openingState = movingState.values.find((s) => openingLookup.includes(s.toLowerCase()));
+                const closingState = movingState.values.find((s) => closingLookup.includes(s.toLowerCase()));
+                const stoppedState = movingState.values.find((s) => stoppedLookup.includes(s.toLowerCase()));
 
                 if (openingState && closingState && stoppedState) {
                     discoveryEntry.discovery_payload.state_opening = openingState;
                     discoveryEntry.discovery_payload.state_closing = closingState;
-                    discoveryEntry.discovery_payload.state_stopped = stoppedState;
-                    discoveryEntry.discovery_payload.value_template = `{% if not value_json.${motorState.property} %}` +
-                        ` ${stoppedState} {% else %} {{ value_json.${motorState.property} }} {% endif %}`;
+                    if (openState && closeState) {
+                        discoveryEntry.discovery_payload.state_open = openState;
+                        discoveryEntry.discovery_payload.state_closed = closeState;
+                        discoveryEntry.discovery_payload.value_template =
+                        `{{ value_json.${movingState.property} if value_json.${movingState.property} and` +
+                        ` value_json.${movingState.property} != '${stoppedState}' else` +
+                        ` value_json.${featurePropertyWithoutEndpoint(state)} }}`;
+                    } else {
+                        discoveryEntry.discovery_payload.state_stopped = stoppedState;
+                        discoveryEntry.discovery_payload.value_template =
+                            `{{ '${stoppedState}' if not value_json.${movingState.property}` +
+                                ` else value_json.${movingState.property} }}`;
+                    }
                 }
             } else if (running) {
                 discoveryEntry.discovery_payload.value_template = `{% if not value_json.${running.property} %} ` +


### PR DESCRIPTION
Curtain/blind switches like TS130F (https://www.zigbee2mqtt.io/devices/TS130F.html#tuya-ts130f) do not show the moving status on the home assistant. This happens because they use a different property to report the moving state, this property is called 'moving'.
This PR reuses the logic for the 'motorState' property (that some other cover switches might use) to report the cover moving state to the home assistant. It was already tested and it's working.
Also, I made some minor adjustments to the docker-compose file to make it possible to build the image directly using it.
Feel free to change something that you don't like or prefer in a different way, or just leave comments and I'll do it.