### PR TITLE
Automatically generate device definitions

### DIFF
--- a/lib/definition_generator.ts
+++ b/lib/definition_generator.ts
@@ -1,0 +1,132 @@
+import {default as HerdsmanDevice } from 'zigbee-herdsman/dist/controller/model/device';
+import {default as fz} from 'zigbee-herdsman-converters/converters/fromZigbee';
+import {default as tz} from 'zigbee-herdsman-converters/converters/toZigbee';
+import * as exposes from 'zigbee-herdsman-converters/lib/exposes';
+import { Configure, Logger } from 'zigbee-herdsman-converters/lib/types';
+import * as reporting from 'zigbee-herdsman-converters/lib/reporting';
+import logger from './util/logger';
+
+const e = exposes.presets;
+
+// This is the type that will change definition based on some defined conditions.
+type definitionModifier = (endpoint: zh.Endpoint) => Partial<zhc.Definition>;
+
+export default class DefinitionGenerator {
+    generate(device: HerdsmanDevice): zhc.Definition {
+        const configs: Configure[] = [];
+
+        const definition: zhc.Definition = {
+            model: device.modelID || '',
+            zigbeeModel: [device.modelID || 'custom'],
+            toZigbee: [tz.read as any, tz.write, tz.command, tz.factory_reset],
+            fromZigbee: [],
+            description: '',
+            options: [],
+            vendor: device.manufacturerName || 'custom',
+            exposes: [],
+            configure: async (device: zh.Device, coordinatorEndpoint: zh.Endpoint, lgr: Logger) => {
+                for (let i = 0; i < configs.length; i++) {
+                    await configs[i](device, coordinatorEndpoint, lgr)
+                }
+            },
+        };
+
+        let definitionUpdated = false;
+
+        device.endpoints.forEach(endpoint => {
+            const clusters = endpoint.getInputClusters();
+
+            clusters.forEach(cluster => {
+                const generator = modifiers[cluster.name || cluster.ID.toString()]
+                if (!generator) {
+                    logger.debug(`Device '${device.modelID}' (ieeeAddr ${device.ieeeAddr}) has unknown cluster for generation: ${cluster.name}`);
+                    return;
+                }
+
+                definitionUpdated = true;
+                const partialDefinition = generator(endpoint);
+                this.mergeDefinitions(definition, partialDefinition, configs)
+            })
+        })
+        // Do not provide definition if we didn't generate anything
+        if (!definitionUpdated) {
+            return null;
+        }
+
+        return definition
+    }
+
+    private mergeDefinitions(into: zhc.Definition, from: Partial<zhc.Definition>, configs: Configure[]) {
+        if (from.fromZigbee) {
+            if (!into.fromZigbee) {
+                into.fromZigbee = [];
+            }
+    
+            into.fromZigbee.push(...from.fromZigbee);
+        }
+    
+        if (from.toZigbee) {
+            if (!into.toZigbee) {
+                into.toZigbee = [];
+            }
+    
+            into.toZigbee.push(...from.toZigbee);
+        }
+    
+        if (from.exposes) {
+            if (!into.exposes) {
+                into.exposes = [];
+            }
+    
+            (into.exposes as zhc.DefinitionExpose[]).push(...(from.exposes as zhc.DefinitionExpose[]))
+        }
+    
+        if (from.configure !== undefined) {
+            configs.push(from.configure);
+        }
+    }
+}
+
+const modifiers: {[clusterName: string]: definitionModifier} = {
+    'genBasic': (_: zh.Endpoint): Partial<zhc.Definition> =>{
+        return {
+            fromZigbee: [fz.linkquality_from_basic as any],
+            exposes: [e.linkquality() as any],
+        }
+    },
+    'genIdentify': (_: zh.Endpoint): Partial<zhc.Definition> => {
+        return {
+            toZigbee: [tz.identify as any],
+        }
+    },
+    'msTemperatureMeasurement': (endpoint: zh.Endpoint): Partial<zhc.Definition> => {
+        return {
+            fromZigbee: [fz.temperature as any],
+            exposes: [e.temperature() as any],
+            configure: async (device: zh.Device, coordinatorEndpoint: zh.Endpoint, logger: Logger) => {
+                await reporting.bind(endpoint, coordinatorEndpoint, ['msTemperatureMeasurement']);
+                await reporting.temperature(endpoint);
+            }
+        }
+    },
+    'msPressureMeasurement': (endpoint: zh.Endpoint): Partial<zhc.Definition> => {
+        return {
+            fromZigbee: [fz.pressure as any],
+            exposes: [e.pressure() as any],
+            configure: async (device: zh.Device, coordinatorEndpoint: zh.Endpoint, logger: Logger) => {
+                await reporting.bind(endpoint, coordinatorEndpoint, ['msPressureMeasurement']);
+                await reporting.pressure(endpoint);
+            }
+        }
+    },
+    'msRelativeHumidity': (endpoint: zh.Endpoint): Partial<zhc.Definition> => {
+        return {
+            fromZigbee: [fz.humidity as any],
+            exposes: [e.humidity() as any],
+            configure: async (device: zh.Device, coordinatorEndpoint: zh.Endpoint, logger: Logger) => {
+                await reporting.bind(endpoint, coordinatorEndpoint, ['msRelativeHumidity']);
+                await reporting.humidity(endpoint);
+            }
+        }
+    },
+}

--- a/lib/definition_generator.ts
+++ b/lib/definition_generator.ts
@@ -5,6 +5,7 @@ import * as exposes from 'zigbee-herdsman-converters/lib/exposes';
 import { Configure, Logger } from 'zigbee-herdsman-converters/lib/types';
 import * as reporting from 'zigbee-herdsman-converters/lib/reporting';
 import logger from './util/logger';
+import * as zhc from 'zigbee-herdsman-converters';
 
 const e = exposes.presets;
 
@@ -78,7 +79,7 @@ export default class DefinitionGenerator {
                 into.exposes = [];
             }
     
-            (into.exposes as zhc.DefinitionExpose[]).push(...(from.exposes as zhc.DefinitionExpose[]))
+            (into.exposes as zhc.Expose[]).push(...(from.exposes as zhc.Expose[]))
         }
     
         if (from.configure !== undefined) {

--- a/lib/model/device.ts
+++ b/lib/model/device.ts
@@ -72,6 +72,10 @@ export default class Device {
         return name === 'default' ? null : name;
     }
 
+    setDefinition(definition: zhc.Definition) {
+        this._definition = definition
+    }
+
     isIkeaTradfri(): boolean {return this.zh.manufacturerID === 4476;}
 
     isDevice(): this is Device {return true;}

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -10,15 +10,18 @@ import Group from './model/group';
 import * as ZHEvents from 'zigbee-herdsman/dist/controller/events';
 import bind from 'bind-decorator';
 import {randomInt} from 'crypto';
+import DefinitionGenerator from './definition_generator';
 
 export default class Zigbee {
     private herdsman: Controller;
     private eventBus: EventBus;
     private groupLookup: {[s: number]: Group} = {};
     private deviceLookup: {[s: string]: Device} = {};
+    private definitionGenerator: DefinitionGenerator;
 
     constructor(eventBus: EventBus) {
         this.eventBus = eventBus;
+        this.definitionGenerator = new DefinitionGenerator();
     }
 
     async start(): Promise<'reset' | 'resumed' | 'restored'> {
@@ -245,6 +248,11 @@ export default class Zigbee {
         const device = this.deviceLookup[ieeeAddr];
         if (device && !device.zh.isDeleted) {
             device.ensureInSettings();
+
+            if (device.zh.interviewCompleted && !device.definition) {
+                device.setDefinition(this.definitionGenerator.generate(device.zh));
+            }
+
             return device;
         }
     }


### PR DESCRIPTION
I am working on a [project](https://github.com/ffenix113/zigbee_home) which is a mix between PTVO & ESPHome. It allows to create Zigbee firmware with custom set of sensors attached, based on yaml configuration.

To test it I need to add custom device to the Zigbee network and see if defined sensors work or not.
Unfortunately defining external convertor each time sensors change is not an option.

This MR introduces ability to generate device definition based on device reported clusters, which in turn allows to test custom/unsupported device without need to touch Zigbee2mqtt convertors.

I would like to know if the approach in this MR is something that possibly could be merged, and if yes - what (apart for tests :slightly_smiling_face: ) should be changed to merge it.