### PR TITLE
Prevent warnings for bridge entities when legacy_entity_attributes is enabled

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1378,7 +1378,7 @@ export default class HomeAssistant extends Extension {
                 payload.tilt_status_topic = stateTopic;
             }
 
-            if (this.entityAttributes) {
+            if (this.entityAttributes && (isDevice || isGroup) ) {
                 payload.json_attributes_topic = stateTopic;
             }
 


### PR DESCRIPTION
Prevents warnings for bridge entities when `legacy_entity_attributes` is enabled. Fixes #20488.