### PR TITLE
Use HA sensor device class atmospheric_pressure instead of pressure

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -695,7 +695,7 @@ export default class HomeAssistant extends Extension {
                 power_factor: {device_class: 'power_factor', enabled_by_default: false,
                     entity_category: 'diagnostic', state_class: 'measurement'},
                 precision: {entity_category: 'config', icon: 'mdi:decimal-comma-increase'},
-                pressure: {device_class: 'pressure', state_class: 'measurement'},
+                pressure: {device_class: 'atmospheric_pressure', state_class: 'measurement'},
                 presence_timeout: {entity_category: 'config', icon: 'mdi:timer'},
                 reporting_time: {entity_category: 'config', icon: 'mdi:clock-time-one-outline'},
                 requested_brightness_level: {

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -201,7 +201,7 @@ describe('HomeAssistant extension', () => {
 
         payload = {
             'unit_of_measurement': 'hPa',
-            'device_class': 'pressure',
+            'device_class': 'atmospheric_pressure',
             'state_class': 'measurement',
             'value_template': '{{ value_json.pressure }}',
             'state_topic': 'zigbee2mqtt/weather_sensor',
@@ -450,7 +450,7 @@ describe('HomeAssistant extension', () => {
 
         payload = {
             'unit_of_measurement': 'hPa',
-            'device_class': 'pressure',
+            'device_class': 'atmospheric_pressure',
             'state_class': 'measurement',
             'value_template': '{{ value_json.pressure }}',
             'state_topic': 'zigbee2mqtt/weather_sensor',


### PR DESCRIPTION
Zigbee2MQTT currently uses the `pressure` device class for devices that measure pressure. `atmospheric_pressure` was [introduced](https://www.home-assistant.io/blog/2023/01/04/release-20231/#other-noteworthy-changes) in HA 2023.1 as a more specific device class for when the pressure being measured is atmospheric pressure specifically. The [pressure preset in the converters library](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/lib/exposes.ts#L690) mentions atmospheric pressure in the description, so we should be using the `atmospheric_pressure` device class instead of `pressure`.

I noticed this issue because HA is converting the pressure reading from my Aqara sensor to PSI which is not an appropriate unit for atmospheric pressure. This PR should fix that.

![image](https://github.com/Koenkk/zigbee2mqtt/assets/2292715/2da9f5ed-f82c-4731-a6ac-5a1560179472)
