### PR TITLE
Feature: Ability to trigger events from converters on incoming Zigbee messages

### DIFF
--- a/lib/eventBus.ts
+++ b/lib/eventBus.ts
@@ -90,6 +90,13 @@ export default class EventBus {
         this.on('entityOptionsChanged', callback, key);
     }
 
+    public emitExposesChanged(data: eventdata.ExposesChanged): void {
+        this.emitter.emit('exposesChanged', data);
+    }
+    public onExposesChanged(key: ListenerKey, callback: (data: eventdata.ExposesChanged) => void): void {
+        this.on('exposesChanged', callback, key);
+    }
+
     public emitDeviceLeave(data: eventdata.DeviceLeave): void {
         this.emitter.emit('deviceLeave', data);
     }

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -146,6 +146,7 @@ export default class HomeAssistant extends Extension {
         this.eventBus.onDeviceMessage(this, this.onZigbeeEvent);
         this.eventBus.onScenesChanged(this, this.onScenesChanged);
         this.eventBus.onEntityOptionsChanged(this, (data) => this.discover(data.entity, true));
+        this.eventBus.onExposesChanged(this, (data) => this.discover(data.device, true));
 
         this.mqtt.subscribe(this.statusTopic);
         this.mqtt.subscribe(defaultStatusTopic);

--- a/lib/extension/receive.ts
+++ b/lib/extension/receive.ts
@@ -140,9 +140,11 @@ export default class Receive extends Extension {
 
         const deviceExposesChanged = (): void => {
             this.eventBus.emitDevicesChanged();
-        }
+            this.eventBus.emitExposesChanged({device: data.device});
+        };
 
-        const meta = {device: data.device.zh, logger, state: this.state.get(data.device), deviceExposesChanged: deviceExposesChanged};
+        const meta = {device: data.device.zh, logger, state: this.state.get(data.device),
+            deviceExposesChanged: deviceExposesChanged};
         let payload: KeyValue = {};
         for (const converter of converters) {
             try {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -90,6 +90,7 @@ declare global {
         type DeviceInterview = { device: Device, status: 'started' | 'successful' | 'failed' };
         type DeviceJoined = { device: Device };
         type EntityOptionsChanged = { entity: Device | Group, from: KeyValue, to: KeyValue };
+        type ExposesChanged = { device: Device };
         type Reconfigure = { device: Device };
         type DeviceLeave = { ieeeAddr: string, name: string };
         type GroupMembersChanged = {group: Group, action: 'remove' | 'add' | 'remove_all',

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -2491,4 +2491,40 @@ describe('HomeAssistant extension', () => {
             expect.any(Function),
         );
     });
+
+    it('Should publish discovery message when a converter announces changed exposes', async () => {
+        MQTT.publish.mockClear();
+        const device = zigbeeHerdsman.devices['BMCT-SLZ'];
+        const data = {deviceMode: 0}
+        const msg = {data, cluster: 'manuSpecificBosch10', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 10};
+        await zigbeeHerdsman.events.message(msg);
+        const payload = {
+            'availability':[{'topic':'zigbee2mqtt/bridge/state'}],
+            'command_topic':'zigbee2mqtt/0x18fc26000000cafe/set/device_mode',
+            'device':{
+                'identifiers':['zigbee2mqtt_0x18fc26000000cafe'],
+                'manufacturer':'Bosch',
+                'model':'Light/shutter control unit II (BMCT-SLZ)',
+                'name':'0x18fc26000000cafe',
+                'sw_version':null,
+                'via_device':'zigbee2mqtt_bridge_0x00124b00120144ae'
+            },
+            'entity_category':'config',
+            'icon':'mdi:tune',
+            'json_attributes_topic':'zigbee2mqtt/0x18fc26000000cafe',
+            'name':'Device mode',
+            'object_id':'0x18fc26000000cafe_device_mode',
+            'options':['light','shutter','disabled'],
+            'origin': origin,
+            'state_topic':'zigbee2mqtt/0x18fc26000000cafe',
+            'unique_id':'0x18fc26000000cafe_device_mode_zigbee2mqtt',
+            'value_template':'{{ value_json.device_mode }}'
+        }
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            "homeassistant/select/0x18fc26000000cafe/device_mode/config",
+            stringify(payload),
+            { retain: true, qos: 1 },
+            expect.any(Function),
+        );
+    });
 });

--- a/test/receive.test.js
+++ b/test/receive.test.js
@@ -467,4 +467,11 @@ describe('Receive', () => {
         expect(MQTT.publish.mock.calls[0][0]).toStrictEqual('zigbee2mqtt/SP600_OLD');
         expect(JSON.parse(MQTT.publish.mock.calls[0][1])).toStrictEqual({energy: 6.65, power: 496});
     });
+    it('Should emit DevicesChanged event when a converter announces changed exposes', async () => {
+        const device = zigbeeHerdsman.devices['BMCT-SLZ'];
+        const data = {deviceMode: 0}
+        const payload = {data, cluster: 'manuSpecificBosch10', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 10};
+        await zigbeeHerdsman.events.message(payload);
+        expect(MQTT.publish.mock.calls[0][0]).toStrictEqual("zigbee2mqtt/bridge/devices");
+    });
 });

--- a/test/stub/zigbeeHerdsman.js
+++ b/test/stub/zigbeeHerdsman.js
@@ -204,6 +204,8 @@ const devices = {
     'heating_actuator': new Device('Router', '0x0017880104e45562', 6545,4151, [new Endpoint(1, [0,3,4,513], [1026])], true, "Mains (single phase)", "heating.actuator"),
     'bj_scene_switch': new Device('EndDevice', '0xd85def11a1002caa', 50117, 4398, [new Endpoint(10, [0,4096], [3,4,5,6,8,25,768,4096], '0xd85def11a1002caa', [{target: bulb_color_2.endpoints[0], cluster: {ID: 8, name: 'genLevelCtrl'}}, {target: bulb_color_2.endpoints[0], cluster: {ID: 6, name: 'genOnOff'}}, {target: bulb_color_2.endpoints[0], cluster: {ID: 768, name: 'lightingColorCtrl'}},]), new Endpoint(11, [0,4096], [3,4,5,6,8,25,768,4096], '0xd85def11a1002caa')], true, 'Battery', 'RB01', false, 'Busch-Jaeger', '20161222', '1.2.0'),
     'GW003-AS-IN-TE-FC': new Device('Router', '0x0017548104a44669', 6545,4699, [new Endpoint(1, [3], [0,3,513,514], '0x0017548104a44669')], true, "Mains (single phase)", 'Adapter Zigbee FUJITSU'),
+    'BMCT-SLZ': new Device('Router', '0x18fc26000000cafe', 6546,4617, [new Endpoint(1, [0,3,4,5,258,1794,2820,2821,64672], [10,25], '0x18fc26000000cafe')], true, "Mains (single phase)", 'RBSH-MMS-ZB-EU'),
+
 }
 
 const mock = {


### PR DESCRIPTION
This is the complementing z2m PR for https://github.com/Koenkk/zigbee-herdsman-converters/pull/6869. CI will pass once that one is merged.

It introduces a new `meta.deviceExposesChanged()` which converters can call from inside fromZigbee `convert()` to request a re-evaluation and re-publishing of a dynamic `expose()`

The `DevicesChanged` event is emitted to publish `zigbee2mqtt/bridge/devices`). I had to add another new `emitExposesChanged` event for the Home Assistant extension, because I did not want to change its behavior too much: The only event that leads to force-sending out a new discovery message is `DeviceOptionsChanged`.



