### PR TITLE
Fix: Remove device from "configuring" when an error occurs during device configuration

### DIFF
--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -127,6 +127,7 @@ export default class Configure extends Extension {
             logger.error(msg);
 
             if (throwError) {
+                this.configuring.delete(device.ieeeAddr);
                 throw error;
             }
         }

--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -127,11 +127,10 @@ export default class Configure extends Extension {
             logger.error(msg);
 
             if (throwError) {
-                this.configuring.delete(device.ieeeAddr);
                 throw error;
             }
+        } finally {
+            this.configuring.delete(device.ieeeAddr);
         }
-
-        this.configuring.delete(device.ieeeAddr);
     }
 }


### PR DESCRIPTION
I noticed that I cannot reconfigure a device (e.g. from the frontend) if a previous configuration attempt has failed, e.g. due to a timeout error. The reason for this is that the device is not removed from `this.configuring` before the function exits when an error is thrown. In any subsequent call, the function will return immediately because `this.configuring` is still set (line 105/106).