### PR TITLE
feat: add HA discovery for climate frost protection temperature

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -336,6 +336,34 @@ export default class HomeAssistant extends Extension {
                 discoveryEntries.push(discoveryEntry);
             }
 
+
+            const frostProtectionTemperature = firstExpose.features.find((f) => f.name === 'frost_protection_temperature');
+            if (frostProtectionTemperature) {
+                const discoveryEntry: DiscoveryEntry = {
+                    type: 'number',
+                    object_id: endpoint ? `${frostProtectionTemperature.name}_${endpoint}` : `${frostProtectionTemperature.name}`,
+                    mockProperties: [{property: frostProtectionTemperature.property, value: null}],
+                    discovery_payload: {
+                        name: endpoint ? `${frostProtectionTemperature.label} ${endpoint}` : frostProtectionTemperature.label,
+                        value_template: `{{ value_json.${frostProtectionTemperature.property} }}`,
+                        command_topic: true,
+                        command_topic_prefix: endpoint,
+                        command_topic_postfix: frostProtectionTemperature.property,
+                        device_class: 'temperature',
+                        entity_category: 'config',
+                        icon: 'mdi:snowflake-thermometer',
+                        ...(frostProtectionTemperature.unit && {unit_of_measurement: frostProtectionTemperature.unit}),
+                    },
+                };
+
+                if (frostProtectionTemperature.value_min != null) discoveryEntry.discovery_payload.min = frostProtectionTemperature.value_min;
+                if (frostProtectionTemperature.value_max != null) discoveryEntry.discovery_payload.max = frostProtectionTemperature.value_max;
+                if (frostProtectionTemperature.value_step != null) {
+                    discoveryEntry.discovery_payload.step = frostProtectionTemperature.value_step;
+                }
+                discoveryEntries.push(discoveryEntry);
+            }
+
             const piHeatingDemand = firstExpose.features.find((f) => f.name === 'pi_heating_demand');
             if (piHeatingDemand) {
                 const discoveryEntry: DiscoveryEntry = {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -337,14 +337,19 @@ export default class HomeAssistant extends Extension {
             }
 
 
-            const frostProtectionTemperature = firstExpose.features.find((f) => f.name === 'frost_protection_temperature');
+            const frostProtectionTemperature =
+                firstExpose.features.find((f) => f.name === 'frost_protection_temperature');
             if (frostProtectionTemperature) {
                 const discoveryEntry: DiscoveryEntry = {
                     type: 'number',
-                    object_id: endpoint ? `${frostProtectionTemperature.name}_${endpoint}` : `${frostProtectionTemperature.name}`,
+                    object_id: endpoint ?
+                        `${frostProtectionTemperature.name}_${endpoint}` :
+                        `${frostProtectionTemperature.name}`,
                     mockProperties: [{property: frostProtectionTemperature.property, value: null}],
                     discovery_payload: {
-                        name: endpoint ? `${frostProtectionTemperature.label} ${endpoint}` : frostProtectionTemperature.label,
+                        name: endpoint ?
+                            `${frostProtectionTemperature.label} ${endpoint}` :
+                            frostProtectionTemperature.label,
                         value_template: `{{ value_json.${frostProtectionTemperature.property} }}`,
                         command_topic: true,
                         command_topic_prefix: endpoint,
@@ -356,8 +361,12 @@ export default class HomeAssistant extends Extension {
                     },
                 };
 
-                if (frostProtectionTemperature.value_min != null) discoveryEntry.discovery_payload.min = frostProtectionTemperature.value_min;
-                if (frostProtectionTemperature.value_max != null) discoveryEntry.discovery_payload.max = frostProtectionTemperature.value_max;
+                if (frostProtectionTemperature.value_min != null) {
+                    discoveryEntry.discovery_payload.min = frostProtectionTemperature.value_min;
+                }
+                if (frostProtectionTemperature.value_max != null) {
+                    discoveryEntry.discovery_payload.max = frostProtectionTemperature.value_max;
+                }
                 if (frostProtectionTemperature.value_step != null) {
                     discoveryEntry.discovery_payload.step = frostProtectionTemperature.value_step;
                 }


### PR DESCRIPTION
As part of the work to expose frost protection temperature for Sonoff TRVs, I extended the `Climate` expose object with a builder function to configure the frost protection temperature.

This PR allows Home Assistant to discover the frost protection temperature entity.

See related PR in zigbee-herdsman-converters: https://github.com/Koenkk/zigbee-herdsman-converters/pull/6425