### PR TITLE
feat: Mark EZSP adapter as deprecated

### DIFF
--- a/test/stub/zigbeeHerdsman.js
+++ b/test/stub/zigbeeHerdsman.js
@@ -219,6 +219,7 @@ const mock = {
     touchlinkScan: jest.fn(),
     touchlinkIdentify: jest.fn(),
     start: jest.fn(),
+    getAdapterName: () => "",
     backup: jest.fn(),
     coordinatorCheck: jest.fn(),
     isStopping: jest.fn(),


### PR DESCRIPTION
The `ezsp` adapter is now deprecated, people should switch over to `ember` (see https://github.com/Koenkk/zigbee2mqtt/discussions/21462).

This PR warns people every hour that they are using a deprecated adapter.

Requires https://github.com/Koenkk/zigbee-herdsman/pull/1038

CC: @kirovilya @Nerivec 