### PR TITLE
Typo fixes

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -47,7 +47,7 @@ export default class Availability extends Extension {
     private resetTimer(device: Device): void {
         clearTimeout(this.timers[device.ieeeAddr]);
 
-        // If the timer triggers, the device is not avaiable anymore otherwise resetTimer already have been called
+        // If the timer triggers, the device is not available anymore otherwise resetTimer already have been called
         if (this.isActiveDevice(device)) {
             // If device did not check in, ping it, if that fails it will be marked as offline
             this.timers[device.ieeeAddr] = setTimeout(

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -82,7 +82,7 @@ export default class Availability extends Extension {
                 const disableRecovery = !(i == 1 && available);
                 await device.zh.ping(disableRecovery);
                 pingedSuccessfully = true;
-                logger.debug(`Succesfully pinged '${device.name}' (attempt ${i + 1}/${attempts})`);
+                logger.debug(`Successfully pinged '${device.name}' (attempt ${i + 1}/${attempts})`);
                 break;
             } catch (error) {
                 logger.warn(`Failed to ping '${device.name}' (attempt ${i + 1}/${attempts}, ${error.message})`);

--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -389,7 +389,7 @@ export default class Bind extends Extension {
                     }
 
                     await endpoint.configureReporting(bind.cluster.name, items);
-                    logger.info(`Succesfully setup reporting for '${entity}' cluster '${bind.cluster.name}'`);
+                    logger.info(`Successfully setup reporting for '${entity}' cluster '${bind.cluster.name}'`);
                 } catch (error) {
                     logger.warn(`Failed to setup reporting for '${entity}' cluster '${bind.cluster.name}'`);
                 }
@@ -431,7 +431,7 @@ export default class Bind extends Extension {
                     }
 
                     await endpoint.configureReporting(cluster, items);
-                    logger.info(`Succesfully disabled reporting for '${entity}' cluster '${cluster}'`);
+                    logger.info(`Successfully disabled reporting for '${entity}' cluster '${cluster}'`);
                 } catch (error) {
                     logger.warn(`Failed to disable reporting for '${entity}' cluster '${cluster}'`);
                 }

--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -4,7 +4,7 @@ import utils from '../util/utils';
 import Extension from './extension';
 import stringify from 'json-stable-stringify-without-jsonify';
 import debounce from 'debounce';
-import * as zigbeeHersdman from 'zigbee-herdsman/dist';
+import * as zigbeeHerdsman from 'zigbee-herdsman/dist';
 import bind from 'bind-decorator';
 import Device from '../model/device';
 import Group from '../model/group';
@@ -97,12 +97,12 @@ const pollOnMessage: PollOnMessage = [
         read: {cluster: 'genLevelCtrl', attributes: ['currentLevel']},
         // When the bound devices/members of group have the following manufacturerIDs
         manufacturerIDs: [
-            zigbeeHersdman.Zcl.ManufacturerCode.Philips,
-            zigbeeHersdman.Zcl.ManufacturerCode.ATMEL,
-            zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
-            zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
-            zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
-            zigbeeHersdman.Zcl.ManufacturerCode.BUSCH_JAEGER,
+            zigbeeHerdsman.Zcl.ManufacturerCode.Philips,
+            zigbeeHerdsman.Zcl.ManufacturerCode.ATMEL,
+            zigbeeHerdsman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
+            zigbeeHerdsman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
+            zigbeeHerdsman.Zcl.ManufacturerCode.TELINK,
+            zigbeeHerdsman.Zcl.ManufacturerCode.BUSCH_JAEGER,
         ],
         manufacturerNames: [
             'GLEDOPTO',
@@ -133,12 +133,12 @@ const pollOnMessage: PollOnMessage = [
         },
         read: {cluster: 'genOnOff', attributes: ['onOff']},
         manufacturerIDs: [
-            zigbeeHersdman.Zcl.ManufacturerCode.Philips,
-            zigbeeHersdman.Zcl.ManufacturerCode.ATMEL,
-            zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
-            zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
-            zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
-            zigbeeHersdman.Zcl.ManufacturerCode.BUSCH_JAEGER,
+            zigbeeHerdsman.Zcl.ManufacturerCode.Philips,
+            zigbeeHerdsman.Zcl.ManufacturerCode.ATMEL,
+            zigbeeHerdsman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
+            zigbeeHerdsman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
+            zigbeeHerdsman.Zcl.ManufacturerCode.TELINK,
+            zigbeeHerdsman.Zcl.ManufacturerCode.BUSCH_JAEGER,
         ],
         manufacturerNames: [
             'GLEDOPTO',
@@ -165,11 +165,11 @@ const pollOnMessage: PollOnMessage = [
             },
         },
         manufacturerIDs: [
-            zigbeeHersdman.Zcl.ManufacturerCode.Philips,
-            zigbeeHersdman.Zcl.ManufacturerCode.ATMEL,
-            zigbeeHersdman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
-            zigbeeHersdman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
-            zigbeeHersdman.Zcl.ManufacturerCode.TELINK,
+            zigbeeHerdsman.Zcl.ManufacturerCode.Philips,
+            zigbeeHerdsman.Zcl.ManufacturerCode.ATMEL,
+            zigbeeHerdsman.Zcl.ManufacturerCode.GLEDOPTO_CO_LTD,
+            zigbeeHerdsman.Zcl.ManufacturerCode.MUELLER_LICHT_INT,
+            zigbeeHerdsman.Zcl.ManufacturerCode.TELINK,
             // Note: ManufacturerCode.BUSCH_JAEGER is left out intentionally here as their devices don't support colors
         ],
         manufacturerNames: [

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -164,7 +164,7 @@ export default class Bridge extends Extension {
             logger.setLevel(newSettings.advanced.log_level);
         }
 
-        logger.info('Succesfully changed options');
+        logger.info('Successfully changed options');
         this.publishInfo();
         return utils.getResponse(message, {restart_required: this.restartRequired}, null);
     }

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -470,7 +470,7 @@ export default class Bridge extends Extension {
             this.publishInfo();
         }
 
-        // Repulish entity state
+        // Republish entity state
         this.publishEntityState(entity, {});
 
         return utils.getResponse(

--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -85,7 +85,7 @@ export default class Configure extends Extension {
     }
 
     private async configure(device: Device, event: 'started' | 'zigbee_event' | 'reporting_disabled' | 'mqtt_message',
-        force=false, thowError=false): Promise<void> {
+        force=false, throwError=false): Promise<void> {
         if (!force) {
             if (device.options.disabled || !device.definition?.configure || !device.zh.interviewCompleted) {
                 return;
@@ -126,7 +126,7 @@ export default class Configure extends Extension {
             const msg = `Failed to configure '${device.name}', attempt ${attempt} (${error.stack})`;
             logger.error(msg);
 
-            if (thowError) {
+            if (throwError) {
                 throw error;
             }
         }

--- a/lib/extension/externalExtension.ts
+++ b/lib/extension/externalExtension.ts
@@ -28,8 +28,8 @@ export default class ExternalExtension extends Extension {
         const basePath = this.getExtensionsBasePath();
         if (fs.existsSync(basePath)) {
             return fs.readdirSync(basePath).filter((f) => f.endsWith('.js')).map((fileName) => {
-                const extensonFilePath = path.join(basePath, fileName);
-                return {'name': fileName, 'code': fs.readFileSync(extensonFilePath, 'utf-8')};
+                const extensionFilePath = path.join(basePath, fileName);
+                return {'name': fileName, 'code': fs.readFileSync(extensionFilePath, 'utf-8')};
             });
         } else {
             return [];
@@ -63,8 +63,8 @@ export default class ExternalExtension extends Extension {
         if (!fs.existsSync(basePath)) {
             fs.mkdirSync(basePath);
         }
-        const extensonFilePath = path.join(basePath, path.basename(name));
-        fs.writeFileSync(extensonFilePath, code);
+        const extensionFilePath = path.join(basePath, path.basename(name));
+        fs.writeFileSync(extensionFilePath, code);
         this.publishExtensions();
         logger.info(`Extension ${name} loaded`);
         return utils.getResponse(message, {}, null);

--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -108,8 +108,8 @@ export default class Frontend extends Extension {
 
     @bind private onUpgrade(request: http.IncomingMessage, socket: net.Socket, head: Buffer): void {
         this.wss.handleUpgrade(request, socket, head, (ws) => {
-            this.authenticate(request, (isAuthentificated) => {
-                if (isAuthentificated) {
+            this.authenticate(request, (isAuthenticated) => {
+                if (isAuthenticated) {
                     this.wss.emit('connection', ws, request);
                 } else {
                     ws.close(4401, 'Unauthorized');

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -237,7 +237,7 @@ export default class HomeAssistant extends Extension {
             const mode = firstExpose.features.find((f) => f.name === 'system_mode');
             if (mode) {
                 if (mode.values.includes('sleep')) {
-                    // 'sleep' is not supported by homeassistent, but is valid according to ZCL
+                    // 'sleep' is not supported by Home Assistant, but is valid according to ZCL
                     // TRV that support sleep (e.g. Viessmann) will have it removed from here,
                     // this allows other expose consumers to still use it, e.g. the frontend.
                     mode.values.splice(mode.values.indexOf('sleep'), 1);
@@ -765,7 +765,7 @@ export default class HomeAssistant extends Extension {
                 delete discoveryEntry.discovery_payload.device_class;
             }
 
-            // Home Assisstant only supports µg/m³, not other units like ppb.
+            // Home Assistant only supports µg/m³, not other units like ppb.
             // https://github.com/Koenkk/zigbee2mqtt/issues/16057
             if (firstExpose.name === 'voc' && discoveryEntry.discovery_payload.unit_of_measurement !== 'µg/m³') {
                 delete discoveryEntry.discovery_payload.device_class;
@@ -968,7 +968,7 @@ export default class HomeAssistant extends Extension {
          * Implements the MQTT device trigger (https://www.home-assistant.io/integrations/device_trigger.mqtt/)
          * The MQTT device trigger does not support JSON parsing, so it cannot listen to zigbee2mqtt/my_device
          * Whenever a device publish an {action: *} we discover an MQTT device trigger sensor
-         * and republish it to zigbee2mqtt/my_devic/action
+         * and republish it to zigbee2mqtt/my_device/action
          */
         if (entity.isDevice() && entity.definition) {
             const keys = ['action', 'click'].filter((k) => data.message[k]);
@@ -1442,7 +1442,7 @@ export default class HomeAssistant extends Extension {
         const identifierPostfix = entity.isGroup() ?
             `zigbee2mqtt_${this.getEncodedBaseTopic()}` : 'zigbee2mqtt';
 
-        // Allow device name to be overriden by homeassistant config
+        // Allow device name to be overridden by homeassistant config
         let deviceName = entity.name;
         if (typeof entity.options.homeassistant?.name === 'string') {
             deviceName = entity.options.homeassistant.name;
@@ -1477,7 +1477,7 @@ export default class HomeAssistant extends Extension {
             }
         });
 
-        // Copy hue -> h, saturation -> s to make homeassitant happy
+        // Copy hue -> h, saturation -> s to make homeassistant happy
         if (message.hasOwnProperty('color')) {
             if (message.color.hasOwnProperty('hue')) {
                 message.color.h = message.color.hue;

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -90,7 +90,7 @@ export default class Publish extends Extension {
         // When reporting is requested for a device (report: true in device-specific settings) we won't
         // ever issue a read here, as we assume the device will properly report changes.
         // Only do this when the retrieve_state option is enabled for this device.
-        // retrieve_state == decprecated
+        // retrieve_state == deprecated
         if (re instanceof Device && result && result.hasOwnProperty('readAfterWriteTime') &&
             re.options.retrieve_state
         ) {
@@ -102,7 +102,7 @@ export default class Publish extends Extension {
         /**
          * Home Assistant always publishes 'state', even when e.g. only setting
          * the color temperature. This would lead to 2 zigbee publishes, where the first one
-         * (state) is probably unecessary.
+         * (state) is probably unnecessary.
          */
         if (settings.get().homeassistant) {
             const hasColorTemp = message.hasOwnProperty('color_temp');
@@ -166,7 +166,7 @@ export default class Publish extends Extension {
          * Order state & brightness based on current bulb state
          *
          * Not all bulbs support setting the color/color_temp while it is off
-         * this results in inconsistant behavior between different vendors.
+         * this results in inconsistent behavior between different vendors.
          *
          * bulb on => move state & brightness to the back
          * bulb off => move state & brightness to the front
@@ -220,7 +220,7 @@ export default class Publish extends Extension {
                 continue;
             }
 
-            // If the endpoint_name name is a nubmer, try to map it to a friendlyName
+            // If the endpoint_name name is a number, try to map it to a friendlyName
             if (!isNaN(Number(endpointName)) && re.isDevice() && utils.isEndpoint(localTarget) &&
                 re.endpointName(localTarget)) {
                 endpointName = re.endpointName(localTarget);

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -38,7 +38,7 @@ function init(): void {
     directory = settings.get().advanced.log_directory.replace('%TIMESTAMP%', timestamp);
     logFilename = settings.get().advanced.log_file.replace('%TIMESTAMP%', timestamp);
 
-    // Make sure that log directoy exsists when not logging to stdout only
+    // Make sure that log directory exists when not logging to stdout only
     if (output.includes('file')) {
         fx.mkdirSync(directory);
 
@@ -177,7 +177,7 @@ function setLevel(level: Z2MLogLevel): void {
 }
 
 function warn(message: string): void {
-    // winston.config.syslog.levels doesnt have warn, but is required for syslog.
+    // winston.config.syslog.levels doesn't have warn, but is required for syslog.
     logger.warning(message);
 }
 

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -211,7 +211,7 @@ function write(): void {
     // Read settings to check if we have to split devices/groups into separate file.
     const actual = yaml.read(file);
 
-    // In case the setting is defined in a separte file (e.g. !secret network_key) update it there.
+    // In case the setting is defined in a separate file (e.g. !secret network_key) update it there.
     for (const path of [
         ['mqtt', 'server'],
         ['mqtt', 'user'],
@@ -330,7 +330,7 @@ function read(): Settings {
 
     // Read !secret MQTT username and password if set
     // eslint-disable-next-line
-    const interpetValue = (value: any): any => {
+    const interpretValue = (value: any): any => {
         const ref = parseValueRef(value);
         if (ref) {
             return yaml.read(data.joinPath(ref.filename))[ref.key];
@@ -340,23 +340,23 @@ function read(): Settings {
     };
 
     if (s.mqtt?.user) {
-        s.mqtt.user = interpetValue(s.mqtt.user);
+        s.mqtt.user = interpretValue(s.mqtt.user);
     }
 
     if (s.mqtt?.password) {
-        s.mqtt.password = interpetValue(s.mqtt.password);
+        s.mqtt.password = interpretValue(s.mqtt.password);
     }
 
     if (s.mqtt?.server) {
-        s.mqtt.server = interpetValue(s.mqtt.server);
+        s.mqtt.server = interpretValue(s.mqtt.server);
     }
 
     if (s.advanced?.network_key) {
-        s.advanced.network_key = interpetValue(s.advanced.network_key);
+        s.advanced.network_key = interpretValue(s.advanced.network_key);
     }
 
     if (s.frontend?.auth_token) {
-        s.frontend.auth_token = interpetValue(s.frontend.auth_token);
+        s.frontend.auth_token = interpretValue(s.frontend.auth_token);
     }
 
     // Read devices/groups configuration from separate file if specified.
@@ -472,7 +472,7 @@ export function apply(newSettings: Record<string, unknown>): boolean {
         throw new Error(`${error.instancePath.substring(1)} ${error.message}`);
     }
 
-    getInternalSettings(); // Ensure _settings is intialized.
+    getInternalSettings(); // Ensure _settings is initialized.
     /* eslint-disable-line */ // @ts-ignore
     _settings = objectAssignDeep.noMutate(_settings, newSettings);
     write();


### PR DESCRIPTION
I initially noticed "Succesfully" in logs and figured I might as well put a PR in to fix the typo, and while doing that decided to fix a couple more.

There's a typo in the API/bus that probably can't be safely fixed here without changes elsewhere: `homeAssisantRename`.

Thanks for the project, it's making my home a whole lot brighter 😁 