### PR TITLE
Poll Busch-Jaeger devices for updates after binding-initiated changes

### DIFF
--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -102,6 +102,7 @@ const pollOnMessage: PollOnMessage = [
             zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
             zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
             zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
+            zigbeeHersdman.Zcl.ManufacturerCode.BUSCH_JAEGER,
         ],
         manufacturerNames: [
             'GLEDOPTO',
@@ -137,6 +138,7 @@ const pollOnMessage: PollOnMessage = [
             zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
             zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
             zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
+            zigbeeHersdman.Zcl.ManufacturerCode.BUSCH_JAEGER,
         ],
         manufacturerNames: [
             'GLEDOPTO',
@@ -168,6 +170,7 @@ const pollOnMessage: PollOnMessage = [
             zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
             zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
             zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
+            // Note: ManufacturerCode.BUSCH_JAEGER is left out intentionally here as their devices don't support colors
         ],
         manufacturerNames: [
             'GLEDOPTO',


### PR DESCRIPTION
The Busch-Jaeger devices don't support reporting and therefore their state should be polled after being changed through a binding partner.