### PR TITLE
POC: Allow hierarchical filtering of logger namespaces

### DIFF
--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -157,8 +157,23 @@ class Logger {
         this.namespacedLevels = nsLevels;
     }
 
+    // returns and store the level of the first matching namespace up the hierarchy 
+    private getsetLevel(namespace: string) : string{
+        let ns=namespace;
+        while(true) {
+            if (this.namespacedLevels[ns]) {
+                return this.namespacedLevels[namespace]=this.namespacedLevels[ns];
+            }
+            let sep=ns.lastIndexOf(":");
+            if(sep==-1) {
+                return this.namespacedLevels[namespace]=this.level;
+            }
+            ns=ns.slice(0,sep);
+        }
+    }
+ 
     private log(level: settings.LogLevel, message: string, namespace: string): void {
-        const nsLevel = this.namespacedLevels[namespace] ?? this.level;
+        const nsLevel = this.namespacedLevels[namespace] ?? this.getsetLevel(namespace);
 
         if (settings.LOG_LEVELS.indexOf(level) <= settings.LOG_LEVELS.indexOf(nsLevel)) {
             this.logger.log(level, message, {namespace});

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -57,7 +57,7 @@ class Logger {
             format: winston.format.combine(
                 winston.format.colorize({colors: {debug: 'blue', info: 'green', warning: 'yellow', error: 'red'}}),
                 winston.format.printf(/* istanbul ignore next */(info) => {
-                    return `[${info.timestamp}] ${info.level}: \t${info.namespace}: ${info.message}`;
+                    return `[${info.timestamp}] ${info.level}: \t${info.message}`;
                 }),
             ),
         }));
@@ -84,7 +84,7 @@ class Logger {
             const transportFileOptions: winston.transports.FileTransportOptions = {
                 filename: path.join(this.directory, logFilename),
                 format: winston.format.printf(/* istanbul ignore next */(info) => {
-                    return `[${info.timestamp}] ${info.level}: \t${info.namespace}: ${info.message}`;
+                    return `[${info.timestamp}] ${info.level}: \t${info.message}`;
                 }),
             };
 
@@ -106,9 +106,6 @@ class Logger {
 
             const options: KeyValue = {
                 app_name: 'Zigbee2MQTT',
-                format: winston.format.printf(/* istanbul ignore next */(info) => {
-                    return `${info.namespace}: ${info.message}`;
-                }),
                 ...settings.get().advanced.log_syslog,
             };
 
@@ -188,7 +185,7 @@ class Logger {
         const nsLevel = this.cacheNamespacedLevel(namespace);
 
         if (settings.LOG_LEVELS.indexOf(level) <= settings.LOG_LEVELS.indexOf(nsLevel)) {
-            this.logger.log(level, message, {namespace});
+            this.logger.log(level, `${namespace}: ${message}`);
         }
     }
 

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -182,7 +182,7 @@ class Logger {
     }
 
     private log(level: settings.LogLevel, message: string, namespace: string): void {
-        const nsLevel = this.namespacedLevels[namespace] ?? this.getsetLevel(namespace);
+        const nsLevel = this.cachedNSLevels[namespace] ?? this.getsetLevel(namespace);
 
         if (settings.LOG_LEVELS.indexOf(level) <= settings.LOG_LEVELS.indexOf(nsLevel)) {
             this.logger.log(level, message, {namespace});

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -304,4 +304,40 @@ describe('Logger', () => {
         expect(logSpy).toHaveBeenCalledTimes(3);
         expect(consoleWriteSpy).toHaveBeenCalledTimes(3);
     });
+    it('Logs with namespaced levels hierarchy', () => {
+        logger.setNamespacedLevels({'zh:zstack': 'debug', 'zh:zstack:unpi:writer': 'error'})
+        logger.setLevel('warning');
+
+        const logSpy = jest.spyOn(logger.winston, 'log');
+
+        consoleWriteSpy.mockClear();
+        logger.debug(`--- parseNext [] debug picked from hierarchy`, 'zh:zstack:unpi:parser');
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        expect(consoleWriteSpy).toHaveBeenCalledTimes(1);
+        logger.warning(`--> frame [36,15] warning explicitely supressed`, 'zh:zstack:unpi:writer');
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        expect(consoleWriteSpy).toHaveBeenCalledTimes(1);
+        logger.warning(`Another supressed warning message in a sub namespace`, 'zh:zstack:unpi:writer:sub:ns');
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        expect(consoleWriteSpy).toHaveBeenCalledTimes(1);
+        logger.error(`but error should go through`, 'zh:zstack:unpi:writer:another:sub:ns');
+        expect(logSpy).toHaveBeenCalledTimes(2);
+        expect(consoleWriteSpy).toHaveBeenCalledTimes(2);
+        logger.warning(`new unconfigured namespace warning`, 'z2m:mqtt');
+        expect(logSpy).toHaveBeenCalledTimes(3);
+        expect(consoleWriteSpy).toHaveBeenCalledTimes(3);
+        logger.info(`cached unconfigured namespace info should be supressed`, 'z2m:mqtt');
+        expect(logSpy).toHaveBeenCalledTimes(3);
+        expect(consoleWriteSpy).toHaveBeenCalledTimes(3);
+
+        logger.setLevel('info');
+        logger.info(`unconfigured namespace info should now pass after default level change and cache reset`, 'z2m:mqtt');
+        expect(logSpy).toHaveBeenCalledTimes(4);
+        expect(consoleWriteSpy).toHaveBeenCalledTimes(4);
+        logger.error(`configured namespace hierachy should still work after the cache reset`, 'zh:zstack:unpi:writer:another:sub:ns');
+        expect(logSpy).toHaveBeenCalledTimes(5);
+        expect(consoleWriteSpy).toHaveBeenCalledTimes(5);
+
+	
+    });
 });


### PR DESCRIPTION
When playing with the new  ``log_namespaced_levels`` [#22619](https://github.com/Koenkk/zigbee2mqtt/pull/22619), I expected  that ``'zh:zstack:unpi' :info `` would match all namespaces below, such as ``zh:zstack:unpi:parser`` , writer, etc

This PR implements a quick POC to allow that.
To limit runtime penalty it uses ~the same ``namespacedLevels`` as~  a lazy cache: the first time a new namespace is seen, it tries to find if any namespace above is defined in the config and stores the level, So in effect 
```
advanced:
  log_namespaced_levels:
    'zh:zstack:unpi': info
```
Would also apply to ``zh:zstack:unpi:writer`` , ``zh:zstack:unpi:parser`` and anything else below ``zh:zstack:unpi`` I might not have seen yet. Of course if a more specific config is defined, it would be picked up.

This would allow to add new namespace sublevels without breaking existing configuration, for example ``z2m:mqtt:connexion`` and  ``z2m:mqtt:publish`` 

BUGS / TODOs :

- [x] The default log level cannot be dynamically changed , the cache would need to be reset when the level is changed at runtime
- [x] Fix  logger tests as the namespacedLevels are now filled (no longer necessary)
- [x] Add new tests for the feature
- [x] There is most likely a nicer / more typescripty way for doing this ... expecting @Nerivec to replace that with a one liner (close enough)
- [x] Add a note in the documentation that the config applies to all namespaces below (or not even needed, that was my initial expectation) https://github.com/Koenkk/zigbee2mqtt.io/pull/2786