### PR TITLE
Allow serving under a non-root base path

### DIFF
--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -239,6 +239,7 @@ declare global {
             auth_token?: string,
             host?: string,
             port?: number,
+            path?: string,
             url?: string,
             ssl_cert?: string,
             ssl_key?: string,

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -378,6 +378,14 @@
               "default": "0.0.0.0",
               "requiresRestart": true
             },
+            "path":{
+              "type": "string",
+              "title": "Path",
+              "description": "Path under which the frontend is available.",
+              "examples": ["/zigbee2mqtt"],
+              "default": "/",
+              "requiresRestart": true
+            },
             "auth_token": {
               "type": ["string", "null"],
               "title": "Auth token",

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -150,7 +150,7 @@ function loadSettingsWithDefaults(): void {
     }
 
     if (_settingsWithDefaults.frontend) {
-        const defaults = {port: 8080, auth_token: false, host: '0.0.0.0'};
+        const defaults = {port: 8080, auth_token: false, host: '0.0.0.0', path: '/'};
         const s = typeof _settingsWithDefaults.frontend === 'object' ? _settingsWithDefaults.frontend : {};
         // @ts-ignore
         _settingsWithDefaults.frontend = {};

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -54,6 +54,16 @@ const mockNodeStatic = {
     events: {},
 };
 
+const mockRequest = {
+    url: '/',
+};
+
+const mockResponse = {
+    writeHead: jest.fn(() => ({
+        end: jest.fn()
+    })),
+};
+
 jest.mock('http', () => ({
     createServer: jest.fn().mockImplementation((onRequest) => {
         mockHTTP.variables.onRequest = onRequest;
@@ -99,7 +109,7 @@ describe('Frontend', () => {
         data.writeDefaultConfiguration();
         data.writeDefaultState();
         settings.reRead();
-        settings.set(['frontend'], {port: 8081, host: "127.0.0.1"});
+        settings.set(['frontend'], {port: 8081, host: "127.0.0.1", path: "/"});
         settings.set(['homeassistant'], true);
         zigbeeHerdsman.devices.bulb.linkquality = 10;
     });
@@ -269,9 +279,9 @@ describe('Frontend', () => {
         mockWS.implementation.handleUpgrade.mock.calls[0][3](99);
         expect(mockWS.implementation.emit).toHaveBeenCalledWith('connection', 99, {"url": "http://localhost:8080/api"});
 
-        mockHTTP.variables.onRequest(1, 2);
+        mockHTTP.variables.onRequest(mockRequest, mockResponse);
         expect(mockNodeStatic.implementation).toHaveBeenCalledTimes(1);
-        expect(mockNodeStatic.implementation).toHaveBeenCalledWith(1, 2, expect.any(Function));
+        expect(mockNodeStatic.implementation).toHaveBeenCalledWith(mockRequest, mockResponse, expect.any(Function));
     });
 
     it('Static server', async () => {

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -935,7 +935,7 @@ describe('Settings', () => {
         });
 
         settings.reRead();
-        expect(settings.get().frontend).toStrictEqual({port: 8080, auth_token: false, host: '0.0.0.0'})
+        expect(settings.get().frontend).toStrictEqual({port: 8080, auth_token: false, host: '0.0.0.0', path: '/'})
     });
 
     it('Baudrate config', () => {


### PR DESCRIPTION
This allows for scenarios where zigbee2mqtt is behind a reverse proxy. For example `example.com/zigbee2mqtt` instead of a root path like `zigbee2mqtt.example.com`.

I also tried to make the WS server available under the same path, but wasn't able to test these changes. I'd appreciate and input or help on testing that.

Related issues:
- nurikk/zigbee2mqtt-frontend#275
- nurikk/zigbee2mqtt-frontend#971
- nurikk/zigbee2mqtt-frontend#1690