### PR TITLE
--no-rebase on git pull

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -28,7 +28,7 @@ echo "Checking out changes to package-lock.json..."
 git checkout package-lock.json
 
 echo "Updating..."
-git pull
+git pull --no-rebase
 
 echo "Installing dependencies..."
 npm ci


### PR DESCRIPTION
Pulling without specifying how to reconcile divergent branches is discouraged and produces an ugly "hint" that can be a little disconcerting when running update.sh