### PR TITLE
[WIP] Add Prometheus metrics extension

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -11,6 +11,7 @@ import bind from 'bind-decorator';
 
 // Extensions
 import ExtensionFrontend from './extension/frontend';
+import ExtensionMetrics from './extension/metrics';
 import ExtensionPublish from './extension/publish';
 import ExtensionReceive from './extension/receive';
 import ExtensionNetworkMap from './extension/networkMap';
@@ -33,7 +34,8 @@ const AllExtensions = [
     ExtensionPublish, ExtensionReceive, ExtensionNetworkMap, ExtensionSoftReset, ExtensionHomeAssistant,
     ExtensionConfigure, ExtensionDeviceGroupMembership, ExtensionBridgeLegacy, ExtensionBridge, ExtensionGroups,
     ExtensionBind, ExtensionReport, ExtensionOnEvent, ExtensionOTAUpdate,
-    ExtensionExternalConverters, ExtensionFrontend, ExtensionExternalExtension, ExtensionAvailability,
+    ExtensionExternalConverters, ExtensionFrontend, ExtensionMetrics,
+    ExtensionExternalExtension, ExtensionAvailability,
 ];
 
 type ExtensionArgs = [Zigbee, MQTT, State, PublishEntityState, EventBus,
@@ -80,6 +82,7 @@ export class Controller {
             new ExtensionExternalExtension(...this.extensionArgs),
             new ExtensionAvailability(...this.extensionArgs),
             settings.get().frontend && new ExtensionFrontend(...this.extensionArgs),
+            settings.get().metrics && new ExtensionMetrics(...this.extensionArgs),
             settings.get().advanced.legacy_api && new ExtensionBridgeLegacy(...this.extensionArgs),
             settings.get().external_converters.length && new ExtensionExternalConverters(...this.extensionArgs),
             settings.get().homeassistant && new ExtensionHomeAssistant(...this.extensionArgs),

--- a/lib/extension/metrics/createZ2MMetrics.ts
+++ b/lib/extension/metrics/createZ2MMetrics.ts
@@ -1,0 +1,119 @@
+import metrics, { Gauge, Summary } from 'prom-client'
+import * as settings from '../../util/settings';
+import utils from '../../util/utils';
+
+export async function createZ2MMetrics(
+  zigbee: Zigbee,
+  mqtt: MQTT,
+  state: State
+) {
+  const zigbee2mqttVersion = await utils.getZigbee2MQTTVersion();
+  const coordinator = await zigbee.getCoordinatorVersion()
+
+  const zigbee2mqttLabel = `${zigbee2mqttVersion.version}-${zigbee2mqttVersion.commitHash}`
+  const coordinatorLabel = `${coordinator?.type ?? 'unknown'}@${coordinator?.meta?.revision ?? 'unknown'}`
+
+  metrics.register.setDefaultLabels({
+    zigbee2mqtt: zigbee2mqttLabel,
+    coordinator: coordinatorLabel
+  })
+
+  // Enable generic nodejs process metrics
+  // see https://github.com/siimon/prom-client#default-metrics
+  if (settings.get().metrics.nodejs_metrics) {
+    metrics.collectDefaultMetrics();
+  }
+
+  // Define zigbee2mqtt metrics
+  new metrics.Gauge({
+    name: 'zigbee_device_joined_count',
+    help: 'Number of devices joined to the network (excluding coordinator)',
+    collect() {
+      this.set(zigbee.devices(false).length)
+    }
+  })
+
+  const device_last_seen_summary = new Summary({
+    name: 'zigbee_device_last_seen_summary',
+    help: 'Seconds since device was last seen, percentile'
+  })
+  new Gauge({
+    name: 'zigbee_device_last_seen',
+    help: 'Seconds since device was last seen, labeled by device ieee address',
+    labelNames: ['ieeeAddr'],
+    collect() {
+      const now = Date.now();
+      device_last_seen_summary.reset()
+      this.reset()
+
+      for (const device of zigbee.devices(false)) {
+        const lastSeenElapsedSeconds = Math.round((now - device.zh.lastSeen) / 1000)
+        if (settings.get().metrics.per_device_labels) {
+          this.set({ ieeeAddr: device.ieeeAddr }, lastSeenElapsedSeconds)
+        }
+        device_last_seen_summary.observe(lastSeenElapsedSeconds)
+      }
+    }
+  })
+
+  const device_lqi_summary = new Summary({
+    name: 'zigbee_device_lqi_summary',
+    help: 'Device link quality index (when available), percentile'
+  })
+  new Gauge({
+    name: 'zigbee_device_lqi',
+    help: 'Device link quality index (when available), labeled by device ieee address',
+    labelNames: ['ieeeAddr'],
+    collect() {
+      device_lqi_summary.reset()
+      this.reset()
+      for (const device of zigbee.devices(false)) {
+        const lqi = device.zh.linkquality
+
+        if (lqi !== undefined) {
+          if (settings.get().metrics.per_device_labels) {
+            this.set({ ieeeAddr: device.ieeeAddr }, lqi)
+          }
+          device_lqi_summary.observe(lqi)
+        }
+      }
+    }
+  })
+
+  new Gauge({
+    name: 'zigbee_device_battery',
+    help: 'Battery status for battery-powered devices, labeled by device ieee address',
+    labelNames: ['ieeeAddr'],
+    collect() {
+      this.reset()
+      for (const device of zigbee.devices(false)) {
+        const battery = state.get(device)?.battery
+
+        if (battery !== undefined) {
+          if (settings.get().metrics.per_device_labels) {
+            this.set({ ieeeAddr: device.ieeeAddr }, battery)
+          }
+        }
+      }
+
+    }
+  })
+
+  new metrics.Gauge({
+    name: 'zigbee_mqtt_connected',
+    help: '1 if zigbee2mqtt is connected to downstream mqtt server, otherwise 0',
+    collect() {
+      this.set(mqtt.isConnected() ? 1 : 0)
+    }
+  })
+
+  new metrics.Gauge({
+    name: 'zigbee_permit_join',
+    help: '1 if network is in Permit Join mode, otherwise 0',
+    collect() {
+      this.set(zigbee.getPermitJoin() ? 1 : 0)
+    }
+  })
+
+}
+

--- a/lib/extension/metrics/createZhMetrics.ts
+++ b/lib/extension/metrics/createZhMetrics.ts
@@ -1,0 +1,103 @@
+import meter, { type Registry as MetricsRegistry } from "prom-client"
+import { Adapter } from "zigbee-herdsman/dist/adapter"
+import { Events as AdapterEvents } from "zigbee-herdsman/dist/adapter/events"
+import { Device, Entity } from "zigbee-herdsman/dist/controller/model"
+import * as settings from '../../util/settings';
+
+function perDeviceHelp(help: string, perDeviceHelp: string) {
+  if (!settings.get().metrics.per_device_labels) {
+    return help
+  }
+  return help + perDeviceHelp
+}
+function perDeviceLabels(labels: Record<string, unknown>, perDeviceLabels: Record<string, unknown>) {
+  if (!settings.get().metrics.per_device_labels) {
+    return labels
+  }
+  return { ...labels, ...perDeviceLabels }
+}
+
+class MetricsZHAdapter extends Entity {
+  static use() {
+    const originalAdapter = Entity.adapter
+    const wrappedAdapter: Adapter = Object.create(originalAdapter)
+    Entity.injectAdapter(wrappedAdapter)
+    return { wrappedAdapter, originalAdapter }
+  }
+}
+
+export function createZhMetrics() {
+  const { wrappedAdapter, originalAdapter } = MetricsZHAdapter.use()
+
+  const zigbee_herdsman_zcl_frame_tx = new meter.Counter({
+    name: 'zigbee_herdsman_zcl_frame_tx',
+    help: perDeviceHelp('Zigbee ZCL frames transmitted, labelled by destination', ' and destination address or group id if available'),
+    labelNames: ['dest', 'destAddr', 'groupId']
+  })
+  wrappedAdapter.sendZclFrameToEndpoint = (...args) => {
+    const destAddr = args[0]
+    zigbee_herdsman_zcl_frame_tx.inc(perDeviceLabels({ dest: 'endpoint' }, { destAddr }), 1)
+    return originalAdapter.sendZclFrameToEndpoint(...args)
+  }
+  wrappedAdapter.sendZclFrameToGroup = (...args) => {
+    const groupId = args[0]
+    zigbee_herdsman_zcl_frame_tx.inc(perDeviceLabels({ dest: 'group' }, { groupId }), 1)
+    return originalAdapter.sendZclFrameToGroup(...args)
+  }
+  wrappedAdapter.sendZclFrameToAll = (...args) => {
+    zigbee_herdsman_zcl_frame_tx.inc({ dest: 'all' })
+    return originalAdapter.sendZclFrameToAll(...args)
+  }
+  wrappedAdapter.sendZclFrameInterPANToIeeeAddr = (...args) => {
+    const destAddr = args[1]
+    zigbee_herdsman_zcl_frame_tx.inc(perDeviceLabels({ dest: 'inter_pan_to_ieee_addr' }, { destAddr }))
+    return originalAdapter.sendZclFrameInterPANToIeeeAddr(...args)
+  }
+  wrappedAdapter.sendZclFrameInterPANBroadcast = (...args) => {
+    zigbee_herdsman_zcl_frame_tx.inc({ dest: 'inter_pan_broadcast' })
+    return originalAdapter.sendZclFrameInterPANBroadcast(...args)
+  }
+
+  const zigbee_herdsman_zcl_frame_rx = new meter.Counter({
+    name: 'zigbee_herdsman_zcl_frame_rx',
+    help: perDeviceHelp('Zigbee ZCL frames received, labelled by type', ' and source ieee address'),
+    labelNames: ['type', 'srcAddr']
+  })
+
+  const rxTypes = [
+    AdapterEvents.deviceJoined,
+    AdapterEvents.deviceAnnounce,
+    AdapterEvents.deviceLeave,
+    AdapterEvents.networkAddress,
+    AdapterEvents.rawData,
+    AdapterEvents.zclData
+  ]
+  rxTypes.forEach(type => {
+    originalAdapter.on(type, (payload) => {
+      let srcAddr
+      switch (type) {
+        case AdapterEvents.rawData:
+        case AdapterEvents.zclData:
+          srcAddr = Device.byNetworkAddress(payload.address).ieeeAddr
+          break;
+        case AdapterEvents.deviceJoined:
+        case AdapterEvents.deviceAnnounce:
+        case AdapterEvents.deviceLeave:
+        case AdapterEvents.networkAddress:
+          srcAddr = payload.ieeeAddr
+          break
+      }
+      srcAddr = srcAddr ?? 'unknown'
+
+      zigbee_herdsman_zcl_frame_rx.inc(perDeviceLabels({ type }, { srcAddr }), 1)
+    })
+  })
+
+  const zigbee_herdsman_adapter_disconnected = new meter.Counter({
+    name: 'zigbee_herdsman_adapter_disconnected',
+    help: 'Number of times the adapter has disconnected'
+  })
+  originalAdapter.on(AdapterEvents.disconnected, () => {
+    zigbee_herdsman_adapter_disconnected.inc(1)
+  })
+}

--- a/lib/extension/metrics/index.ts
+++ b/lib/extension/metrics/index.ts
@@ -1,0 +1,31 @@
+import Extension from '../extension';
+import metrics from 'prom-client'
+
+import { createZhMetrics } from './createZhMetrics';
+import { MetricsServer } from './server';
+import { createZ2MMetrics as createZ2MMetrics } from './createZ2MMetrics'
+
+/**
+ * This extension serves prometheus metrics
+ */
+export default class Metrics extends Extension {
+  server: MetricsServer;
+
+  override async start(): Promise<void> {
+
+    createZ2MMetrics(this.zigbee, this.mqtt, this.state)
+    createZhMetrics()
+
+    this.server = await MetricsServer.create()
+  }
+
+  override async stop(): Promise<void> {
+    super.stop()
+
+    metrics.register.clear()
+
+    if (this.server) {
+      await this.server.stop()
+    }
+  }
+}

--- a/lib/extension/metrics/server.ts
+++ b/lib/extension/metrics/server.ts
@@ -1,0 +1,57 @@
+import metrics from "prom-client";
+import http from 'node:http'
+import * as settings from '../../util/settings';
+import bind from 'bind-decorator';
+import logger from "../../util/logger";
+
+export class MetricsServer {
+  private server: http.Server;
+  private host = settings.get().metrics.host;
+  private port = settings.get().metrics.port;
+
+  private constructor() {
+    this.server = http.createServer(this.onRequest);
+
+  }
+
+  async start() {
+    await new Promise<void>((resolve, reject) => {
+      this.server.listen(this.port, this.host, resolve)
+        .on('error', reject)
+    })
+
+    logger.info(`Started metrics on port ${this.host}:${this.port}/metrics`);
+  }
+
+  async stop() {
+    await new Promise<void>((resolve, reject) => {
+      this.server.close((err) => {
+        if (err) { return reject(err) }
+        resolve()
+      })
+    })
+    logger.info(`Stopped metrics on port ${this.host}:${this.port}/metrics`);
+  }
+
+  @bind private onRequest(request: http.IncomingMessage, response: http.ServerResponse): void {
+    if (request.url !== '/metrics') {
+      response.statusCode = 404
+      response.end()
+      return
+    }
+
+    this.onMetricsRequest(request, response);
+  }
+
+  private async onMetricsRequest(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
+    const metricsResponse = await metrics.register.metrics()
+    response.write(metricsResponse)
+    response.end()
+  }
+
+  static async create(): Promise<MetricsServer> {
+    const server = new MetricsServer()
+    await server.start()
+    return server
+  }
+}

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -239,6 +239,12 @@ declare global {
             ssl_cert?: string,
             ssl_key?: string,
         },
+        metrics?: {
+          per_device_labels: boolean;
+          nodejs_metrics: boolean;
+          host?: string,
+          port?: number
+        }
         devices?: {[s: string]: DeviceOptions},
         groups?: {[s: string]: GroupOptions},
         device_options: KeyValue,

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -407,6 +407,51 @@
       "title": "Frontend",
       "requiresRestart": true
     },
+    "metrics": {
+      "oneOf": [
+        {
+          "type": "boolean",
+          "title": "Metrics (simple)"
+        },
+        {
+          "type": "object",
+          "title": "Metrics (advanced)",
+          "properties": {
+            "port": {
+              "type": "number",
+              "title": "Port",
+              "description": "Metrics binding port - make sure it doesn't collide with Frontend port",
+              "default": 8081,
+              "requiresRestart": true
+            },
+            "host": {
+              "type": "string",
+              "title": "Bind host",
+              "description": "Metrics binding host",
+              "default": "0.0.0.0",
+              "requiresRestart": true
+            },
+            "per_device_labels" :  {
+              "type": ["boolean"],
+              "title": "Per device labels",
+              "description": "Report metrics per device in your network. May increase memory usage if you have a very large number of devices.",
+              "default": true,
+              "requiresRestart": true
+            },
+            "nodejs_metrics" :  {
+              "type": ["boolean"],
+              "title": "Node.js Metrics",
+              "description": "Report generic nodejs process metrics related to memory and resource usage",
+              "default": true,
+              "requiresRestart": true
+            }
+          }
+        }
+      ],
+      "title": "Metrics",
+      "description": "Enable the Prometheus metrics endpoint server",
+      "requiresRestart": true
+    },
     "devices": {
       "type": "object",
       "propertyNames": {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -157,6 +157,14 @@ function loadSettingsWithDefaults(): void {
         objectAssignDeep(_settingsWithDefaults.frontend, defaults, s);
     }
 
+    if (_settingsWithDefaults.metrics) {
+      const defaults = {port: 8081, host: '0.0.0.0', nodejs_metrics: true, per_device_labels: true};
+      const s = typeof _settingsWithDefaults.metrics === 'object' ? _settingsWithDefaults.metrics : {};
+        // @ts-ignore
+        _settingsWithDefaults.metrics = {};
+        objectAssignDeep(_settingsWithDefaults.metrics, defaults, s);
+    }
+
     if (_settings.advanced?.hasOwnProperty('baudrate') && _settings.serial?.baudrate == null) {
         // @ts-ignore
         _settingsWithDefaults.serial.baudrate = _settings.advanced.baudrate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "moment": "^2.29.4",
         "mqtt": "4.3.7",
         "object-assign-deep": "^0.4.0",
+        "prom-client": "^14.1.1",
         "rimraf": "^4.1.2",
         "semver": "^7.3.8",
         "source-map-support": "^0.5.21",
@@ -3605,6 +3606,11 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -7812,6 +7818,17 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/prom-client": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.1.1.tgz",
+      "integrity": "sha512-hFU32q7UZQ59bVJQGUtm3I2PrJ3gWvoCkilX9sF165ks1qflhugVCeK+S1JjJYHvyt3o5kj68+q3bchormjnzw==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -8518,6 +8535,14 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {
@@ -11668,6 +11693,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -14809,6 +14839,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "prom-client": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.1.1.tgz",
+      "integrity": "sha512-hFU32q7UZQ59bVJQGUtm3I2PrJ3gWvoCkilX9sF165ks1qflhugVCeK+S1JjJYHvyt3o5kj68+q3bchormjnzw==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -15337,6 +15375,14 @@
             "process": "^0.11.10"
           }
         }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
       }
     },
     "test-exclude": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "moment": "^2.29.4",
     "mqtt": "4.3.7",
     "object-assign-deep": "^0.4.0",
+    "prom-client": "^14.1.1",
     "rimraf": "^4.1.2",
     "semver": "^7.3.8",
     "source-map-support": "^0.5.21",


### PR DESCRIPTION
fixes Koenkk/zigbee2mqtt-user-extensions#5 

Adds new `metrics` extension and related settings to collect zigbee2mqtt and zigbee-herdsman metrics, and report them in Prometheus format. 

(Note, Prometheus format is a defacto standard, with common adapters available for other tools mentioned in Koenkk/zigbee2mqtt-user-extensions#5 such as influxdb and graphite)

Opening this for early discussion. The basics are working enough to see it end-to-end, but since this is my first significant contribution to zigbee2mqtt, I want to check in and see if this is the best general direction before polishing this up. Thanks for working with me on this!

## Implementation considerations / requests for feedback
- added npm package https://www.npmjs.com/package/prom-client which seems popular, well maintained, and reasonably well designed
- Prometheus metrics are served over an http endpoint. Since the `frontend` extension may not be enabled, I took the approach of creating a second http server listening on another port (default 8081). It would be possible for them to share the same port, but this would require refactoring of the `frontend` extension. If maintainers would like me to take a shared http server approach, I'm happy to try refactoring.
- In Koenkk/zigbee2mqtt-user-extensions#5 @Koenkk suggested metrics as an extension. I took that approach in this PR - all the metrics instrumentation is colocated. This has the advantage of being able to see all the metrics in one part of the codebase, but it makes instrumenting certain metrics harder. For example, I wanted to add device availability, but that's only handled by the `availability` extension. I'd prefer to avoid extensions depending on other extensions. An alternative would be to make metrics more generally available to other parts of the codebase, similar to logging in `util/logger`. Do maintainers want to keep this as an extension, or other thoughts and preferences?
- Zigbee Herdsman is the best source for lower-level metrics such as zigbee data sent and received, and the various supported adapters seem well abstracted. I took an approach in `createZhMetrics` to wrap the ZH Adapter singleton. An alternative would be to add instrumentation to zigbee-herdsman directly. I'm unsure whether there is usage of ZH outside of zigbee2mqtt, or what the general philosophy of this project is for which repo / module to locate code in. I'm open to whichever direction the maintainers prefer.
- Tests not yet implemented. Anything in particular you'd like me to cover? Otherwise, I'll try copying the style from the frontend tests.
- I'm open to feedback or suggested changes on naming, style, or other nits. 

## TODO:
- [ ] get feedback on design and implementation from maintainers
- [ ] get feedback on metric names / information from participants in Koenkk/zigbee2mqtt-user-extensions#5 
- [ ] write tests

Example graphs in Prometheus:
<img width="1499" alt="image" src="https://user-images.githubusercontent.com/1106489/222854162-2ff2454e-7426-4f9b-a31f-67a4fd2f434d.png">
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/1106489/222854187-2bf2f0c5-dc53-435d-a673-c2083a0ea18c.png">
(just to get an idea - after this lands, it'd be nice to make a default dashboard in a proper visualization tool like Grafana)

Example `/metrics` endpoint output:
<details>
```
# HELP zigbee_herdsman_zcl_frame_tx Zigbee ZCL frames transmitted, labelled by destination and destination address or group id if available
# TYPE zigbee_herdsman_zcl_frame_tx counter

# HELP zigbee_herdsman_zcl_frame_rx Zigbee ZCL frames received, labelled by type and source ieee address
# TYPE zigbee_herdsman_zcl_frame_rx counter
zigbee_herdsman_zcl_frame_rx{type="zclData",srcAddr="0x00158d0008e1b9b6",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 16

# HELP zigbee_herdsman_adapter_disconnected Number of times the adapter has disconnected
# TYPE zigbee_herdsman_adapter_disconnected counter
zigbee_herdsman_adapter_disconnected{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0

# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.735087

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.15991399999999997

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.8950010000000002

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1677884422

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 127025152

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.010905042

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.009240576

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.012050431

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.010817536

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.0004689603398920638

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.011034623

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.011108351

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.012050431

# HELP nodejs_active_resources Number of active resources that are currently keeping the event loop alive, grouped by async resource type.
# TYPE nodejs_active_resources gauge
nodejs_active_resources{type="TTYWrap",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 3
nodejs_active_resources{type="TCPSocketWrap",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 6
nodejs_active_resources{type="TCPServerWrap",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_active_resources{type="Timeout",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 6
nodejs_active_resources{type="Immediate",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1

# HELP nodejs_active_resources_total Total number of active resources.
# TYPE nodejs_active_resources_total gauge
nodejs_active_resources_total{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 18

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="WriteStream",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_active_handles{type="ReadStream",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1
nodejs_active_handles{type="Socket",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 6
nodejs_active_handles{type="Server",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 11

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 57491456

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 53779136

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1936206

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_total_bytes{space="old",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 47513600
nodejs_heap_space_size_total_bytes{space="code",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 3325952
nodejs_heap_space_size_total_bytes{space="map",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_total_bytes{space="shared",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_total_bytes{space="new",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1048576
nodejs_heap_space_size_total_bytes{space="large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 4882432
nodejs_heap_space_size_total_bytes{space="code_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 720896
nodejs_heap_space_size_total_bytes{space="new_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_total_bytes{space="shared_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_used_bytes{space="old",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 45737808
nodejs_heap_space_size_used_bytes{space="code",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2666464
nodejs_heap_space_size_used_bytes{space="map",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_used_bytes{space="shared",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_used_bytes{space="new",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 87288
nodejs_heap_space_size_used_bytes{space="large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 4675512
nodejs_heap_space_size_used_bytes{space="code_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 616800
nodejs_heap_space_size_used_bytes{space="new_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_used_bytes{space="shared_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_available_bytes{space="old",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 918752
nodejs_heap_space_size_available_bytes{space="code",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 20512
nodejs_heap_space_size_available_bytes{space="map",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_available_bytes{space="shared",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_available_bytes{space="new",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 943720
nodejs_heap_space_size_available_bytes{space="large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1031008
nodejs_heap_space_size_available_bytes{space="shared_large_object",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v19.7.0",major="19",minor="7",patch="0",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_sum{kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.0020759170055389404
nodejs_gc_duration_seconds_count{kind="incremental",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="1",kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="2",kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="5",kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_sum{kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.005241834044456482
nodejs_gc_duration_seconds_count{kind="major",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 2
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 6
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 15
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 15
nodejs_gc_duration_seconds_bucket{le="1",kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 15
nodejs_gc_duration_seconds_bucket{le="2",kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 15
nodejs_gc_duration_seconds_bucket{le="5",kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 15
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 15
nodejs_gc_duration_seconds_sum{kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0.01567208194732666
nodejs_gc_duration_seconds_count{kind="minor",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 15

# HELP zigbee_device_joined_count Number of devices joined to the network (excluding coordinator)
# TYPE zigbee_device_joined_count gauge
zigbee_device_joined_count{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 10

# HELP zigbee_device_last_seen_summary Seconds since device was last seen, percentile
# TYPE zigbee_device_last_seen_summary summary
zigbee_device_last_seen_summary{quantile="0.01",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 7
zigbee_device_last_seen_summary{quantile="0.05",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 7
zigbee_device_last_seen_summary{quantile="0.5",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 3227.5
zigbee_device_last_seen_summary{quantile="0.9",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 474354.5
zigbee_device_last_seen_summary{quantile="0.95",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 870774
zigbee_device_last_seen_summary{quantile="0.99",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 870774
zigbee_device_last_seen_summary{quantile="0.999",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 870774
zigbee_device_last_seen_summary_sum{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1043999
zigbee_device_last_seen_summary_count{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 10

# HELP zigbee_device_last_seen Seconds since device was last seen, labeled by device ieee address
# TYPE zigbee_device_last_seen gauge
zigbee_device_last_seen{ieeeAddr="0x00158d000895c279",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 897
zigbee_device_last_seen{ieeeAddr="0x54ef4410007a2768",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1384
zigbee_device_last_seen{ieeeAddr="0x00158d0008ce9f48",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 992
zigbee_device_last_seen{ieeeAddr="0x00124b0025796a78",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 870774
zigbee_device_last_seen{ieeeAddr="0x00158d0008e1b9b6",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 7
zigbee_device_last_seen{ieeeAddr="0x086bd7fffe6e5e72",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 5073
zigbee_device_last_seen{ieeeAddr="0x086bd7fffe6e60d2",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 77935
zigbee_device_last_seen{ieeeAddr="0x086bd7fffe6e5fff",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 77304
zigbee_device_last_seen{ieeeAddr="0xec1bbdfffefafd82",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 8743
zigbee_device_last_seen{ieeeAddr="0x54ef4410007a22fe",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 894

# HELP zigbee_device_lqi_summary Device link quality index (when available), percentile
# TYPE zigbee_device_lqi_summary summary
zigbee_device_lqi_summary{quantile="0.01",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186
zigbee_device_lqi_summary{quantile="0.05",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186
zigbee_device_lqi_summary{quantile="0.5",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186
zigbee_device_lqi_summary{quantile="0.9",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186
zigbee_device_lqi_summary{quantile="0.95",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186
zigbee_device_lqi_summary{quantile="0.99",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186
zigbee_device_lqi_summary{quantile="0.999",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186
zigbee_device_lqi_summary_sum{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186
zigbee_device_lqi_summary_count{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1

# HELP zigbee_device_lqi Device link quality index (when available), labeled by device ieee address
# TYPE zigbee_device_lqi gauge
zigbee_device_lqi{ieeeAddr="0x00158d0008e1b9b6",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 186

# HELP zigbee_device_battery Battery status for battery-powered devices, labeled by device ieee address
# TYPE zigbee_device_battery gauge
zigbee_device_battery{ieeeAddr="0x00158d000895c279",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 100
zigbee_device_battery{ieeeAddr="0x54ef4410007a2768",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 100
zigbee_device_battery{ieeeAddr="0x00158d0008ce9f48",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 100
zigbee_device_battery{ieeeAddr="0x54ef4410007a22fe",zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 100

# HELP zigbee_mqtt_connected 1 if zigbee2mqtt is connected to downstream mqtt server, otherwise 0
# TYPE zigbee_mqtt_connected gauge
zigbee_mqtt_connected{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 1

# HELP zigbee_permit_join 1 if network is in Permit Join mode, otherwise 0
# TYPE zigbee_permit_join gauge
zigbee_permit_join{zigbee2mqtt="1.30.2-a1b4f8ab",coordinator="zStack3x0@20210708"} 0
```
</details>