### PR TITLE
Bridge discovery

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -115,6 +115,7 @@ export default class HomeAssistant extends Extension {
     private zigbee2MQTTVersion: string;
     private discoveryOrigin: {name: string, sw: string, url: string};
     private bridge: Bridge;
+    private bridgeIdentifier: string;
 
     constructor(zigbee: Zigbee, mqtt: MQTT, state: State, publishEntityState: PublishEntityState,
         eventBus: EventBus, enableDisableExtension: (enable: boolean, name: string) => Promise<void>,
@@ -133,6 +134,7 @@ export default class HomeAssistant extends Extension {
         this.zigbee2MQTTVersion = (await utils.getZigbee2MQTTVersion(false)).version;
         this.discoveryOrigin = {name: 'Zigbee2MQTT', sw: this.zigbee2MQTTVersion, url: 'https://www.zigbee2mqtt.io'};
         this.bridge = this.getBridgeEntity(await this.zigbee.getCoordinatorVersion());
+        this.bridgeIdentifier = this.getDevicePayload(this.bridge).identifiers[0];
         this.eventBus.onDeviceRemoved(this, this.onDeviceRemoved);
         this.eventBus.onMQTTMessage(this, this.onMQTTMessage);
         this.eventBus.onEntityRenamed(this, this.onEntityRenamed);
@@ -1661,6 +1663,11 @@ export default class HomeAssistant extends Extension {
 
         if (!url) {
             delete payload.configuration_url;
+        }
+
+        // Link devices & groups to bridge.
+        if (entity !== this.bridge) {
+            payload.via_device = this.bridgeIdentifier;
         }
 
         return payload;

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1261,7 +1261,7 @@ export default class HomeAssistant extends Extension {
     }
 
     private getDiscoverKey(entity: Device | Group): string | number {
-        return entity.isDevice() ? entity.ieeeAddr : entity.ID;
+        return entity.ID;
     }
 
     private discover(entity: Device | Group, force=false): void {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1757,6 +1757,41 @@ export default class HomeAssistant extends Extension {
         const baseTopic = `${settings.get().mqtt.base_topic}/${bridge.name}`;
 
         discovery.push(
+            // Binary sensors.
+            {
+                type: 'binary_sensor',
+                object_id: 'connection_state',
+                mockProperties: [],
+                discovery_payload: {
+                    name: 'Connection state',
+                    device_class: 'connectivity',
+                    entity_category: 'diagnostic',
+                    state_topic: true,
+                    state_topic_postfix: 'state',
+                    value_template: '{{ value_json.state }}',
+                    payload_on: 'online',
+                    payload_off: 'offline',
+                    availability: false,
+                },
+            },
+            {
+                type: 'binary_sensor',
+                object_id: 'restart_required',
+                mockProperties: [],
+                discovery_payload: {
+                    name: 'Restart required',
+                    device_class: 'problem',
+                    entity_category: 'diagnostic',
+                    enabled_by_default: false,
+                    state_topic: true,
+                    state_topic_postfix: 'info',
+                    value_template: '{{ value_json.restart_required }}',
+                    payload_on: true,
+                    payload_off: false,
+                },
+            },
+
+            // Buttons.
             {
                 type: 'button',
                 object_id: 'restart',
@@ -1769,20 +1804,25 @@ export default class HomeAssistant extends Extension {
                     payload_press: '',
                 },
             },
+
+            // Selects.
             {
-                type: 'sensor',
-                object_id: 'connection_state',
+                type: 'select',
+                object_id: 'log_level',
                 mockProperties: [],
                 discovery_payload: {
-                    name: 'Connection state',
-                    icon: 'mdi:router-wireless',
-                    entity_category: 'diagnostic',
+                    name: 'Log level',
+                    entity_category: 'config',
                     state_topic: true,
-                    state_topic_postfix: 'state',
-                    value_template: '{{ value_json.state }}',
-                    availability: false,
+                    state_topic_postfix: 'info',
+                    value_template: '{{ value_json.log_level | lower }}',
+                    command_topic: `${baseTopic}/request/options`,
+                    command_template:
+                        '{"options": {"advanced": {"log_level": "{{ value }}" } } }',
+                    options: ['info', 'warn', 'error', 'debug'],
                 },
             },
+            // Sensors:
             {
                 type: 'sensor',
                 object_id: 'version',
@@ -1827,6 +1867,23 @@ export default class HomeAssistant extends Extension {
                     json_attributes_template: '{{ value_json.data.value | tojson }}',
                 },
             },
+            {
+                type: 'sensor',
+                object_id: 'permit_join_timeout',
+                mockProperties: [],
+                discovery_payload: {
+                    name: 'Permit join timeout',
+                    device_class: 'duration',
+                    unit_of_measurement: 's',
+                    entity_category: 'diagnostic',
+                    state_topic: true,
+                    state_topic_postfix: 'info',
+                    value_template: '{{ int(value_json.permit_join_timeout, default="unknown") }}',
+                    expire_after: 2,
+                },
+            },
+
+            // Switches.
             {
                 type: 'switch',
                 object_id: 'permit_join',

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -90,6 +90,7 @@ describe('HomeAssistant extension', () => {
                "sw_version": version,
                "model": "Group",
                "manufacturer": "Zigbee2MQTT",
+               "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "max_mireds": 454,
             "min_mireds": 250,
@@ -135,6 +136,7 @@ describe('HomeAssistant extension', () => {
                "sw_version": version,
                "model": "Group",
                "manufacturer": "Zigbee2MQTT",
+               "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "json_attributes_topic":"zigbee2mqtt/ha_discovery_group",
             "name":null,
@@ -170,6 +172,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
             'enabled_by_default': true,
@@ -199,6 +202,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -227,6 +231,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -256,6 +261,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -286,6 +292,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -307,7 +314,8 @@ describe('HomeAssistant extension', () => {
                 "manufacturer":"Xiaomi",
                 "model":"Aqara double key wired wall switch without neutral wire. Doesn't work as a router and doesn't support power meter (QBKG03LM)",
                 "name":"wall_switch_double",
-                "sw_version": null
+                "sw_version": null,
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "json_attributes_topic":"zigbee2mqtt/wall_switch_double",
             "name":"Left",
@@ -337,7 +345,8 @@ describe('HomeAssistant extension', () => {
                 "manufacturer":"Xiaomi",
                 "model":"Aqara double key wired wall switch without neutral wire. Doesn't work as a router and doesn't support power meter (QBKG03LM)",
                 "name":"wall_switch_double",
-                "sw_version": null
+                "sw_version": null,
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "json_attributes_topic":"zigbee2mqtt/wall_switch_double",
             "name":"Right",
@@ -374,6 +383,7 @@ describe('HomeAssistant extension', () => {
                 "model":"TRADFRI LED bulb E26/E27 980 lumen, dimmable, white spectrum, opal white (LED1545G12)",
                 "name":"bulb",
                 "sw_version": null,
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "effect":true,
             "effect_list":[
@@ -432,6 +442,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -460,6 +471,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -488,6 +500,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -546,6 +559,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': 'test',
                 'model': 'custom model',
                 'manufacturer': 'From Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
             'expire_after': 90,
@@ -573,6 +587,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'custom model',
                 'manufacturer': 'Not from Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'origin': origin,
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
@@ -619,6 +634,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
             'enabled_by_default': true,
@@ -648,6 +664,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -690,7 +707,8 @@ describe('HomeAssistant extension', () => {
               "manufacturer": "Xiaomi",
               "model": "Aqara single key wired wall switch without neutral wire. Doesn't work as a router and doesn't support power meter (QBKG04LM)",
               "name": "my_switch",
-              "sw_version": null
+              "sw_version": null,
+              "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "json_attributes_topic": "zigbee2mqtt/my_switch",
             "name": "my_light_name_override",
@@ -773,7 +791,8 @@ describe('HomeAssistant extension', () => {
                "name":"fan",
                "sw_version": null,
                "model":"Universal wink enabled white ceiling fan premier remote control (99432)",
-               "manufacturer":"Hampton Bay"
+               "manufacturer":"Hampton Bay",
+               "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
          };
@@ -806,7 +825,8 @@ describe('HomeAssistant extension', () => {
                 "manufacturer":"TuYa",
                 "model":"Radiator valve with thermostat (TS0601_thermostat)",
                 "name":"TS0601_thermostat",
-                "sw_version":null
+                "sw_version":null,
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "preset_mode_command_topic":"zigbee2mqtt/TS0601_thermostat/set/preset",
             "preset_modes":[
@@ -875,7 +895,8 @@ describe('HomeAssistant extension', () => {
                 name: 'smart vent',
                 sw_version: null,
                 model: 'Smart vent (SV01)',
-                manufacturer: 'Keen Home'
+                manufacturer: 'Keen Home',
+                via_device: 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -895,7 +916,8 @@ describe('HomeAssistant extension', () => {
                 "manufacturer": "Siglis",
                 "model": "zigfred plus smart in-wall switch (ZFP-1A-CH)",
                 "name": "zigfred_plus",
-                "sw_version": null
+                "sw_version": null,
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "json_attributes_topic": "zigbee2mqtt/zigfred_plus/l6",
             "name": "L6",
@@ -947,6 +969,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -1075,6 +1098,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -1212,6 +1236,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability_mode': 'all',
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}, {topic: 'zigbee2mqtt/weather_sensor/availability'}],
@@ -1295,6 +1320,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -1329,7 +1355,8 @@ describe('HomeAssistant extension', () => {
                     "name":"weather_sensor_renamed",
                     "sw_version": null,
                     "model":"Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)",
-                    "manufacturer":"Xiaomi"
+                    "manufacturer":"Xiaomi",
+                    "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
                 }
             }),
             { retain: true, qos: 1 },
@@ -1356,6 +1383,7 @@ describe('HomeAssistant extension', () => {
                "sw_version": version,
                "model": "Group",
                "manufacturer": "Zigbee2MQTT",
+               "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "json_attributes_topic":"zigbee2mqtt/ha_discovery_group_new",
             "max_mireds": 454,
@@ -1429,6 +1457,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -1460,7 +1489,8 @@ describe('HomeAssistant extension', () => {
                 "name":"bulb",
                 'sw_version': null,
                 "model":"TRADFRI LED bulb E26/E27 980 lumen, dimmable, white spectrum, opal white (LED1545G12)",
-                "manufacturer":"IKEA"
+                "manufacturer":"IKEA",
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
             'device_class': 'update',
@@ -1502,7 +1532,8 @@ describe('HomeAssistant extension', () => {
                 "name":"button",
                 "sw_version": null,
                 "model":"Aqara wireless switch (WXKG11LM)",
-                "manufacturer":"Xiaomi"
+                "manufacturer":"Xiaomi",
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             }
         };
 
@@ -1527,7 +1558,8 @@ describe('HomeAssistant extension', () => {
                 "name":"button",
                 "sw_version": null,
                 "model":"Aqara wireless switch (WXKG11LM)",
-                "manufacturer":"Xiaomi"
+                "manufacturer":"Xiaomi",
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             }
         };
 
@@ -1692,7 +1724,8 @@ describe('HomeAssistant extension', () => {
                 "name":"button",
                 "sw_version": null,
                 "model":"Aqara wireless switch (WXKG11LM)",
-                "manufacturer":"Xiaomi"
+                "manufacturer":"Xiaomi",
+                "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             }
         };
 
@@ -1867,6 +1900,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae'
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -1896,6 +1930,7 @@ describe('HomeAssistant extension', () => {
                "sw_version": version,
                "model": "Group",
                "manufacturer": "Zigbee2MQTT",
+               "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "json_attributes_topic":"zigbee2mqtt/ha_discovery_group",
             "max_mireds": 454,
@@ -1949,6 +1984,7 @@ describe('HomeAssistant extension', () => {
                "sw_version": version,
                "model": "Group",
                "manufacturer": "Zigbee2MQTT",
+               "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "max_mireds": 454,
             "min_mireds": 250,
@@ -2009,7 +2045,8 @@ describe('HomeAssistant extension', () => {
                "manufacturer":"IKEA",
                "model":"TRADFRI LED bulb E26/E27 980 lumen, dimmable, white spectrum, opal white (LED1545G12)",
                "name":"bulb",
-               "sw_version":null
+               "sw_version":null,
+               "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "effect":true,
             "effect_list":[
@@ -2059,7 +2096,8 @@ describe('HomeAssistant extension', () => {
                "manufacturer":"IKEA",
                "model":"TRADFRI LED bulb E26/E27 980 lumen, dimmable, white spectrum, opal white (LED1545G12)",
                "name":"bulb",
-               "sw_version": null
+               "sw_version": null,
+               "via_device": "zigbee2mqtt_bridge_0x00124b00120144ae",
             },
             "enabled_by_default":false,
             "icon":"mdi:clock",
@@ -2107,7 +2145,8 @@ describe('HomeAssistant extension', () => {
                 'sw_version': null,
                 'model': 'Aqara temperature, humidity and pressure sensor (WSDCGQ11LM)',
                 'manufacturer': 'Xiaomi',
-                'configuration_url': 'http://zigbee.mqtt/#/device/0x0017880104e45522/info'
+                'configuration_url': 'http://zigbee.mqtt/#/device/0x0017880104e45522/info',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'availability': [{topic: 'zigbee2mqtt/bridge/state'}],
         };
@@ -2145,6 +2184,7 @@ describe('HomeAssistant extension', () => {
                 'sw_version': '5.127.1.26581',
                 'model': 'Hue Go (7146060PH)',
                 'manufacturer': 'Philips',
+                'via_device': 'zigbee2mqtt_bridge_0x00124b00120144ae',
             },
             'origin': origin,
             'availability': [ { 'topic': 'zigbee2mqtt/bridge/state' } ]

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -53,7 +53,7 @@ describe('HomeAssistant extension', () => {
         const duplicated = [];
         require('zigbee-herdsman-converters').definitions.forEach((d) => {
             const exposes = typeof d.exposes == 'function' ? d.exposes() : d.exposes;
-            const device = {definition: d, isDevice: () => true, options: {}, exposes: () => exposes, zh: {endpoints: []}};
+            const device = {definition: d, isDevice: () => true, isGroup: () => false, options: {}, exposes: () => exposes, zh: {endpoints: []}};
             const configs = extension.getConfigs(device);
             const cfg_type_object_ids = [];
 

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -2249,8 +2249,52 @@ describe('HomeAssistant extension', () => {
             'sw_version': z2m_version,
         };
 
-        // Buttons.
+        // Binary sensors.
         let payload;
+        payload = {
+            'name': 'Connection state',
+            'object_id': 'zigbee2mqtt_bridge_connection_state',
+            'entity_category': 'diagnostic',
+            'device_class': 'connectivity',
+            'unique_id': 'bridge_0x00124b00120144ae_connection_state_zigbee2mqtt',
+            'state_topic': 'zigbee2mqtt/bridge/state',
+            'value_template': '{{ value_json.state }}',
+            'payload_on': 'online',
+            'payload_off': 'offline',
+            'origin': origin,
+            'device': devicePayload,
+        };
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/binary_sensor/1221051039810110150109113116116_0x00124b00120144ae/connection_state/config',
+            stringify(payload),
+            { retain: true, qos: 1 },
+            expect.any(Function),
+        );
+
+        payload = {
+            'name': 'Restart required',
+            'object_id': 'zigbee2mqtt_bridge_restart_required',
+            'entity_category': 'diagnostic',
+            'device_class': 'problem',
+            'enabled_by_default': false,
+            'unique_id': 'bridge_0x00124b00120144ae_restart_required_zigbee2mqtt',
+            'state_topic': 'zigbee2mqtt/bridge/info',
+            'value_template': '{{ value_json.restart_required }}',
+            'payload_on': true,
+            'payload_off': false,
+            'origin': origin,
+            'device': devicePayload,
+            'availability': [{'topic': 'zigbee2mqtt/bridge/state'}],
+            'availability_mode': 'all',
+        };
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/binary_sensor/1221051039810110150109113116116_0x00124b00120144ae/restart_required/config',
+            stringify(payload),
+            { retain: true, qos: 1 },
+            expect.any(Function),
+        );
+
+        // Buttons.
         payload = {
             'name': 'Restart',
             'object_id': 'zigbee2mqtt_bridge_restart',
@@ -2270,25 +2314,31 @@ describe('HomeAssistant extension', () => {
             expect.any(Function),
         );
 
-        // Sensors.
+        // Selects.
         payload = {
-            'name': 'Connection state',
-            'object_id': 'zigbee2mqtt_bridge_connection_state',
-            'entity_category': 'diagnostic',
-            'icon': 'mdi:router-wireless',
-            'unique_id': 'bridge_0x00124b00120144ae_connection_state_zigbee2mqtt',
-            'state_topic': 'zigbee2mqtt/bridge/state',
-            'value_template': '{{ value_json.state }}',
+            'name': 'Log level',
+            'object_id': 'zigbee2mqtt_bridge_log_level',
+            'entity_category': 'config',
+            'unique_id': 'bridge_0x00124b00120144ae_log_level_zigbee2mqtt',
+            'state_topic': 'zigbee2mqtt/bridge/info',
+            'value_template': '{{ value_json.log_level | lower }}',
+            'command_topic': 'zigbee2mqtt/bridge/request/options',
+            'command_template':
+                '{"options": {"advanced": {"log_level": "{{ value }}" } } }',
+            'options': ['info', 'warn', 'error', 'debug'],
             'origin': origin,
             'device': devicePayload,
+            'availability': [{'topic': 'zigbee2mqtt/bridge/state'}],
+            'availability_mode': 'all',
         };
         expect(MQTT.publish).toHaveBeenCalledWith(
-            'homeassistant/sensor/1221051039810110150109113116116_0x00124b00120144ae/connection_state/config',
+            'homeassistant/select/1221051039810110150109113116116_0x00124b00120144ae/log_level/config',
             stringify(payload),
             { retain: true, qos: 1 },
             expect.any(Function),
         );
 
+        // Sensors.
         payload = {
             'name': 'Version',
             'object_id': 'zigbee2mqtt_bridge_version',
@@ -2347,6 +2397,28 @@ describe('HomeAssistant extension', () => {
         };
         expect(MQTT.publish).toHaveBeenCalledWith(
             'homeassistant/sensor/1221051039810110150109113116116_0x00124b00120144ae/network_map/config',
+            stringify(payload),
+            { retain: true, qos: 1 },
+            expect.any(Function),
+        );
+
+        payload = {
+            'name': 'Permit join timeout',
+            'object_id': 'zigbee2mqtt_bridge_permit_join_timeout',
+            'entity_category': 'diagnostic',
+            'device_class': 'duration',
+            'unit_of_measurement': 's',
+            'unique_id': 'bridge_0x00124b00120144ae_permit_join_timeout_zigbee2mqtt',
+            'state_topic': 'zigbee2mqtt/bridge/info',
+            'value_template': '{{ int(value_json.permit_join_timeout, default="unknown") }}',
+            'expire_after': 2,
+            'origin': origin,
+            'device': devicePayload,
+            'availability': [{'topic': 'zigbee2mqtt/bridge/state'}],
+            'availability_mode': 'all',
+        };
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/sensor/1221051039810110150109113116116_0x00124b00120144ae/permit_join_timeout/config',
             stringify(payload),
             { retain: true, qos: 1 },
             expect.any(Function),


### PR DESCRIPTION
- Adds discovery for the Z2M Bridge. Fixes #19877.
- Simplifies the `getDiscoverKey` method.
- Adds support for disabling the `availability` payload for certain entities.
- Adds the following entities for the bridge:
   * Control:
     - `Permit join` (`switch`)
     - `Restart` (`button`)
   * Config:
     - `Log level` (`select`)
   * Diagnostic:
      - `Connection state` (`binary_sensor`)
      - `Network map` (`sensor`)
      - `Permit join timeout` (`sensor`)
      - `Restart required` (`binary_sensor`)
      - `Version` (`sensor`)
      - `Coordinator version` (`sensor`)
  