### PR TITLE
remove sendWhen from otaUpdate.ts

### DIFF
--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -125,11 +125,11 @@ export default class OTAUpdate extends Extension {
         logger.debug(`Responded to OTA request of '${data.device.name}' with 'NO_IMAGE_AVAILABLE'`);
     }
 
-    private async readSoftwareBuildIDAndDateCode(device: Device, sendWhen: 'active' | 'immediate'):
+    private async readSoftwareBuildIDAndDateCode(device: Device, sendPolicy?: 'immediate'):
         Promise<{softwareBuildID: string, dateCode: string}> {
         try {
             const endpoint = device.zh.endpoints.find((e) => e.supportsInputCluster('genBasic'));
-            const result = await endpoint.read('genBasic', ['dateCode', 'swBuildId'], {sendWhen});
+            const result = await endpoint.read('genBasic', ['dateCode', 'swBuildId'], {sendPolicy});
             return {softwareBuildID: result.swBuildId, dateCode: result.dateCode};
         } catch (e) {
             return null;
@@ -273,7 +273,7 @@ export default class OTAUpdate extends Extension {
                     const payload = this.getEntityPublishPayload(device,
                         {available: false, currentFileVersion: fileVersion, otaFileVersion: fileVersion});
                     this.publishEntityState(device, payload);
-                    const to = await this.readSoftwareBuildIDAndDateCode(device, 'active');
+                    const to = await this.readSoftwareBuildIDAndDateCode(device);
                     const [fromS, toS] = [stringify(from_), stringify(to)];
                     logger.info(`Device '${device.name}' was updated from '${fromS}' to '${toS}'`);
                     responseData.from = from_ ? utils.toSnakeCase(from_) : null;

--- a/test/otaUpdate.test.js
+++ b/test/otaUpdate.test.js
@@ -89,8 +89,8 @@ describe('OTA update', () => {
         expect(logger.info).toHaveBeenCalledWith(`Finished update of 'bulb'`);
         expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190103","softwareBuildID":3}'`);
         expect(device.save).toHaveBeenCalledTimes(2);
-        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendWhen': 'immediate'});
-        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendWhen': 'active'});
+        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': 'immediate'});
+        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {});
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb',
             stringify({"update_available":false,"update":{"state":"updating","progress":0}}),
@@ -392,7 +392,7 @@ describe('OTA update', () => {
         expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190103","softwareBuildID":3}'`);
         expect(logger.error).toHaveBeenCalledTimes(0);
         expect(device.save).toHaveBeenCalledTimes(2);
-        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendWhen': 'immediate'});
+        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': 'immediate'});
     });
 
     it('Legacy api: Should handle when OTA update fails', async () => {


### PR DESCRIPTION
These are the last remaining occurrences of `sendWhen` which need to be replaced before the legacy adapter in zigbee-herdsman can be removed
cf. https://github.com/Koenkk/zigbee-herdsman/pull/860#issuecomment-1883606553