### PR TITLE
Fix in_progress attribute for Home Assistant update sensor

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1198,7 +1198,7 @@ export default class HomeAssistant extends Extension {
                     value_template: `{{ value_json['update']['installed_version'] }}`,
                     latest_version_template: `{{ value_json['update']['latest_version'] }}`,
                     json_attributes_topic: `${settings.get().mqtt.base_topic}/${entity.name}`, // state topic
-                    json_attributes_template: `{"in_progress": "{{ value_json['update']['state'] == 'updating' }}"}`,
+                    json_attributes_template: `{"in_progress": {{ value_json['update']['state'] == 'updating' }}}`,
                 },
             };
             configs.push(updateSensor);


### PR DESCRIPTION
I made a mistake in my last PR https://github.com/Koenkk/zigbee2mqtt/pull/19207
The value "false" (in quotes) is recognized as true in Home Assistant. Fixed in this PR.