### PR TITLE
Always return an object when loading a YAML file

### DIFF
--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -4,7 +4,8 @@ import equals from 'fast-deep-equal/es6';
 
 function read(file: string): KeyValue {
     try {
-        return yaml.load(fs.readFileSync(file, 'utf8'));
+        const result = yaml.load(fs.readFileSync(file, 'utf8'));
+        return result as KeyValue ?? {};
     } catch (error) {
         if (error.name === 'YAMLException') {
             error.file = file;

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -335,22 +335,15 @@ describe('Settings', () => {
         expect(read(devicesFile)).toStrictEqual(expected);
     });
 
-    it('Should add devices for first file when using 2 separates file', () => {
+    function extractFromMultipleDeviceConfigs(contentDevices2) {
         const contentConfiguration = {
-            devices: ['devices.yaml', 'devices2.yaml']
+            devices: ['devices.yaml', 'devices2.yaml'],
         };
 
         const contentDevices = {
             '0x12345678': {
                 friendly_name: '0x12345678',
-                retain: false,
-            },
-        };
-
-        const contentDevices2 = {
-            '0x87654321': {
-                friendly_name: '0x87654321',
-                retain: false,
+                retain:        false,
             },
         };
 
@@ -365,15 +358,28 @@ describe('Settings', () => {
         const expected = {
             '0x12345678': {
                 friendly_name: '0x12345678',
-                retain: false,
+                retain:        false,
             },
-            '0x1234': {
+            '0x1234':     {
                 friendly_name: '0x1234',
             },
         };
 
         expect(read(devicesFile)).toStrictEqual(expected);
         expect(read(devicesFile2)).toStrictEqual(contentDevices2);
+    }
+
+    it('Should add devices for first file when using 2 separates file', () => {
+        extractFromMultipleDeviceConfigs({
+            '0x87654321': {
+                friendly_name: '0x87654321',
+                retain:        false,
+            },
+        });
+    });
+
+    it('Should add devices for first file when using 2 separates file and the second file is empty', () => {
+        extractFromMultipleDeviceConfigs(null)
     });
 
     it('Should add devices to a separate file if devices.yaml doesnt exist', () => {


### PR DESCRIPTION
If loading an empty file or a file that only contains comments, yaml.load() returns null, which is the cause for Koenkk#20283. This PR should make loading of YAML file more robust, as I don't think anybody relies on the special behavior of getting a null for an empty file.