### PR TITLE
Make frontend listen on both IPv4 and IPv6 by default

### DIFF
--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -74,7 +74,10 @@ export default class Frontend extends Extension {
         this.wss = new WebSocket.Server({noServer: true});
         this.wss.on('connection', this.onWebSocketConnection);
 
-        if (this.host.startsWith('/')) {
+        if (!this.host) {
+            this.server.listen(this.port);
+            logger.info(`Started frontend on port ${this.port}`);
+        } else if (this.host.startsWith('/')) {
             this.server.listen(this.host);
             logger.info(`Started frontend on socket ${this.host}`);
         } else {

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -371,11 +371,10 @@
               "requiresRestart": true
             },
             "host": {
-              "type": "string",
+              "type": ["string", "null"],
               "title": "Bind host",
               "description": "Frontend binding host. Binds to a unix socket when an absolute path is given instead.",
-              "examples": ["127.0.0.1", "/run/zigbee2mqtt/zigbee2mqtt.sock"],
-              "default": "0.0.0.0",
+              "examples": ["127.0.0.1", "::1", "/run/zigbee2mqtt/zigbee2mqtt.sock"],
               "requiresRestart": true
             },
             "auth_token": {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -150,7 +150,7 @@ function loadSettingsWithDefaults(): void {
     }
 
     if (_settingsWithDefaults.frontend) {
-        const defaults = {port: 8080, auth_token: false, host: '0.0.0.0'};
+        const defaults = {port: 8080, auth_token: false};
         const s = typeof _settingsWithDefaults.frontend === 'object' ? _settingsWithDefaults.frontend : {};
         // @ts-ignore
         _settingsWithDefaults.frontend = {};

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -135,6 +135,30 @@ describe('Frontend', () => {
         mockHTTPS.implementation.listen.mockClear();
     });
 
+    it('Start/stop without host', async () => {
+        settings.set(['frontend'], {port: 8081});
+        controller = new Controller(jest.fn(), jest.fn());
+        await controller.start();
+        expect(mockNodeStatic.variables.path).toBe("my/dummy/path");
+        expect(mockHTTP.implementation.listen).toHaveBeenCalledWith(8081);
+        const mockWSClient = {
+            implementation: {
+                terminate: jest.fn(),
+                send: jest.fn(),
+            },
+            events: {},
+        };
+        mockWS.implementation.clients.push(mockWSClient.implementation);
+        await controller.stop();
+        expect(mockWSClient.implementation.terminate).toHaveBeenCalledTimes(1);
+        expect(mockHTTP.implementation.close).toHaveBeenCalledTimes(1);
+        expect(mockWS.implementation.close).toHaveBeenCalledTimes(1);
+        mockWS.implementation.close.mockClear();
+        mockHTTP.implementation.close.mockClear();
+        mockHTTP.implementation.listen.mockClear();
+        mockHTTPS.implementation.listen.mockClear();
+    });
+
     it('Start/stop unix socket', async () => {
         settings.set(['frontend'], {host: "/tmp/zigbee2mqtt.sock"});
         controller = new Controller(jest.fn(), jest.fn());

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -935,7 +935,7 @@ describe('Settings', () => {
         });
 
         settings.reRead();
-        expect(settings.get().frontend).toStrictEqual({port: 8080, auth_token: false, host: '0.0.0.0'})
+        expect(settings.get().frontend).toStrictEqual({port: 8080, auth_token: false})
     });
 
     it('Baudrate config', () => {


### PR DESCRIPTION
This PR drops the default listening IPv4 address for the frontend and subsequently enables IPv4 + IPv6 (Dual Stack) for it by default.
Enforcing to listen on `0.0.0.0` by default artificially limits a user to access the frontend via IPv4-only. This means it cannot be accessed via IPv6 at all.
As long as a user doesn't explicitly configures IPv4-only, I think the frontend should be available on both stacks by default.

My changes allow `frontend.host` to also be `null`, so that `listen()` will be called with no host, but the port only. When called without a host, `listen()` will listen on all interfaces on both IPv4 and IPv6 (https://nodejs.org/docs/latest/api/net.html#serverlistenport-host-backlog-callback).
This behavior has the advantages that
- users, who don't care about this, won't experience any difference, because IPv4 will still be bound
- users, who care about IPv6 will be able to the frontend out-of-the-box

Manually specifying `host: "0.0.0.0"` (to keep binding IPv4-only) is of course still possible.
If IPv6 is disabled system-wide (e.g. by setting `sysctl net.ipv6.conf.all.disable_ipv6 1`), Node.js will fallback to binding IPv4-only.

I tested these changes by the following setups and the default config of `frontend: true`:
1. Running it in an dual-stacked VM: The frontend is available via both IPv4 and IPv6
2. Running it in an IPv6-only VM: The frontend is available via IPv6
3. Running it in an IPv4-only VM (IPv6 disabled via sysctl): The frontend is available via IPv4