### PR TITLE
Check if Zigbee2MQTT is running in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,18 +1,24 @@
 #!/bin/bash -e
 cd "$(dirname "$0")"
 
+NEED_RESTART=0
+
 if [ -d data-backup ]; then
-   echo "ERROR: Backup directory exists. May be previous restoring was failed?"
-   echo "1. Save 'data-backup' and 'data' dirs to safe location to make possibility to restore config later."
-   echo "2. Manually delete 'data-backup' dir and try again."
-   exit 1
+    echo "ERROR: Backup directory exists. May be previous restoring was failed?"
+    echo "1. Save 'data-backup' and 'data' dirs to safe location to make possibility to restore config later."
+    echo "2. Manually delete 'data-backup' dir and try again."
+    exit 1
 fi
 
 if which systemctl 2> /dev/null > /dev/null; then
-       echo "Stopping Zigbee2MQTT..."
-       sudo systemctl stop zigbee2mqtt
+    echo "Checking Zigbee2MQTT status..."
+    if systemctl is-active --quiet zigbee2mqtt; then
+        echo "Stopping Zigbee2MQTT..."
+        sudo systemctl stop zigbee2mqtt
+        NEED_RESTART=1
+    fi
 else
-       echo "Skipped stopping Zigbee2MQTT, no systemctl found"
+    echo "Skipped stopping Zigbee2MQTT, no systemctl found"
 fi
 
 echo "Creating backup of configuration..."
@@ -34,11 +40,9 @@ echo "Restore configuration..."
 cp -R data-backup/* data
 rm -rf data-backup
 
-if which systemctl 2> /dev/null > /dev/null; then
-       echo "Starting Zigbee2MQTT..."
-       sudo systemctl start zigbee2mqtt
-else
-       echo "Skipped starting Zigbee2MQTT, no systemctl found"
+if [ $NEED_RESTART -eq 1 ]; then
+    echo "Starting Zigbee2MQTT..."
+    sudo systemctl start zigbee2mqtt
 fi
 
 echo "Done!"


### PR DESCRIPTION
Hi,

I’m running Zigbee2MQTT as an unprivileged user, and I don’t want to give it sudo rights. I can’t use the update.sh script the way it was because it asked me for the sudo password.

I’ve changed it so now it checks if zigbee2mqtt is currently running. If it’s not, then it doesn’t try to stop the service, and it will not try to restart it.

That way, I’ll be able to use it (i’ll just stop and start it manually), and for people using sudo, it doesn’t change anything.