### PR TITLE
fix: Generate pan_id for new installations

### DIFF
--- a/data/configuration.example.yaml
+++ b/data/configuration.example.yaml
@@ -23,3 +23,5 @@ serial:
 advanced:
   # Let Zigbee2MQTT generate a network key on first start
   network_key: GENERATE
+  # Let Zigbee2MQTT generate a pan_id on first start
+  pan_id: GENERATE


### PR DESCRIPTION
As discussed in https://github.com/Koenkk/zigbee2mqtt/pull/18357