### PR TITLE
Missing HA Climate Idle state

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -261,7 +261,7 @@ export default class HomeAssistant extends Extension {
                 discoveryEntry.mockProperties.push({property: state.property, value: null});
                 discoveryEntry.discovery_payload.action_topic = true;
                 discoveryEntry.discovery_payload.action_template = `{% set values = ` +
-                        `{None:None,'idle':'off','heat':'heating','cool':'cooling','fan_only':'fan'}` +
+                        `{None:None,'idle':'idle','heat':'heating','cool':'cooling','fan_only':'fan'}` +
                         ` %}{{ values[value_json.${state.property}] }}`;
             }
 

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -785,7 +785,7 @@ describe('HomeAssistant extension', () => {
         let payload;
 
         payload = {
-            "action_template":"{% set values = {None:None,'idle':'off','heat':'heating','cool':'cooling','fan_only':'fan'} %}{{ values[value_json.running_state] }}",
+            "action_template":"{% set values = {None:None,'idle':'idle','heat':'heating','cool':'cooling','fan_only':'fan'} %}{{ values[value_json.running_state] }}",
             "action_topic":"zigbee2mqtt/TS0601_thermostat",
             "availability":[
                 {


### PR DESCRIPTION
Idle is now mapped to idle state in HA instead of off.

This is a PR made from this issue: https://github.com/Koenkk/zigbee2mqtt/issues/16080

The solution was from @compujuckel

