### PR TITLE
Fix `motor_state` and `moving` in HA covers

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -390,10 +390,9 @@ export default class HomeAssistant extends Extension {
                 ?.features.find((f) => f.name === 'position');
             const tilt = exposes.find((expose) => expose.features.find((e) => e.name === 'tilt'))
                 ?.features.find((f) => f.name === 'tilt');
-            const motorState = allExposes?.find((e) => e.type === 'enum' && e.name === 'motor_state' &&
-                e.access === ACCESS_STATE);
+            const motorState = allExposes?.find((e) => e.type === 'enum' &&
+                ['motor_state', 'moving'].includes(e.name) && e.access === ACCESS_STATE);
             const running = allExposes?.find((e) => e.type === 'binary' && e.name === 'running');
-            const moving = allExposes?.find((e) => e.type === 'enum' && e.name === 'moving');
 
             const discoveryEntry: DiscoveryEntry = {
                 type: 'cover',
@@ -407,27 +406,24 @@ export default class HomeAssistant extends Extension {
                 },
             };
 
-            // For curtains that have `motor_state` lookup a possible state names and make this
+            // For curtains that have `motor_state` or `moving` lookup a possible state names and make this
             // available for discovery. If the curtains only support the `running` value,
             // then we use it anyway. The movement direction is calculated (assumed) in this case.
-            if (motorState || moving) {
+            if (motorState) {
                 const openingLookup = ['opening', 'open', 'forward', 'up', 'rising'];
                 const closingLookup = ['closing', 'close', 'backward', 'back', 'reverse', 'down', 'declining'];
                 const stoppedLookup = ['stopped', 'stop', 'pause', 'paused'];
 
-                const movingState = motorState ? motorState : moving;
-
-                const openingState = movingState.values.find((s) => openingLookup.includes(s.toLowerCase()));
-                const closingState = movingState.values.find((s) => closingLookup.includes(s.toLowerCase()));
-                const stoppedState = movingState.values.find((s) => stoppedLookup.includes(s.toLowerCase()));
+                const openingState = motorState.values.find((s) => openingLookup.includes(s.toLowerCase()));
+                const closingState = motorState.values.find((s) => closingLookup.includes(s.toLowerCase()));
+                const stoppedState = motorState.values.find((s) => stoppedLookup.includes(s.toLowerCase()));
 
                 if (openingState && closingState && stoppedState) {
                     discoveryEntry.discovery_payload.state_opening = openingState;
                     discoveryEntry.discovery_payload.state_closing = closingState;
                     discoveryEntry.discovery_payload.state_stopped = stoppedState;
-                    discoveryEntry.discovery_payload.value_template =
-                        `{{ ${stoppedState} if not value_json.${movingState.property} ` +
-                        `else value_json.${movingState.property} }}`;
+                    discoveryEntry.discovery_payload.value_template = `{% if not value_json.${motorState.property} %}` +
+                        ` ${stoppedState} {% else %} {{ value_json.${motorState.property} }} {% endif %}`;
                 }
             } else if (running) {
                 discoveryEntry.discovery_payload.value_template = `{% if not value_json.${running.property} %} ` +


### PR DESCRIPTION
This PR reverts #16017 to fix #15873 and add handle a `moving` state in `motorState`.