### PR TITLE
Improve scene republishing

### DIFF
--- a/lib/eventBus.ts
+++ b/lib/eventBus.ts
@@ -146,10 +146,10 @@ export default class EventBus {
         this.on('devicesChanged', callback, key);
     }
 
-    public emitScenesChanged(): void {
-        this.emitter.emit('scenesChanged');
+    public emitScenesChanged(data: eventdata.ScenesChanged): void {
+        this.emitter.emit('scenesChanged', data);
     }
-    public onScenesChanged(key: ListenerKey, callback: () => void): void {
+    public onScenesChanged(key: ListenerKey, callback: (data: eventdata.ScenesChanged) => void): void {
         this.on('scenesChanged', callback, key);
     }
 

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -298,7 +298,7 @@ export default class Publish extends Extension {
         const scenesChanged = Object.values(usedConverters)
             .some((cl) => cl.some((c) => c.key.some((k) => sceneConverterKeys.includes(k))));
         if (scenesChanged) {
-            this.eventBus.emitScenesChanged();
+            this.eventBus.emitScenesChanged({entity: re});
         }
     }
 }

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -107,6 +107,7 @@ declare global {
             data: KeyValue | Array<string | number>;
             meta: {zclTransactionSequenceNumber?: number; manufacturerCode?: number; frameControl?: ZHFrameControl;};
         };
+        type ScenesChanged = { entity: Device | Group };
     }
 
     // Settings


### PR DESCRIPTION
Improves scene republishing by adding the affected entity to the event bus. This removes a lot of completely unnecessary clearing and republishing of discovery topics. It also fixes discovery for the first scenes added to an endpoint or a group (because the discovery topic for that is currently never published except on a Z2M restart).