### PR TITLE
feat: Drop Node.js 14 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/Koenkk/zigbee2mqtt.git"
   },
   "engines": {
-    "node": "^14 || ^16 || ^18 || ^19 || ^20"
+    "node": "^16 || ^18 || ^19 || ^20"
   },
   "keywords": [
     "xiaomi",


### PR DESCRIPTION
Several packages dropped Node 14 support (e.g. serialport 12 and mqtt.js 5). Drop Node 14 support so we can upgrade to those.