### PR TITLE
Fix frontend ota zigbee_ota_override_index_location property to support null value

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -345,7 +345,7 @@
           "default": false
         },
         "zigbee_ota_override_index_location": {
-          "type": "string",
+          "type": ["string", "null"],
           "title": "OTA index override file name",
           "requiresRestart": true,
           "description": "Location of override OTA index file",


### PR DESCRIPTION
Fix can't revert to empty value after use custom value in 'OTA index override file name'