### PR TITLE
fix: Disable automatic reconfigure when configureKey changes

### DIFF
--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -96,8 +96,7 @@ export default class Configure extends Extension {
                 return;
             }
 
-            if (device.zh.meta?.hasOwnProperty('configured') &&
-                device.zh.meta.configured === zhc.getConfigureKey(device.definition)) {
+            if (device.zh.meta?.hasOwnProperty('configured')) {
                 return;
             }
 


### PR DESCRIPTION
This PR disables the automatic reconfigure whenever the configureKey changes due to the `configure()` method being changed. The initial trigger for me to disable this came from https://github.com/Koenkk/zigbee-herdsman-converters/pull/7319, which removes the `logger` argument from `configure()` and thus triggering a reconfigure for **all** devices. In the past this already caused a lot of issues (e.g. with the modern extend refactor). 

Note that the automatic reconfigure is broken anyway for devices that use modern extend (because `configure()` is a loop over all modern extends configure, the `configureKey` never changes).

We have to find a better way to deal with reconfigure, but I'm thinking something like this:
- Add back `meta: {configureKey: XX}` (can be added partially automatic for modern extend based devices)
- When a new `configureKey` is found, mark the device in the frontend, so that the user can press the reconfigure button (yellow refresh icon)

This also fixes the issue that devices are unexpectedly being reconfigured causing them to break (e.g. last month due to an automatic reconfigure, my Hue Wall Switch lost it's bindings).

CC: @Nerivec @kirovilya @sjorge @mrskycriper (I'm merging this PR immediately to prevent reconfigure for all devices on the dev branch but feel free to provide feedback) 