### PR TITLE
feat(HA): Add support for button entity in Home Assistant

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -946,6 +946,7 @@ export default class HomeAssistant extends Extension {
                 effect: {enabled_by_default: false, icon: 'mdi:palette'},
                 force: {entity_category: 'config', icon: 'mdi:valve'},
                 keep_time: {entity_category: 'config', icon: 'mdi:av-timer'},
+                identify: {device_class: 'identify'},
                 keypad_lockout: {entity_category: 'config', icon: 'mdi:lock'},
                 load_detection_mode: {entity_category: 'config', icon: 'mdi:tune'},
                 load_dimmable: {entity_category: 'config', icon: 'mdi:chart-bell-curve'},
@@ -960,6 +961,7 @@ export default class HomeAssistant extends Extension {
                 power_outage_memory: {entity_category: 'config', icon: 'mdi:power-settings'},
                 power_supply_mode: {entity_category: 'config', icon: 'mdi:power-settings'},
                 power_type: {entity_category: 'config', icon: 'mdi:lightning-bolt-circle'},
+                restart: {device_class: 'restart'},
                 sensitivity: {entity_category: 'config', icon: 'mdi:tune'},
                 sensor: {icon: 'mdi:tune'},
                 sensors_type: {entity_category: 'config', icon: 'mdi:tune'},
@@ -969,6 +971,7 @@ export default class HomeAssistant extends Extension {
                 temperature_display_mode: {entity_category: 'config', icon: 'mdi:thermometer'},
                 temperature_sensor_select: {entity_category: 'config', icon: 'mdi:home-thermometer'},
                 thermostat_unit: {entity_category: 'config', icon: 'mdi:thermometer'},
+                update: {device_class: 'update'},
                 volume: {entity_category: 'config', icon: 'mdi: volume-high'},
                 week: {entity_category: 'config', icon: 'mdi:calendar-clock'},
             };
@@ -1008,6 +1011,29 @@ export default class HomeAssistant extends Extension {
                         command_topic: true,
                         command_topic_postfix: firstExpose.property,
                         options: firstExpose.values.map((v) => v.toString()),
+                        enabled_by_default: firstExpose.values.length !== 1, // hide if button is exposed
+                        ...lookup[firstExpose.name],
+                    },
+                });
+            }
+
+            /**
+             * If enum has only item and only supports SET then expose as button entity.
+             * Note: select entity is hidden by default to avoid breaking changes
+             * for selects already existing in HA (legacy).
+             */
+            if (firstExpose.access & ACCESS_SET && firstExpose.values.length === 1) {
+                discoveryEntries.push({
+                    type: 'button',
+                    object_id: firstExpose.property,
+                    mockProperties: [],
+                    discovery_payload: {
+                        name: endpoint ? `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                        state_topic: false,
+                        command_topic_prefix: endpoint,
+                        command_topic: true,
+                        command_topic_postfix: firstExpose.property,
+                        payload_press: firstExpose.values[0].toString(),
                         ...lookup[firstExpose.name],
                     },
                 });

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -2530,7 +2530,8 @@ describe('HomeAssistant extension', () => {
             'origin': origin,
             'state_topic':'zigbee2mqtt/0x18fc26000000cafe',
             'unique_id':'0x18fc26000000cafe_device_mode_zigbee2mqtt',
-            'value_template':'{{ value_json.device_mode }}'
+            'value_template':'{{ value_json.device_mode }}',
+            'enabled_by_default': true,
         }
         expect(MQTT.publish).toHaveBeenCalledWith(
             "homeassistant/select/0x18fc26000000cafe/device_mode/config",


### PR DESCRIPTION
This PR introduces new discovery logic that exposes `select` with only one option and no state as [`button`](https://www.home-assistant.io/integrations/button/) entity. For compatibility `select` is simply hidden by default in case `button` is exposed.

Additional [PR](https://github.com/Koenkk/zigbee-herdsman-converters/pull/7060) to zigbee-herdsman-converters utilizes this new entity to add `identify` button that will be useful for a lot of devices and is already implemented in ZHA.