### PR TITLE
feat: add support for ingress multiplath

### DIFF
--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'charts/**'
+  workflow_dispatch:
 
 jobs:
   release:

--- a/charts/zigbee2mqtt/templates/ingress.yaml
+++ b/charts/zigbee2mqtt/templates/ingress.yaml
@@ -26,31 +26,20 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-  {{- if .Values.ingress.hosts  }}
   {{- range .Values.ingress.hosts }}
-    - host: {{ tpl . $ | quote }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ $ingressPath }}
-            pathType: {{ $ingressPathType }}
+          {{- range .paths }}
+          - path: {{ .path }}
+           {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $servicePort }}
+          {{- end }}
   {{- end }}
-  {{- else }}
-    - http:
-        paths:
-          - backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $servicePort }}
-            {{- with $ingressPath }}
-            path: {{ . }}
-            {{- end }}
-            pathType: {{ $ingressPathType }}
-
-  {{- end -}}
 {{- end }}

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -178,24 +178,30 @@ zigbee2mqtt:
     # In case you are having issues try `200`.
     # For more information see https://github.com/Koenkk/zigbee2mqtt/issues/4884
     adapter_delay: 0
+# -- Ingress configuration. Zigbee2mqtt does use webssockets, which is not part of the Ingress standart settings.
+# most of the popular ingresses supports them through annotations. Please check https://www.zigbee2mqtt.io/guide/installation/08_kubernetes.html
+# for examples.
 ingress:
   # -- When enabled a new Ingress will be created
   enabled: false
-  # The ingress class name for the ingress
+  # -- The ingress class name for the ingress
   ingressClassName: contour
-  # Additional labels for the ingres
+  # -- Additional labels for the ingres
   labels: {}
-  # URL in which the ingress will be accepting requests for zigbee2mqtt
-  path: /
-  # Ingress implementation specific (potentially) for most use cases Prefix should be ok
+  # -- Ingress implementation specific (potentially) for most use cases Prefix should be ok
   pathType: Prefix
   # Additional annotations for the ingress. ExternalDNS, and CertManager are tipically integrated here
-  annotations: {}
-  # configuration for tls service (ig any)
+  annotations: { }
+  # -- list of hosts that should be allowed for the zigbee2mqtt service
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+        - path: /api
+          pathType: ImplementationSpecific
+  # -- configuration for tls service (ig any)
   tls:
     - secretName: some-tls-secret
       hosts:
         - yourdomain.com
-  # list of hosts that should be allowed for the zigbee2mqtt service
-  hosts:
-    - yourdomain.com


### PR DESCRIPTION
Hi @Koenkk 

I thing the chart is ready to be released, i did the full process on my fork.

Index is available (in my fork) : https://jlpedrosa.github.io/zigbee2mqtt/index.yaml
Package can be downloaded and installed: 
```
zigbee2mqtt            29m   True    Helm install succeeded for release homeassistant/homeassistant-zigbee2mqtt.v1 with chart zigbee2mqtt@1.37.1
```

Deployment seems to work just fine:
![image](https://github.com/Koenkk/zigbee2mqtt/assets/4932947/e2aac9ce-2888-46ea-8a76-783b2416e7ad)
