### PR TITLE
Expose device configuration after hass is online

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Zigbee2MQTT integrates well with (almost) every home automation solution because
 
 ### [IoBroker](https://www.iobroker.net/)
 - Integration implemented in IoBroker ([documentation](https://github.com/o0shojo0o/ioBroker.zigbee2mqtt)).
-  
+
 <br>
 
 ## Architecture

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1684,6 +1684,19 @@ export default class HomeAssistant extends Extension {
             const timer = setTimeout(async () => {
                 // Publish all device states.
                 for (const entity of [...this.zigbee.devices(false), ...this.zigbee.groups()]) {
+
+                    // Expose device configurations to homeassistant
+                    // https://github.com/Koenkk/zigbee2mqtt/issues/18862
+                    this.discover(entity, true);
+
+                    if (entity.isDevice() && this.discoveredTriggers[entity.ieeeAddr]) {
+                        for (const config of this.discoveredTriggers[entity.ieeeAddr]) {
+                            const key = config.substring(0, config.indexOf('_'));
+                            const value = config.substring(config.indexOf('_') + 1);
+                            this.publishDeviceTriggerDiscover(entity, key, value, true);
+                        }
+                    }
+
                     if (this.state.exists(entity)) {
                         this.publishEntityState(entity, this.state.get(entity), 'publishCached');
                     }


### PR DESCRIPTION
Hi, I solved the problem with device resending device configuration after restarting Homeassistant

Short story long: It is about Zigbee devices unavailable (in Homeassistant `2023.12.3`) after Home Assistant restarting.

I added calling the `discover(entity, forced)` when we get `online` message in homeassistant state topic.

I am not sure about using next section:

```ts
if (entity.isDevice() && this.discoveredTriggers[entity.ieeeAddr]) {
    for (const config of this.discoveredTriggers[entity.ieeeAddr]) {
        const key = config.substring(0, config.indexOf('_'));
        const value = config.substring(config.indexOf('_') + 1);
        this.publishDeviceTriggerDiscover(entity, key, value, true);
    }
}
```

Please let me know if some changes I should to add to the PR or edit my PR by yourself (I allow it).

Source: https://github.com/Koenkk/zigbee2mqtt/issues/18862