### PR TITLE
fix: Fix Home Assistant `MQTT device name is equal to entity name in your config

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1226,11 +1226,12 @@ export default class HomeAssistant extends Extension {
             // Set (unique) name, separate by space if device name contains space.
             if (!payload.device_class || ['timestamp'].includes(payload.device_class)) {
                 const nameSeparator = devicePayload.name.includes('_') ? '_' : ' ';
-                payload.name = devicePayload.name;
                 if (config.object_id.startsWith(config.type) && config.object_id.includes('_')) {
-                    payload.name += `${nameSeparator}${config.object_id.split(/_(.+)/)[1]}`;
+                    payload.name = `${config.object_id.split(/_(.+)/)[1]}`;
                 } else if (!config.object_id.startsWith(config.type)) {
-                    payload.name += `${nameSeparator}${config.object_id.replace(/_/g, nameSeparator)}`;
+                    payload.name = `${config.object_id.replace(/_/g, nameSeparator)}`;
+                } else {
+                    payload.name = null;
                 }
             }
 

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -9,7 +9,7 @@ const Controller = require('../lib/controller');
 const fs = require('fs');
 const path = require('path');
 
-describe('onlythisHomeAssistant extension', () => {
+describe('HomeAssistant extension', () => {
     let version;
     let controller;
     let extension;

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -9,7 +9,7 @@ const Controller = require('../lib/controller');
 const fs = require('fs');
 const path = require('path');
 
-describe('HomeAssistant extension', () => {
+describe('onlythisHomeAssistant extension', () => {
     let version;
     let controller;
     let extension;
@@ -91,7 +91,7 @@ describe('HomeAssistant extension', () => {
             "max_mireds": 454,
             "min_mireds": 250,
             "json_attributes_topic":"zigbee2mqtt/ha_discovery_group",
-            "name":"ha_discovery_group",
+            "name":null,
             "schema":"json",
             "state_topic":"zigbee2mqtt/ha_discovery_group",
             "supported_color_modes":[
@@ -130,7 +130,7 @@ describe('HomeAssistant extension', () => {
                "sw_version": version,
             },
             "json_attributes_topic":"zigbee2mqtt/ha_discovery_group",
-            "name":"ha_discovery_group",
+            "name":null,
             "payload_off":"OFF",
             "payload_on":"ON",
             "state_topic":"zigbee2mqtt/ha_discovery_group",
@@ -259,7 +259,7 @@ describe('HomeAssistant extension', () => {
             'value_template': '{{ value_json.linkquality }}',
             'state_topic': 'zigbee2mqtt/weather_sensor',
             'json_attributes_topic': 'zigbee2mqtt/weather_sensor',
-            'name': 'weather_sensor_linkquality',
+            'name': 'linkquality',
             'unique_id': '0x0017880104e45522_linkquality_zigbee2mqtt',
             'device': {
                 'identifiers': ['zigbee2mqtt_0x0017880104e45522'],
@@ -291,7 +291,7 @@ describe('HomeAssistant extension', () => {
                 "sw_version": null
             },
             "json_attributes_topic":"zigbee2mqtt/wall_switch_double",
-            "name":"wall_switch_double_left",
+            "name":"left",
             "payload_off":"OFF",
             "payload_on":"ON",
             "state_topic":"zigbee2mqtt/wall_switch_double",
@@ -319,7 +319,7 @@ describe('HomeAssistant extension', () => {
                 "sw_version": null
             },
             "json_attributes_topic":"zigbee2mqtt/wall_switch_double",
-            "name":"wall_switch_double_right",
+            "name":"right",
             "payload_off":"OFF",
             "payload_on":"ON",
             "state_topic":"zigbee2mqtt/wall_switch_double",
@@ -362,7 +362,7 @@ describe('HomeAssistant extension', () => {
                 "stop_effect"
             ],
             "json_attributes_topic":"zigbee2mqtt/bulb",
-            "name":"bulb",
+            "name":null,
             "schema":"json",
             "state_topic":"zigbee2mqtt/bulb",
             "unique_id":"0x000b57fffec6a5b2_light_zigbee2mqtt",
@@ -721,7 +721,7 @@ describe('HomeAssistant extension', () => {
             "speed_range_min":1,
             "speed_range_max":4,
             "json_attributes_topic":"zigbee2mqtt/fan",
-            "name":"fan",
+            "name":null,
             "unique_id":"0x0017880104e45548_fan_zigbee2mqtt",
             "device":{
                "identifiers":[
@@ -788,7 +788,7 @@ describe('HomeAssistant extension', () => {
                 "auto",
                 "off"
             ],
-            "name":"TS0601_thermostat",
+            "name":null,
             "temp_step":0.5,
             "temperature_command_topic":"zigbee2mqtt/TS0601_thermostat/set/current_heating_setpoint",
             "temperature_state_template":"{{ value_json.current_heating_setpoint }}",
@@ -820,7 +820,7 @@ describe('HomeAssistant extension', () => {
             state_closed: 'CLOSE',
             state_stopped: 'STOP',
             json_attributes_topic: 'zigbee2mqtt/smart vent',
-            name: 'smart vent',
+            name: null,
             unique_id: '0x0017880104e45551_cover_zigbee2mqtt',
             device:
             {
@@ -851,7 +851,7 @@ describe('HomeAssistant extension', () => {
                 "sw_version": null
             },
             "json_attributes_topic": "zigbee2mqtt/zigfred_plus/l6",
-            "name": "zigfred_plus_l6",
+            "name": "l6",
             "position_template": "{{ value_json.position }}",
             "position_topic": "zigbee2mqtt/zigfred_plus/l6",
             "set_position_template": "{ \"position_l6\": {{ position }} }",
@@ -1300,7 +1300,7 @@ describe('HomeAssistant extension', () => {
             "json_attributes_topic":"zigbee2mqtt/ha_discovery_group_new",
             "max_mireds": 454,
             "min_mireds": 250,
-            "name":"ha_discovery_group_new",
+            "name":null,
             "schema":"json",
             "state_topic":"zigbee2mqtt/ha_discovery_group_new",
             "supported_color_modes":[
@@ -1826,7 +1826,7 @@ describe('HomeAssistant extension', () => {
             "json_attributes_topic":"zigbee2mqtt/ha_discovery_group",
             "max_mireds": 454,
             "min_mireds": 250,
-            "name":"ha_discovery_group",
+            "name":null,
             "schema":"json",
             "state_topic":"zigbee2mqtt/ha_discovery_group",
             "supported_color_modes":[
@@ -1875,7 +1875,7 @@ describe('HomeAssistant extension', () => {
             "max_mireds": 454,
             "min_mireds": 250,
             "json_attributes_topic":"zigbee2mqtt/ha_discovery_group",
-            "name":"ha_discovery_group",
+            "name":null,
             "schema":"json",
             "state_topic":"zigbee2mqtt/ha_discovery_group",
             "supported_color_modes":[
@@ -1943,7 +1943,7 @@ describe('HomeAssistant extension', () => {
             "json_attributes_topic":"zigbee2mqtt/bulb",
             "max_mireds":454,
             "min_mireds":250,
-            "name":"bulb",
+            "name":null,
             "schema":"json",
             "state_topic":"zigbee2mqtt/bulb",
             "supported_color_modes":[
@@ -1982,7 +1982,7 @@ describe('HomeAssistant extension', () => {
             "enabled_by_default":false,
             "icon":"mdi:clock",
             "json_attributes_topic":"zigbee2mqtt/bulb",
-            "name":"bulb last seen",
+            "name":"last seen",
             "state_topic":"zigbee2mqtt/bulb",
             "unique_id":"0x000b57fffec6a5b2_last_seen_zigbee2mqtt",
             "value_template":"{{ value_json.last_seen }}",


### PR DESCRIPTION
Trying to fi_x https://github.com/Koenkk/zigbee2mqtt/issues/18445