### PR TITLE
Add device class for soil_moisture sensor in HA

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -730,7 +730,7 @@ export default class HomeAssistant extends Extension {
                     enabled_by_default: false, entity_category: 'diagnostic', icon: 'mdi:brightness-5',
                 },
                 smoke_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
-                soil_moisture: {icon: 'mdi:water-percent', state_class: 'measurement'},
+                soil_moisture: {device_class: 'moisture', state_class: 'measurement'},
                 temperature: {device_class: 'temperature', state_class: 'measurement'},
                 temperature_calibration: {entity_category: 'config', icon: 'mdi:wrench-clock'},
                 temperature_max: {entity_category: 'config', icon: 'mdi:thermometer-plus'},


### PR DESCRIPTION
Home Assistant has dedicated [device class](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes) for moisture in percentage. It has its own icon, so no longer need to icon explicitly.
Also it helps other components to discover the sensor as moisture in something.