### PR TITLE
fix: Home Assistant: clear old discovery topics when exposed are changed

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1327,6 +1327,7 @@ export default class HomeAssistant extends Extension {
             (entity.options.hasOwnProperty('homeassistant') && !entity.options.homeassistant))) {
             return;
         }
+        const lastDiscovered = this.discovered[discoverKey];
 
         this.discovered[discoverKey] = {topics: new Set(), mockProperties: new Set(), objectIDs: new Set()};
         this.getConfigs(entity).forEach((config) => {
@@ -1536,6 +1537,11 @@ export default class HomeAssistant extends Extension {
             this.discovered[discoverKey].objectIDs.add(config.object_id);
             config.mockProperties?.forEach((mockProperty) =>
                 this.discovered[discoverKey].mockProperties.add(mockProperty));
+        });
+        lastDiscovered?.topics?.forEach((topic) => {
+            if (!this.discovered[discoverKey].topics.has(topic)) {
+                this.mqtt.publish(topic, null, {retain: true, qos: 1}, this.discoveryTopic, false, false);
+            }
         });
     }
 

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -2449,4 +2449,17 @@ describe('HomeAssistant extension', () => {
             expect.any(Function),
         );
     });
+
+    it('Should remove discovery entries for removed exposes when device options change', async () => {
+        MQTT.publish.mockClear();
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/options', stringify({"id": "0xf4ce368a38be56a1", "options": {"dimmer_1_enabled": "false", "dimmer_1_dimming_enabled": "false"}}));
+        await flushPromises();
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/light/0xf4ce368a38be56a1/light_l2/config',
+            null,
+            { retain: true, qos: 1 },
+            expect.any(Function),
+        );
+    });
 });


### PR DESCRIPTION
This PR fixes Home Assistant discovery to also clear outdated discovery topics:
When a device changes its exposes dynamically, newly added and modified discovery topics are sent, but until now, discovery topics for removed exposed are not cleared. This leads to leftover entities in Home Assistant which can only be removed by manually clearing the discovery topic or restarting mqtt.