### PR TITLE
Fix extension path to make debugging easier in VScode

### DIFF
--- a/lib/extension/externalExtension.ts
+++ b/lib/extension/externalExtension.ts
@@ -56,7 +56,7 @@ export default class ExternalExtension extends Extension {
 
     @bind private async saveExtension(message: KeyValue): Promise<MQTTResponse> {
         const {name, code} = message;
-        const ModuleConstructor = utils.loadModuleFromText(code) as typeof Extension;
+        const ModuleConstructor = utils.loadModuleFromText(code,name) as typeof Extension;
         await this.loadExtension(ModuleConstructor);
         const basePath = this.getExtensionsBasePath();
         /* istanbul ignore else */
@@ -95,7 +95,7 @@ export default class ExternalExtension extends Extension {
     private loadUserDefinedExtensions(): void {
         const extensions = this.getListOfUserDefinedExtensions();
         extensions
-            .map(({code}) => utils.loadModuleFromText(code))
+            .map(({code,name}) => utils.loadModuleFromText(code,name))
             .map(this.loadExtension);
     }
 

--- a/lib/extension/externalExtension.ts
+++ b/lib/extension/externalExtension.ts
@@ -56,7 +56,7 @@ export default class ExternalExtension extends Extension {
 
     @bind private async saveExtension(message: KeyValue): Promise<MQTTResponse> {
         const {name, code} = message;
-        const ModuleConstructor = utils.loadModuleFromText(code,name) as typeof Extension;
+        const ModuleConstructor = utils.loadModuleFromText(code, name) as typeof Extension;
         await this.loadExtension(ModuleConstructor);
         const basePath = this.getExtensionsBasePath();
         /* istanbul ignore else */
@@ -95,7 +95,7 @@ export default class ExternalExtension extends Extension {
     private loadUserDefinedExtensions(): void {
         const extensions = this.getListOfUserDefinedExtensions();
         extensions
-            .map(({code,name}) => utils.loadModuleFromText(code,name))
+            .map(({code, name}) => utils.loadModuleFromText(code, name))
             .map(this.loadExtension);
     }
 

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -134,8 +134,8 @@ function parseJSON(value: string, fallback: string): KeyValue | string {
     }
 }
 
-function loadModuleFromText(moduleCode: string): unknown {
-    const moduleFakePath = path.join(__dirname, 'externally-loaded.js');
+function loadModuleFromText(moduleCode: string, name?: string): unknown {
+    const moduleFakePath = path.join(__dirname, '..', '..', 'data', 'extension', name || 'externally-loaded.js');
     const sandbox = {
         require: require,
         module: {},


### PR DESCRIPTION
VSCode seems to be confused if you have multiple extensions loaded as they all have the same module "name".

This fix links them back to the data/extensions directory so VSCode can correctly match up source-maps, etc.