### PR TITLE
fix: availability checks not stopped on extension stop

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -99,8 +99,8 @@ export default class Availability extends Extension {
         }
 
         if (entry.interrupted) {
-            // On stop, an async executing ping must not trigger any follow-up tasks.
-            // Exit here to cut the loop and avoid re-queuing another ping attempt.
+            // On stop, an async ping may have just been executing. To prevent side effects, exit here
+            // to avoid triggering any follow-up activity (e.g., re-queuing another ping attempt).
             return;
         }
 

--- a/test/availability.test.js
+++ b/test/availability.test.js
@@ -358,7 +358,7 @@ describe('Availability', () => {
         await advancedTime(utils.minutes(1));
 
         expect(availability.pingQueue).toEqual([]);
-        // Assert that the stop-interrupt works correctly by checking that the following call does not happen
+        // Validate the stop-interrupt implicitly by checking that it prevents further function invocations
         expect(publishAvailabilitySpy).not.toHaveBeenCalled();
     });
 });

--- a/test/availability.test.js
+++ b/test/availability.test.js
@@ -348,7 +348,7 @@ describe('Availability', () => {
 
     it('Should clear the ping queue on stop', async () => {
         const availability = controller.extensions.find((extension) => extension instanceof Availability);
-        const publishAvailabilitySpy = jest.spyOn(availability, 'publishAvailability').mockReturnValue(undefined);
+        const publishAvailabilitySpy = jest.spyOn(availability, 'publishAvailability');
 
         devices.bulb_color.zh = { ping: jest.fn().mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 1000)))};
         availability.addToPingQueue(devices.bulb_color);

--- a/test/availability.test.js
+++ b/test/availability.test.js
@@ -361,4 +361,12 @@ describe('Availability', () => {
         // Validate the stop-interrupt implicitly by checking that it prevents further function invocations
         expect(publishAvailabilitySpy).not.toHaveBeenCalled();
     });
+
+    it('Should prevent instance restart', async () => {
+        const availability = controller.extensions.find((extension) => extension instanceof Availability);
+
+        await availability.stop();
+
+        await expect(() => availability.start()).rejects.toThrowError();
+    });
 });

--- a/test/availability.test.js
+++ b/test/availability.test.js
@@ -6,6 +6,7 @@ import zigbeeHerdsman from './stub/zigbeeHerdsman';
 import utils from '../lib/util/utils';
 import * as settings from '../lib/util/settings';
 import Controller from '../lib/controller';
+import Availability from '../lib/extension/availability';
 import flushPromises from './lib/flushPromises';
 import stringify from 'json-stable-stringify-without-jsonify';
 
@@ -343,5 +344,21 @@ describe('Availability', () => {
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/group_tradfri_remote/availability',
             'online', {retain: true, qos: 1}, expect.any(Function));
+    });
+
+    it('Should clear the ping queue on stop', async () => {
+        const availability = controller.extensions.find((extension) => extension instanceof Availability);
+        const publishAvailabilitySpy = jest.spyOn(availability, 'publishAvailability').mockReturnValue(undefined);
+
+        devices.bulb_color.zh = { ping: jest.fn().mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 1000)))};
+        availability.addToPingQueue(devices.bulb_color);
+        availability.addToPingQueue(devices.bulb_color_2);
+
+        await availability.stop();
+        await advancedTime(utils.minutes(1));
+
+        expect(availability.pingQueue).toEqual([]);
+        // Assert that the stop-interrupt works correctly by checking that the following call does not happen
+        expect(publishAvailabilitySpy).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Clear the ping queue of the availability extension on stop, to prevent availability check (ping) cycles of unavailable devices continuing to run. This prevents the following issues:
- In case of a "soft" restart (e.g., via UI), the restart of the extension created additional availability check cycles, leading to every availability check executing twice (and thrice after the next restart, etc.). 
- When a device is disabled, the UI asks for a restart. If that device is unavailable, and a check cycle therefore already running, the checks continue after the restart. To users, this looks like disabling of unavailable devices does not work.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/20021.