### PR TITLE
Prevent scene entities from being duplicated

### DIFF
--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -2171,6 +2171,9 @@ describe('HomeAssistant extension', () => {
             expect.any(Function),
         );
 
+        jest.runOnlyPendingTimers();
+        await flushPromises();
+
         const payload = {
             'name': 'Chill scene',
             'command_topic': 'zigbee2mqtt/bulb_color_2/set',


### PR DESCRIPTION
Adds a delay between flushing and re-publishing scene discovery topics. This should fix the duplicate entities sometimes created by Home Assistant (reported in https://github.com/Koenkk/zigbee2mqtt/pull/19838#issuecomment-1844841580). 