### PR TITLE
feat: Support coordinator check

### DIFF
--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -46,6 +46,7 @@ export default class Bridge extends Extension {
             'install_code/add': this.installCodeAdd,
             'touchlink/scan': this.touchlinkScan,
             'health_check': this.healthCheck,
+            'coordinator_check': this.coordinatorCheck,
             'options': this.bridgeOptions,
             // Below are deprecated
             'config/last_seen': this.configLastSeen,
@@ -179,6 +180,14 @@ export default class Bridge extends Extension {
 
     @bind async healthCheck(message: string | KeyValue): Promise<MQTTResponse> {
         return utils.getResponse(message, {healthy: true}, null);
+    }
+
+    @bind async coordinatorCheck(message: string | KeyValue): Promise<MQTTResponse> {
+        const result = await this.zigbee.coordinatorCheck();
+        const missingRouters = result.missingRouters.map((d) => {
+            return {ieee_address: d.ieeeAddr, friendly_name: d.name};
+        });
+        return utils.getResponse(message, {missing_routers: missingRouters}, null);
     }
 
     @bind async groupAdd(message: string | KeyValue): Promise<MQTTResponse> {

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -195,6 +195,11 @@ export default class Zigbee {
         return this.herdsman.backup();
     }
 
+    async coordinatorCheck(): Promise<{missingRouters: Device[]}> {
+        const check = await this.herdsman.coordinatorCheck();
+        return {missingRouters: check.missingRouters.map((d) => this.resolveDevice(d.ieeeAddr))};
+    }
+
     async getNetworkParameters(): Promise<zh.NetworkParameters> {
         return this.herdsman.getNetworkParameters();
     }

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -408,6 +408,18 @@ describe('Bridge', () => {
         );
     });
 
+    it('Should allow a coordinator check', async () => {
+        MQTT.publish.mockClear();
+        zigbeeHerdsman.coordinatorCheck.mockReturnValueOnce({missingRouters: [zigbeeHerdsman.getDeviceByIeeeAddr('0x000b57fffec6a5b2')]})
+        MQTT.events.message('zigbee2mqtt/bridge/request/coordinator_check', '');
+        await flushPromises();
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'zigbee2mqtt/bridge/response/coordinator_check',
+            stringify({"data":{"missing_routers":[{"friendly_name":"bulb","ieee_address":"0x000b57fffec6a5b2"}]},"status":"ok"}),
+            {retain: false, qos: 0}, expect.any(Function)
+        );
+    });
+
     it('Should allow to remove device by string', async () => {
         const device = zigbeeHerdsman.devices.bulb;
         settings.set(['groups'], {'1': {friendly_name: 'group_1', retain: false, devices: ['0x999b57fffec6a5b9/1', '0x000b57fffec6a5b2/1', 'bulb', 'bulb/right', 'other_bulb', 'bulb_1', '0x000b57fffec6a5b2', 'bulb/room/2']}});

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -197,7 +197,7 @@ describe('Frontend', () => {
 
     });
 
-    it('onlythis Websocket interaction', async () => {
+    it('Websocket interaction', async () => {
         controller = new Controller(jest.fn(), jest.fn());
         await controller.start();
 

--- a/test/stub/zigbeeHerdsman.js
+++ b/test/stub/zigbeeHerdsman.js
@@ -214,6 +214,7 @@ const mock = {
     touchlinkIdentify: jest.fn(),
     start: jest.fn(),
     backup: jest.fn(),
+    coordinatorCheck: jest.fn(),
     isStopping: jest.fn(),
     permitJoin: jest.fn(),
     addInstallCode: jest.fn(),


### PR DESCRIPTION
Linked PRs:
- https://github.com/Koenkk/zigbee-herdsman/pull/742
- https://github.com/Koenkk/zigbee2mqtt.io/pull/2169

Issue: https://github.com/Koenkk/zigbee2mqtt/issues/18426, original check: https://github.com/Koenkk/zigbee2mqtt/issues/10339#issuecomment-1179710676


Copied docs for convenience:

> #### zigbee2mqtt/bridge/request/coordinator_check
> 
> Allows to check to execute a coordinator check. Payload has to be empty, example response: `{"data":{"missing_routers":[{"friendly_name":"bulb","ieee_address":"0x000b57fffec6a5b2"}]},"status":"ok"}`.
> 
> This check is only supported for Texas Instruments based adapters (e.g. CC2652/CC1352). It checks whether any routers are missing from the coordinator memory. In case routers are missing, you may experience one of the following problems:
> - Unable to pair devices to your network, pairing might fail for any device that tries to joins the network via this missing router.
> - Devices falling of the network. Sometimes devices that are in the network re-join it, if they try to re-join via this missing router, re-joining will fail.
> 
> The solution is to re-pair the missing routers. There are 2 known reasons for routers to go missing:
> - Migration from a Zigbee 1.2 coordinator to 3.0 (e.g. CC2530/CC2531 -> CC2652/CC1352) without re-pairing any devices. This is because Zigbee 1.2 has less strict security requirements.
> - Upgrading of the firmware, this seems to occur because of a bug in the Texas Instruments SDK.