### PR TITLE
Sane defaults for remote syslog

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -511,13 +511,13 @@
               "type": "number",
               "title": "Port",
               "description": "The port on the host that syslog is running on, defaults to syslogd's default port.",
-              "default": 123
+              "default": 514
             },
             "protocol": {
               "type": "string",
               "title": "Protocol",
               "description": "The network protocol to log over (e.g. tcp4, udp4, tls4, unix, unix-connect, etc).",
-              "default": "tcp4",
+              "default": "udp4",
               "examples": [
                 "udp4",
                 "tls4",


### PR DESCRIPTION
The most commonly used transport for remote syslog is port 514/udp. It also is the only defined method for BSD syslog ([RFC 3164](https://www.rfc-editor.org/rfc/rfc3164)). RFCs [5424](https://www.rfc-editor.org/rfc/rfc5424)+[5425](https://www.rfc-editor.org/rfc/rfc5425) specify an additional TLS transport via 6514/tcp, which does not seem to be supported by zigbee2mqtt, as evidenced by the lack of TLS-related configuration options in this area. [RFC 6587](https://www.rfc-editor.org/rfc/rfc6587) describes legacy uses of syslog over TCP, recommending against them.

Port 123, the previous default, was probably used by accident and is reserved for NTP.

```console
$ grep -w -e 123 -e 514 -e 601 -e 6514 /etc/services
ntp	123/udp				# Network Time Protocol
shell	514/tcp		cmd syslog	# no passwords used
syslog	514/udp
syslog-tls	6514/tcp		# Syslog over TLS [RFC5425]
```
