### PR TITLE
Expose 'voc_index' sensor measurements as such in HA

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -711,6 +711,7 @@ export default class HomeAssistant extends Extension {
                 temperature_min: {entity_category: 'config', icon: 'mdi:thermometer-minus'},
                 transition: {entity_category: 'config', icon: 'mdi:transition'},
                 voc: {device_class: 'volatile_organic_compounds', state_class: 'measurement'},
+                voc_index: {state_class: 'measurement'},
                 vibration_timeout: {entity_category: 'config', icon: 'mdi:timer'},
                 voltage: {
                     device_class: 'voltage',


### PR DESCRIPTION
Some air quality sensors, such as the [IKEA E2112](https://www.zigbee2mqtt.io/devices/E2112.html) present a proxy for the air quality in the form of `voc_index`, a dimension-less number between 0 and ∞.
Currently this is presented in Home-Assistant as a sensor with an infinite number of states.

With this fix, the sensor output is considered a `measurement`, which e.g. allows drawing the history of the value in a graph.

I decided to leave the [`device_class`](https://www.home-assistant.io/integrations/number/#device-class) unset, because `volatile_organic_compounds` is calibrated to µg/m³, and `aqi` is a standardized term that includes more than just VOC.