### PR TITLE
chore: bump zigbee-herdsman version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "winston-syslog": "^2.7.0",
     "winston-transport": "^4.6.0",
     "ws": "^8.14.2",
-    "zigbee-herdsman": "0.21.0",
-    "zigbee-herdsman-converters": "15.106.0",
+    "zigbee-herdsman": "0.23.0",
+    "zigbee-herdsman-converters": "15.115.0",
     "zigbee2mqtt-frontend": "0.6.142"
   },
   "devDependencies": {


### PR DESCRIPTION
I need to upgrade to last version of zigbee-herdsman to be able to use new devices with zigbee