### PR TITLE
Support legacy_availability_payload for connection_state entity

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1796,6 +1796,7 @@ export default class HomeAssistant extends Extension {
         const discovery: DiscoveryEntry[] = [];
         const bridge = new Bridge(coordinatorIeeeAddress, coordinatorVersion, discovery);
         const baseTopic = `${settings.get().mqtt.base_topic}/${bridge.name}`;
+        const legacyAvailability = settings.get().advanced.legacy_availability_payload;
 
         discovery.push(
             // Binary sensors.
@@ -1809,7 +1810,7 @@ export default class HomeAssistant extends Extension {
                     entity_category: 'diagnostic',
                     state_topic: true,
                     state_topic_postfix: 'state',
-                    value_template: '{{ value_json.state }}',
+                    value_template: !legacyAvailability ? '{{ value_json.state }}' : '{{ value }}',
                     payload_on: 'online',
                     payload_off: 'offline',
                     availability: false,

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -2290,7 +2290,7 @@ describe('HomeAssistant extension', () => {
             'device_class': 'connectivity',
             'unique_id': 'bridge_0x00124b00120144ae_connection_state_zigbee2mqtt',
             'state_topic': 'zigbee2mqtt/bridge/state',
-            'value_template': '{{ value_json.state }}',
+            'value_template': '{{ value }}',
             'payload_on': 'online',
             'payload_off': 'offline',
             'origin': origin,


### PR DESCRIPTION
Adds support for `legacy_availability_payload` setting in `connection_state` bridge entity discovery. Fixes #20489.