### PR TITLE
Additional icons for Aqara TRV entities and various others

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -635,6 +635,7 @@ export default class HomeAssistant extends Extension {
                 setup: {device_class: 'running'},
                 smoke: {device_class: 'smoke'},
                 sos: {device_class: 'safety'},
+                schedule: {icon: 'mdi:calendar'},
                 status_capacitive_load: {entity_category: 'diagnostic', icon: 'mdi:tune'},
                 status_forward_phase_control: {entity_category: 'diagnostic', icon: 'mdi:tune'},
                 status_inductive_load: {entity_category: 'diagnostic', icon: 'mdi:tune'},
@@ -1019,6 +1020,7 @@ export default class HomeAssistant extends Extension {
                 programming_mode: {icon: 'mdi:calendar-clock'},
                 program: {value_template: `{{ value_json.${firstExpose.property}|default('',True) ` +
                     `| truncate(254, True, '', 0) }}`},
+                schedule_settings: {icon: 'mdi:calendar-clock'},
             };
             if (firstExpose.access & ACCESS_STATE) {
                 const discoveryEntry: DiscoveryEntry = {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -709,6 +709,7 @@ export default class HomeAssistant extends Extension {
             const lookup: {[s: string]: KeyValue} = {
                 ac_frequency: {device_class: 'frequency', enabled_by_default: false, entity_category: 'diagnostic',
                     state_class: 'measurement'},
+                action_duration: {icon: 'mdi:timer', device_class: 'duration'},
                 alarm_humidity_max: {device_class: 'humidity', entity_category: 'config', icon: 'mdi:water-plus'},
                 alarm_humidity_min: {device_class: 'humidity', entity_category: 'config', icon: 'mdi:water-minus'},
                 alarm_temperature_max: {device_class: 'temperature', entity_category: 'config',
@@ -767,6 +768,7 @@ export default class HomeAssistant extends Extension {
                 eco2: {device_class: 'carbon_dioxide', state_class: 'measurement'},
                 eco_temperature: {entity_category: 'config', icon: 'mdi:thermometer'},
                 energy: {device_class: 'energy', state_class: 'total_increasing'},
+                external_temperature_input: {icon: 'mdi:thermometer'},
                 formaldehyd: {state_class: 'measurement'},
                 gas_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
                 hcho: {icon: 'mdi:air-filter', state_class: 'measurement'},
@@ -810,7 +812,6 @@ export default class HomeAssistant extends Extension {
                 requested_brightness_percent: {
                     enabled_by_default: false, entity_category: 'diagnostic', icon: 'mdi:brightness-5',
                 },
-                sensor_temp: {icon: 'mdi:thermometer'},
                 smoke_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
                 soil_moisture: {device_class: 'moisture', state_class: 'measurement'},
                 temperature: {device_class: 'temperature', state_class: 'measurement'},
@@ -1016,6 +1017,7 @@ export default class HomeAssistant extends Extension {
             const settableText = firstExpose.type === 'text' && firstExpose.access & ACCESS_SET;
             const lookup: {[s: string]: KeyValue} = {
                 action: {icon: 'mdi:gesture-double-tap'},
+                color_options: {icon: 'mdi:palette'},
                 level_config: {entity_category: 'diagnostic'},
                 programming_mode: {icon: 'mdi:calendar-clock'},
                 program: {value_template: `{{ value_json.${firstExpose.property}|default('',True) ` +


### PR DESCRIPTION
 [Fixed the converter](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6922) and adding corresponding icons for `schedule` and `schedule_settings`.

Added icons for `action_duration`, `color_options` and renamed `sensor_temp` to `external_temperature_input`.