### PR TITLE
Helm chart - Ingress notes

### DIFF
--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'charts/**'
+  workflow_dispatch:
 
 jobs:
   release:

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -178,6 +178,9 @@ zigbee2mqtt:
     # In case you are having issues try `200`.
     # For more information see https://github.com/Koenkk/zigbee2mqtt/issues/4884
     adapter_delay: 0
+# -- Ingress configuration. Zigbee2mqtt does use webssockets, which is not part of the Ingress standart settings.
+# most of the popular ingresses supports them through annotations. Please check https://www.zigbee2mqtt.io/guide/installation/08_kubernetes.html
+# for examples.
 ingress:
   # -- When enabled a new Ingress will be created
   enabled: false

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -181,21 +181,21 @@ zigbee2mqtt:
 ingress:
   # -- When enabled a new Ingress will be created
   enabled: false
-  # The ingress class name for the ingress
+  # -- The ingress class name for the ingress
   ingressClassName: contour
-  # Additional labels for the ingres
+  # -- Additional labels for the ingres
   labels: {}
-  # URL in which the ingress will be accepting requests for zigbee2mqtt
+  # -- URL in which the ingress will be accepting requests for zigbee2mqtt
   path: /
-  # Ingress implementation specific (potentially) for most use cases Prefix should be ok
+  # -- Ingress implementation specific (potentially) for most use cases Prefix should be ok
   pathType: Prefix
   # Additional annotations for the ingress. ExternalDNS, and CertManager are tipically integrated here
   annotations: {}
-  # configuration for tls service (ig any)
+  # -- configuration for tls service (ig any)
   tls:
     - secretName: some-tls-secret
       hosts:
         - yourdomain.com
-  # list of hosts that should be allowed for the zigbee2mqtt service
+  # -- list of hosts that should be allowed for the zigbee2mqtt service
   hosts:
     - yourdomain.com


### PR DESCRIPTION
Add notes about ingress + websockets:
```
# -- Ingress configuration. Zigbee2mqtt does use webssockets, which is not part of the Ingress standart settings.
# most of the popular ingresses supports them through annotations. Please check https://www.zigbee2mqtt.io/guide/installation/08_kubernetes.html
# for examples.
```