### PR TITLE
Fix race condition with for reinitializing after MQTT reconnect

### DIFF
--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -101,9 +101,10 @@ export default class MQTT {
         }, utils.seconds(10));
 
         logger.info('Connected to MQTT server');
-        await this.publishStateOnline();
 
-        if (!this.initialConnect) {
+        if (this.initialConnect) {
+            await this.publishStateOnline();
+        } else {
             this.republishRetainedTimer = setTimeout(() => {
                 // Republish retained messages in case MQTT broker does not persist them.
                 // https://github.com/Koenkk/zigbee2mqtt/issues/9629

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -651,7 +651,7 @@ describe('Controller', () => {
         MQTT.events['connect']();
         await flushPromises();
         jest.runOnlyPendingTimers();
-        expect(MQTT.publish).toHaveBeenCalledTimes(13);
+        expect(MQTT.publish).toHaveBeenCalledTimes(12);
         expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/info', expect.any(String), { retain: true, qos: 0 }, expect.any(Function));
     });
 
@@ -662,8 +662,7 @@ describe('Controller', () => {
         await flushPromises();
         await MQTT.events.message('zigbee2mqtt/bridge/state', 'online');
         jest.runOnlyPendingTimers();
-        expect(MQTT.publish).toHaveBeenCalledTimes(1);
-        expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/state', expect.any(String), { retain: true, qos: 0 }, expect.any(Function));
+        expect(MQTT.publish).toHaveBeenCalledTimes(0);
     });
 
     it('Should prevent any message being published with retain flag when force_disable_retain is set', async () => {


### PR DESCRIPTION
Fixes #9629 

First related commit: https://github.com/Koenkk/zigbee2mqtt/commit/343ef7fd9f796c25dcbc3532bec3ef51699a5739
Second related commit that introduces the problem: https://github.com/Koenkk/zigbee2mqtt/commit/6314b86d9b286494fc47d0a8acaf07da66fb43d7