### PR TITLE
fix: Remove deprecated Home Assistant `color_mode`

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -210,7 +210,6 @@ export default class HomeAssistant extends Extension {
             ].filter((c) => c);
 
             if (colorModes.length) {
-                discoveryEntry.discovery_payload.color_mode = true;
                 discoveryEntry.discovery_payload.supported_color_modes = colorModes;
             }
 

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -83,7 +83,6 @@ describe('HomeAssistant extension', () => {
             "availability":[{"topic":"zigbee2mqtt/bridge/state"}],
             "brightness":true,
             "brightness_scale":254,
-            "color_mode":true,
             "command_topic":"zigbee2mqtt/ha_discovery_group/set",
             "device":{
                "identifiers":["zigbee2mqtt_1221051039810110150109113116116_9"],
@@ -371,7 +370,6 @@ describe('HomeAssistant extension', () => {
             "availability":[{"topic":"zigbee2mqtt/bridge/state"}],
             "brightness":true,
             "brightness_scale":254,
-            "color_mode": true,
             "supported_color_modes": ["color_temp"],
             "min_mireds": 250,
             "max_mireds": 454,
@@ -1369,7 +1367,6 @@ describe('HomeAssistant extension', () => {
             "availability":[{"topic":"zigbee2mqtt/bridge/state"}],
             "brightness":true,
             "brightness_scale":254,
-            "color_mode":true,
             "command_topic":"zigbee2mqtt/ha_discovery_group_new/set",
             "device":{
                "identifiers":["zigbee2mqtt_1221051039810110150109113116116_9"],
@@ -1916,7 +1913,6 @@ describe('HomeAssistant extension', () => {
             "availability":[{"topic":"zigbee2mqtt/bridge/state"}],
             "brightness":true,
             "brightness_scale":254,
-            "color_mode":true,
             "command_topic":"zigbee2mqtt/ha_discovery_group/set",
             "device":{
                "identifiers":["zigbee2mqtt_1221051039810110150109113116116_9"],
@@ -1970,7 +1966,6 @@ describe('HomeAssistant extension', () => {
             "availability":[{"topic":"zigbee2mqtt/bridge/state","value_template":'{{ value_json.state }}'}],
             "brightness":true,
             "brightness_scale":254,
-            "color_mode":true,
             "command_topic":"zigbee2mqtt/ha_discovery_group/set",
             "device":{
                "identifiers":["zigbee2mqtt_1221051039810110150109113116116_9"],
@@ -2030,7 +2025,6 @@ describe('HomeAssistant extension', () => {
             ],
             "brightness":true,
             "brightness_scale":254,
-            "color_mode":true,
             "command_topic":"zigbee2mqtt/bulb/set",
             "device":{
                "identifiers":[


### PR DESCRIPTION
Removes the Home Assistant `color_mode: true` from the discovery payload which was deprecated in https://github.com/home-assistant/core/pull/111676 . Shouldn't cause a breaking change since it was not used anymore, from https://github.com/home-assistant/core/pull/111676:

> The color_mode flag is not used anymore, and should be removed.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/21982