### PR TITLE
Adjust default entity category of updates in Home Assistant

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1180,6 +1180,7 @@ export default class HomeAssistant extends Extension {
                     latest_version_topic: true,
                     state_topic: true,
                     device_class: 'firmware',
+                    entity_category: 'config',
                     command_topic: `${settings.get().mqtt.base_topic}/bridge/request/device/ota_update/update`,
                     payload_install: `{"id": "${entity.ieeeAddr}"}`,
                     value_template: `{{ value_json['update']['installed_version'] }}`,


### PR DESCRIPTION
This PR adjusts the entity category of the `update` entity exposed to Home Assistant.
It doesn't have the entity category assigned, making it a primary entity. This also means these updates will appear in all places (like the default-generated dashboards). At the same time, this is more an entity used for the management of one's smart home.

This PR marks this entity a `config` categorized entity, which matches the default behavior of Home Assistant itself. 

Ref: <https://github.com/home-assistant/core/blob/af9cae289f15910252462b533a8d9e31faf6d9dd/homeassistant/components/update/__init__.py#L183>

This change is not a breaking change and is backward compatible.