### PR TITLE
fix: Fix socket error crashing Zigbee2MQTT

### DIFF
--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -119,6 +119,7 @@ export default class Frontend extends Extension {
     }
 
     @bind private onWebSocketConnection(ws: WebSocket): void {
+        ws.on('error', (msg) => logger.error(`WebSocket error: ${msg.message}`));
         ws.on('message', (data: Buffer, isBinary: boolean) => {
             if (!isBinary && data) {
                 const message = data.toString();

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -1,5 +1,5 @@
 const data = require('./stub/data');
-require('./stub/logger');
+const logger = require('./stub/logger');
 require('./stub/zigbeeHerdsman');
 const MQTT = require('./stub/mqtt');
 const settings = require('../lib/util/settings');
@@ -197,7 +197,7 @@ describe('Frontend', () => {
 
     });
 
-    it('Websocket interaction', async () => {
+    it('onlythis Websocket interaction', async () => {
         controller = new Controller(jest.fn(), jest.fn());
         await controller.start();
 
@@ -232,6 +232,10 @@ describe('Frontend', () => {
         mockWSClient.events.message("", false);
         mockWSClient.events.message(null, false);
         await flushPromises();
+
+        // Error
+        mockWSClient.events.error(new Error('This is an error'));
+        expect(logger.error).toHaveBeenCalledWith('WebSocket error: This is an error');
 
         // Received message on socket
         expect(mockWSClient.implementation.send).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Experienced a `Invalid WebSocket frame: RSV2 and RSV3 must be clear` which completely crashed Zigbee2MQTT. Apparently an `error` handler must be in place to gracefully handle this (https://github.com/websockets/ws/issues/1354) 