### PR TITLE
fix for TypeError: The "path" argument must be of type string in writeDevicesOrGroups

### DIFF
--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -230,7 +230,7 @@ function write(): void {
 
     // Write devices/groups to separate file if required.
     const writeDevicesOrGroups = (type: 'devices' | 'groups'): void => {
-        if (typeof actual[type] === 'string' || Array.isArray(actual[type])) {
+        if (typeof actual[type] === 'string' || (Array.isArray(actual[type]) && actual[type].length > 0)) {
             const fileToWrite = Array.isArray(actual[type]) ? actual[type][0] : actual[type];
             const content = objectAssignDeep({}, settings[type]);
 
@@ -361,7 +361,7 @@ function read(): Settings {
 
     // Read devices/groups configuration from separate file if specified.
     const readDevicesOrGroups = (type: 'devices' | 'groups'): void => {
-        if (typeof s[type] === 'string' || Array.isArray(s[type])) {
+        if (typeof s[type] === 'string' || (Array.isArray(s[type]) && Array(s[type]).length > 0)) {
             /* eslint-disable-line */ // @ts-ignore
             const files: string[] = Array.isArray(s[type]) ? s[type] : [s[type]];
             s[type] = {};

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -123,6 +123,22 @@ describe('Settings', () => {
         expect(actual).toStrictEqual(expected);
     });
 
+    it('Should add devices even when devices exist empty', () => {
+        write(configurationFile, {devices: []});
+        settings.addDevice('0x12345678');
+
+        const actual = read(configurationFile);
+        const expected = {
+            devices: {
+                '0x12345678': {
+                    friendly_name: '0x12345678',
+                },
+            },
+        };
+
+        expect(actual).toStrictEqual(expected);
+    });
+
     it('Should read devices', () => {
         const content = {
             devices: {
@@ -904,7 +920,7 @@ describe('Settings', () => {
 
     it('Frontend config', () => {
         write(configurationFile, {...minimalConfig,
-            frontend: true, 
+            frontend: true,
         });
 
         settings.reRead();
@@ -913,7 +929,7 @@ describe('Settings', () => {
 
     it('Baudrate config', () => {
         write(configurationFile, {...minimalConfig,
-            advanced: {baudrate: 20}, 
+            advanced: {baudrate: 20},
         });
 
         settings.reRead();
@@ -922,7 +938,7 @@ describe('Settings', () => {
 
     it('ikea_ota_use_test_url config', () => {
         write(configurationFile, {...minimalConfig,
-            advanced: {ikea_ota_use_test_url: true}, 
+            advanced: {ikea_ota_use_test_url: true},
         });
 
         settings.reRead();
@@ -931,7 +947,7 @@ describe('Settings', () => {
 
     it('transmit_power config', () => {
         write(configurationFile, {...minimalConfig,
-            experimental: {transmit_power: 1337}, 
+            experimental: {transmit_power: 1337},
         });
 
         settings.reRead();
@@ -940,7 +956,7 @@ describe('Settings', () => {
 
     it('output config', () => {
         write(configurationFile, {...minimalConfig,
-            experimental: {output: 'json'}, 
+            experimental: {output: 'json'},
         });
 
         settings.reRead();
@@ -949,7 +965,7 @@ describe('Settings', () => {
 
     it('Baudrartsctste config', () => {
         write(configurationFile, {...minimalConfig,
-            advanced: {rtscts: true}, 
+            advanced: {rtscts: true},
         });
 
         settings.reRead();
@@ -958,7 +974,7 @@ describe('Settings', () => {
 
     it('Deprecated: Home Assistant config', () => {
         write(configurationFile, {...minimalConfig,
-            homeassistant: {discovery_topic: 'new'}, 
+            homeassistant: {discovery_topic: 'new'},
             advanced: {homeassistant_discovery_topic: 'old', homeassistant_status_topic: 'olds'},
         });
 


### PR DESCRIPTION
fixes https://github.com/Koenkk/zigbee2mqtt/issues/16605

it seems an additional check if the array is not empty is required to get the rest to create a new array.