### PR TITLE
chore: bump zigbee-herdsman version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "winston-syslog": "^2.7.0",
         "winston-transport": "^4.6.0",
         "ws": "^8.14.2",
-        "zigbee-herdsman": "0.21.0",
-        "zigbee-herdsman-converters": "15.106.0",
+        "zigbee-herdsman": "0.23.0",
+        "zigbee-herdsman-converters": "15.115.0",
         "zigbee2mqtt-frontend": "0.6.142"
       },
       "bin": {
@@ -3896,9 +3896,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -9903,9 +9903,9 @@
       }
     },
     "node_modules/zigbee-herdsman": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/zigbee-herdsman/-/zigbee-herdsman-0.21.0.tgz",
-      "integrity": "sha512-gksNtJNHIrxEPPnNJ/8sR+UtKCB7oyKFu7XmNJqF4RWBcTyzxh6kaMw+q0nPmicP+BlnqM9fRj9ZWEVWXgG6XQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/zigbee-herdsman/-/zigbee-herdsman-0.23.0.tgz",
+      "integrity": "sha512-2uggWvKA7pHltY5M5SzBSianuXeA1pBEYHst/xO588l4ss2m0SU/P2jtPH66Kc9YwcWKVwIhVU3J3q/OGNPKYg==",
       "dependencies": {
         "@serialport/bindings-cpp": "^12.0.1",
         "@serialport/parser-delimiter": "^12.0.0",
@@ -9920,15 +9920,32 @@
       }
     },
     "node_modules/zigbee-herdsman-converters": {
-      "version": "15.106.0",
-      "resolved": "https://registry.npmjs.org/zigbee-herdsman-converters/-/zigbee-herdsman-converters-15.106.0.tgz",
-      "integrity": "sha512-Rj1IL1unqphrTlo4c3cE35RSsM3e998xlVjkk0EdVr/m4t+ac/YL4B4AUOqrccpafvoRI0jTfFJ9e0YVYvWGoA==",
+      "version": "15.115.0",
+      "resolved": "https://registry.npmjs.org/zigbee-herdsman-converters/-/zigbee-herdsman-converters-15.115.0.tgz",
+      "integrity": "sha512-wJhm4S1UlMZ4D/X3wa4y4FUH54fIKIKi1vpvNPyte0rsGClH32/sl7j9YA9zdFvgVIA12rCuIbwaFzwUvs4QsQ==",
       "dependencies": {
-        "axios": "^1.6.0",
+        "axios": "^1.6.1",
         "buffer-crc32": "^0.2.13",
         "https-proxy-agent": "^7.0.2",
         "tar-stream": "^3.1.6",
-        "zigbee-herdsman": "^0.21.0"
+        "zigbee-herdsman": "^0.22.1"
+      }
+    },
+    "node_modules/zigbee-herdsman-converters/node_modules/zigbee-herdsman": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/zigbee-herdsman/-/zigbee-herdsman-0.22.1.tgz",
+      "integrity": "sha512-3xok9UrOEsIUa5JM/4KG2sr+FrmxHN9WqSCMeD6WP2BGAkNPXQUf2HyWJLczzV5uPXnVVaiJLQVxiwGonMgy0Q==",
+      "dependencies": {
+        "@serialport/bindings-cpp": "^12.0.1",
+        "@serialport/parser-delimiter": "^12.0.0",
+        "@serialport/stream": "^12.0.0",
+        "bonjour-service": "^1.1.1",
+        "debounce": "^1.2.1",
+        "debug": "^4.3.4",
+        "fast-deep-equal": "^3.1.3",
+        "mixin-deep": "^2.0.1",
+        "mz": "^2.7.0",
+        "slip": "^1.0.2"
       }
     },
     "node_modules/zigbee2mqtt-frontend": {
@@ -12670,9 +12687,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -17108,9 +17125,9 @@
       "dev": true
     },
     "zigbee-herdsman": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/zigbee-herdsman/-/zigbee-herdsman-0.21.0.tgz",
-      "integrity": "sha512-gksNtJNHIrxEPPnNJ/8sR+UtKCB7oyKFu7XmNJqF4RWBcTyzxh6kaMw+q0nPmicP+BlnqM9fRj9ZWEVWXgG6XQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/zigbee-herdsman/-/zigbee-herdsman-0.23.0.tgz",
+      "integrity": "sha512-2uggWvKA7pHltY5M5SzBSianuXeA1pBEYHst/xO588l4ss2m0SU/P2jtPH66Kc9YwcWKVwIhVU3J3q/OGNPKYg==",
       "requires": {
         "@serialport/bindings-cpp": "^12.0.1",
         "@serialport/parser-delimiter": "^12.0.0",
@@ -17125,15 +17142,34 @@
       }
     },
     "zigbee-herdsman-converters": {
-      "version": "15.106.0",
-      "resolved": "https://registry.npmjs.org/zigbee-herdsman-converters/-/zigbee-herdsman-converters-15.106.0.tgz",
-      "integrity": "sha512-Rj1IL1unqphrTlo4c3cE35RSsM3e998xlVjkk0EdVr/m4t+ac/YL4B4AUOqrccpafvoRI0jTfFJ9e0YVYvWGoA==",
+      "version": "15.115.0",
+      "resolved": "https://registry.npmjs.org/zigbee-herdsman-converters/-/zigbee-herdsman-converters-15.115.0.tgz",
+      "integrity": "sha512-wJhm4S1UlMZ4D/X3wa4y4FUH54fIKIKi1vpvNPyte0rsGClH32/sl7j9YA9zdFvgVIA12rCuIbwaFzwUvs4QsQ==",
       "requires": {
-        "axios": "^1.6.0",
+        "axios": "^1.6.1",
         "buffer-crc32": "^0.2.13",
         "https-proxy-agent": "^7.0.2",
         "tar-stream": "^3.1.6",
-        "zigbee-herdsman": "^0.21.0"
+        "zigbee-herdsman": "^0.22.1"
+      },
+      "dependencies": {
+        "zigbee-herdsman": {
+          "version": "0.22.1",
+          "resolved": "https://registry.npmjs.org/zigbee-herdsman/-/zigbee-herdsman-0.22.1.tgz",
+          "integrity": "sha512-3xok9UrOEsIUa5JM/4KG2sr+FrmxHN9WqSCMeD6WP2BGAkNPXQUf2HyWJLczzV5uPXnVVaiJLQVxiwGonMgy0Q==",
+          "requires": {
+            "@serialport/bindings-cpp": "^12.0.1",
+            "@serialport/parser-delimiter": "^12.0.0",
+            "@serialport/stream": "^12.0.0",
+            "bonjour-service": "^1.1.1",
+            "debounce": "^1.2.1",
+            "debug": "^4.3.4",
+            "fast-deep-equal": "^3.1.3",
+            "mixin-deep": "^2.0.1",
+            "mz": "^2.7.0",
+            "slip": "^1.0.2"
+          }
+        }
       }
     },
     "zigbee2mqtt-frontend": {

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "winston-syslog": "^2.7.0",
     "winston-transport": "^4.6.0",
     "ws": "^8.14.2",
-    "zigbee-herdsman": "0.21.0",
-    "zigbee-herdsman-converters": "15.106.0",
+    "zigbee-herdsman": "0.23.0",
+    "zigbee-herdsman-converters": "15.115.0",
     "zigbee2mqtt-frontend": "0.6.142"
   },
   "devDependencies": {


### PR DESCRIPTION
I need to upgrade to last version of zigbee-herdsman to be able to use new devices with zigbee