### PR TITLE
Fix parsing entity name that contains slash in the name and endpoint …

### DIFF
--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -11,7 +11,7 @@ import * as ZHEvents from 'zigbee-herdsman/dist/controller/events';
 import bind from 'bind-decorator';
 import {randomInt} from 'crypto';
 
-const entityIDRegex = new RegExp(`^(.+?)(?:/(.+))?$`);
+const entityIDRegex = new RegExp(`^(.+?)(?:/([^/]+))?$`);
 
 export default class Zigbee {
     private herdsman: Controller;


### PR DESCRIPTION
Problem:
When adding the `device/with/slash/1` endpoint to the group, zigbee2mqtt reports there is no such device found.

Fix: there was slightly incorrect regexp that suppose to separate endpoint name/number from the device name. Before the fix it did split on the first found slash, while the correct behavior is to split on latest slash.