### PR TITLE
Fix Insecure Zigbee Network Encryption Key Generation

### DIFF
--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -9,6 +9,7 @@ import Device from './model/device';
 import Group from './model/group';
 import * as ZHEvents from 'zigbee-herdsman/dist/controller/events';
 import bind from 'bind-decorator';
+import {randomInt} from 'crypto';
 
 export default class Zigbee {
     private herdsman: Controller;
@@ -164,13 +165,13 @@ export default class Zigbee {
     }
 
     private generateNetworkKey(): number[] {
-        const key = Array.from({length: 16}, () => Math.floor(Math.random() * 255));
+        const key = Array.from({length: 16}, () => randomInt(256));
         settings.set(['advanced', 'network_key'], key);
         return key;
     }
 
     private generatePanID(): number {
-        const panID = Math.floor(Math.random() * (0xFFFF - 2)) + 1;
+        const panID = randomInt(1, 0xFFFF - 1);
         settings.set(['advanced', 'pan_id'], panID);
         return panID;
     }


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/18313.
Replaces the insecure `Math.random()` function with `crypto.randomInt()`for the Zigbee Network Encryption Key Generation. It also fixed the missing 255 value from the key bytes.

Additionally, I use `randomInt` for `generatePanID` to have a more consistent code. Could please check if the minimal and maximal generated numbers are correct: 1, 65533 (0xffff-2)?

I also requested a CVE number for this issue, but I haven't heard back from MITRE.