### PR TITLE
feat: add api for device re-interview

### DIFF
--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -40,7 +40,7 @@ export default class Bridge extends Extension {
             'device/options': this.deviceOptions,
             'device/configure_reporting': this.deviceConfigureReporting,
             'device/remove': this.deviceRemove,
-            'device/reinterview': this.deviceReinterview,
+            'device/interview': this.deviceInterview,
             'device/generate_external_definition': this.deviceGenerateExternalDefinition,
             'device/rename': this.deviceRename,
             'group/add': this.groupAdd,
@@ -501,7 +501,7 @@ export default class Bridge extends Extension {
         }, null);
     }
 
-    @bind async deviceReinterview(message: string | KeyValue): Promise<MQTTResponse> {
+    @bind async deviceInterview(message: string | KeyValue): Promise<MQTTResponse> {
         if (typeof message !== 'object' || !message.hasOwnProperty('id')) {
             throw new Error(`Invalid payload`);
         }
@@ -512,7 +512,7 @@ export default class Bridge extends Extension {
         try {
             await device.zh.interview();
         } catch (error) {
-            throw new Error(`re-interview of '${device.name}' (${device.ieeeAddr}) failed: ${error}`, {cause: error});
+            throw new Error(`interview of '${device.name}' (${device.ieeeAddr}) failed: ${error}`, {cause: error});
         }
 
         return utils.getResponse(message, {id: message.id}, null);

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -515,6 +515,9 @@ export default class Bridge extends Extension {
             throw new Error(`interview of '${device.name}' (${device.ieeeAddr}) failed: ${error}`, {cause: error});
         }
 
+        // publish devices so that the front-end has up-to-date info.
+        await this.publishDevices();
+
         return utils.getResponse(message, {id: message.id}, null);
     }
 

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -40,6 +40,7 @@ export default class Bridge extends Extension {
             'device/options': this.deviceOptions,
             'device/configure_reporting': this.deviceConfigureReporting,
             'device/remove': this.deviceRemove,
+            'device/reinterview': this.deviceReinterview,
             'device/generate_external_definition': this.deviceGenerateExternalDefinition,
             'device/rename': this.deviceRename,
             'group/add': this.groupAdd,
@@ -498,6 +499,23 @@ export default class Bridge extends Extension {
             minimum_report_interval: message.minimum_report_interval, reportable_change: message.reportable_change,
             attribute: message.attribute,
         }, null);
+    }
+
+    @bind async deviceReinterview(message: string | KeyValue): Promise<MQTTResponse> {
+        if (typeof message !== 'object' || !message.hasOwnProperty('id')) {
+            throw new Error(`Invalid payload`);
+        }
+
+        const device = this.zigbee.resolveEntityAndEndpoint(message.id).entity as Device;
+        if (!device) throw new Error(`Device '${message.id}' does not exist`);
+
+        try {
+            await device.zh.interview();
+        } catch (error) {
+            throw new Error(`re-interview of '${device.name}' (${device.ieeeAddr}) failed: ${error}`, {cause: error});
+        }
+
+        return utils.getResponse(message, {id: message.id}, null);
     }
 
     @bind async deviceGenerateExternalDefinition(message: string | KeyValue): Promise<MQTTResponse> {

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -506,8 +506,7 @@ export default class Bridge extends Extension {
             throw new Error(`Invalid payload`);
         }
 
-        const device = this.zigbee.resolveEntityAndEndpoint(message.id).entity as Device;
-        if (!device) throw new Error(`Device '${message.id}' does not exist`);
+        const device = this.getEntity('device', message.id) as Device;
 
         try {
             await device.zh.interview();

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -739,6 +739,13 @@ describe('Bridge', () => {
             stringify({"data":{"id":"bulb"},"status":"ok"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
+
+        // The following indicates that devices have published.
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'zigbee2mqtt/bridge/devices',
+            expect.any(String),
+            {retain: true, qos: 0}, expect.any(Function)
+        );
     });
 
     it('Should throw error on invalid device interview payload', async () => {

--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -728,50 +728,50 @@ describe('Bridge', () => {
         );
     });
 
-    it('Should allow reinterviewing a device', async () => {
+    it('Should allow interviewing a device', async () => {
         MQTT.publish.mockClear();
         zigbeeHerdsman.devices.bulb.interview.mockClear();
-        MQTT.events.message('zigbee2mqtt/bridge/request/device/reinterview', stringify({id: 'bulb'}));
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/interview', stringify({id: 'bulb'}));
         await flushPromises();
         expect(zigbeeHerdsman.devices.bulb.interview).toHaveBeenCalled();
         expect(MQTT.publish).toHaveBeenCalledWith(
-            'zigbee2mqtt/bridge/response/device/reinterview',
+            'zigbee2mqtt/bridge/response/device/interview',
             stringify({"data":{"id":"bulb"},"status":"ok"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
     });
 
-    it('Should throw error on invalid device reinterview payload', async () => {
+    it('Should throw error on invalid device interview payload', async () => {
         MQTT.publish.mockClear();
-        MQTT.events.message('zigbee2mqtt/bridge/request/device/reinterview', stringify({foo: 'bulb'}));
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/interview', stringify({foo: 'bulb'}));
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledWith(
-            'zigbee2mqtt/bridge/response/device/reinterview',
+            'zigbee2mqtt/bridge/response/device/interview',
             stringify({"data":{},"status":"error","error":"Invalid payload"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
     });
 
-    it('Should throw error on non-existing device reinterview', async () => {
+    it('Should throw error on non-existing device interview', async () => {
         MQTT.publish.mockClear();
-        MQTT.events.message('zigbee2mqtt/bridge/request/device/reinterview', stringify({id: 'bulb_not_existing'}));
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/interview', stringify({id: 'bulb_not_existing'}));
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledWith(
-            'zigbee2mqtt/bridge/response/device/reinterview',
+            'zigbee2mqtt/bridge/response/device/interview',
             stringify({"data":{},"status":"error","error":"Device 'bulb_not_existing' does not exist"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
     });
 
-    it('Should throw error on when reinterview fails', async () => {
+    it('Should throw error on when interview fails', async () => {
         MQTT.publish.mockClear();
         zigbeeHerdsman.devices.bulb.interview.mockClear();
         zigbeeHerdsman.devices.bulb.interview.mockImplementation(() => Promise.reject(new Error('something went wrong')))
-        MQTT.events.message('zigbee2mqtt/bridge/request/device/reinterview', stringify({id: 'bulb'}));
+        MQTT.events.message('zigbee2mqtt/bridge/request/device/interview', stringify({id: 'bulb'}));
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledWith(
-            'zigbee2mqtt/bridge/response/device/reinterview',
-            stringify({"data":{},"status":"error","error":"re-interview of 'bulb' (0x000b57fffec6a5b2) failed: Error: something went wrong"}),
+            'zigbee2mqtt/bridge/response/device/interview',
+            stringify({"data":{},"status":"error","error":"interview of 'bulb' (0x000b57fffec6a5b2) failed: Error: something went wrong"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
     });

--- a/test/stub/zigbeeHerdsman.js
+++ b/test/stub/zigbeeHerdsman.js
@@ -127,6 +127,7 @@ class Device {
         this.softwareBuildID = softwareBuildID;
         this.interviewCompleted = interviewCompleted;
         this.modelID = modelID;
+        this.interview = jest.fn();
         this.interviewing = interviewing;
         this.meta = {};
         this.ping = jest.fn();


### PR DESCRIPTION
- Adds an API that allows for the re-interview of a device. This can be useful a device firmware upgrade adds new device endpoints (as is the case when upgrading an Inovelli VZM31-SN to 2.18). Without the ability to re-interview, one must remove and re-add the device.


Notes: 
- I have only really tested performing device re-interviews via a hand-crafted extension (see [gist](https://gist.github.com/justfalter/fe2e07dfef22c0a99d5e434e9294f48d)). It was as simple as `await someDevice.interview()`. I have not had a chance to this changeset on my system (it's sunday morning and the kids are running around).
- As far as I can tell, this seems to require restarting z2m in order for the UI to reflect any changes picked up by the re-interview. I feel like this might be a matter of having whatever drives the frontend be responsive to device interview events?
- As mentioned, this eliminated the need for me to remove and re-add 18 Inovelli VZM31-SN switches. I reinterviewed the devices, restarted z2m, and all was good in the world.
