### PR TITLE
Enforce no floating promises.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,9 +13,10 @@ module.exports = {
     'rules': {
         'require-jsdoc': 'off',
         'indent': ['error', 4],
-        'max-len': ['error', {'code': 120}],
+        'max-len': ['error', {'code': 150}],
         'no-prototype-builtins': 'off',
         'linebreak-style': ['error', (process.platform === 'win32' ? 'windows' : 'unix')], // https://stackoverflow.com/q/39114446/2771889
+        '@typescript-eslint/no-floating-promises': 'error',
     },
     'plugins': [
         'jest',
@@ -38,9 +39,10 @@ module.exports = {
             '@typescript-eslint/semi': ['error'],
             'array-bracket-spacing': ['error', 'never'],
             'indent': ['error', 4],
-            'max-len': ['error', {'code': 120}],
+            'max-len': ['error', {'code': 150}],
             'no-return-await': 'error',
             'object-curly-spacing': ['error', 'never'],
+            '@typescript-eslint/no-floating-promises': 'error',
         },
     }],
 };

--- a/.gitignore
+++ b/.gitignore
@@ -63,18 +63,6 @@ tsconfig.tsbuildinfo
 # dotenv environment variables file
 .env
 
-# data
-data/database.db
-data/config.json
-data/log*.txt
-data/state.json
-data/log
-data-backup/
-data/coordinator_backup.json
-data/.storage
-data/database.db.backup
-data/extension
-
 # MacOS indexing file
 .DS_Store
 
@@ -82,7 +70,7 @@ data/extension
 .idea
 
 # Ignore config
-data/*.yaml
+data/*
 !data/configuration.example.yaml
 
 # commit-user-lookup.json

--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -122,7 +122,7 @@ export class Controller {
             settings.set(['advanced', 'legacy_api'], false);
             settings.set(['advanced', 'legacy_availability_payload'], false);
             settings.set(['device_options', 'legacy'], false);
-            this.enableDisableExtension(false, 'BridgeLegacy');
+            await this.enableDisableExtension(false, 'BridgeLegacy');
         }
 
         // Log zigbee clients on startup
@@ -164,7 +164,7 @@ export class Controller {
         if (settings.get().advanced.cache_state_send_on_startup && settings.get().advanced.cache_state) {
             for (const entity of [...devices, ...this.zigbee.groups()]) {
                 if (this.state.exists(entity)) {
-                    this.publishEntityState(entity, this.state.get(entity), 'publishCached');
+                    await this.publishEntityState(entity, this.state.get(entity), 'publishCached');
                 }
             }
         }

--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -285,7 +285,7 @@ export default class Bind extends Extension {
 
                         /* istanbul ignore else */
                         if (settings.get().advanced.legacy_api) {
-                            this.mqtt.publish(
+                            await this.mqtt.publish(
                                 'bridge/log',
                                 stringify({type: `device_${type}`,
                                     message: {from: source.name, to: target.name, cluster}}),
@@ -300,7 +300,7 @@ export default class Bind extends Extension {
 
                         /* istanbul ignore else */
                         if (settings.get().advanced.legacy_api) {
-                            this.mqtt.publish(
+                            await this.mqtt.publish(
                                 'bridge/log',
                                 stringify({type: `device_${type}_failed`,
                                     message: {from: source.name, to: target.name, cluster}}),
@@ -316,7 +316,7 @@ export default class Bind extends Extension {
 
                 /* istanbul ignore else */
                 if (settings.get().advanced.legacy_api) {
-                    this.mqtt.publish(
+                    await this.mqtt.publish(
                         'bridge/log',
                         stringify({type: `device_${type}_failed`, message: {from: source.name, to: target.name}}),
                     );

--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -39,7 +39,7 @@ export default class Configure extends Extension {
                 return;
             }
 
-            this.configure(device, 'mqtt_message', true);
+            await this.configure(device, 'mqtt_message', true);
         } else if (data.topic === this.topic) {
             const message = utils.parseJSON(data.message, data.message);
             const ID = typeof message === 'object' && message.hasOwnProperty('id') ? message.id : message;
@@ -75,13 +75,13 @@ export default class Configure extends Extension {
             }
         });
 
-        this.eventBus.onDeviceJoined(this, (data) => {
+        this.eventBus.onDeviceJoined(this, async (data) => {
             if (data.device.zh.meta.hasOwnProperty('configured')) {
                 delete data.device.zh.meta.configured;
                 data.device.zh.save();
             }
 
-            this.configure(data.device, 'zigbee_event');
+            await this.configure(data.device, 'zigbee_event');
         });
         this.eventBus.onDeviceInterview(this, (data) => this.configure(data.device, 'zigbee_event'));
         this.eventBus.onLastSeenChanged(this, (data) => this.configure(data.device, 'zigbee_event'));

--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -87,7 +87,7 @@ export default class Frontend extends Extension {
     }
 
     override async stop(): Promise<void> {
-        super.stop();
+        await super.stop();
         this.wss?.clients.forEach((client) => {
             client.send(stringify({topic: 'bridge/state', payload: 'offline'}));
             client.terminate();

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -152,8 +152,8 @@ export default class HomeAssistant extends Extension {
         this.eventBus.onDeviceInterview(this, this.onZigbeeEvent);
         this.eventBus.onDeviceMessage(this, this.onZigbeeEvent);
         this.eventBus.onScenesChanged(this, this.onScenesChanged);
-        this.eventBus.onEntityOptionsChanged(this, (data) => this.discover(data.entity));
-        this.eventBus.onExposesChanged(this, (data) => this.discover(data.device));
+        this.eventBus.onEntityOptionsChanged(this, async (data) => this.discover(data.entity));
+        this.eventBus.onExposesChanged(this, async (data) => this.discover(data.device));
 
         this.mqtt.subscribe(this.statusTopic);
         this.mqtt.subscribe(defaultStatusTopic);
@@ -166,13 +166,19 @@ export default class HomeAssistant extends Extension {
         const discoverWait = 5;
         // Discover with `published = false`, this will populate `this.discovered` without publishing the discoveries.
         // This is needed for clearing outdated entries in `this.onMQTTMessage()`
-        [this.bridge, ...this.zigbee.devices(false), ...this.zigbee.groups()].forEach((e) => this.discover(e, false));
+        for (const e of [this.bridge, ...this.zigbee.devices(false), ...this.zigbee.groups()]) {
+            await this.discover(e, false);
+        }
+
         logger.debug(`Discovering entities to Home Assistant in ${discoverWait}s`);
         this.mqtt.subscribe(`${this.discoveryTopic}/#`);
-        setTimeout(() => {
+        setTimeout(async () => {
             this.mqtt.unsubscribe(`${this.discoveryTopic}/#`);
             logger.debug(`Discovering entities to Home Assistant`);
-            [this.bridge, ...this.zigbee.devices(false), ...this.zigbee.groups()].forEach((e) => this.discover(e));
+
+            for (const e of [this.bridge, ...this.zigbee.devices(false), ...this.zigbee.groups()]) {
+                await this.discover(e);
+            }
         }, utils.seconds(discoverWait));
 
         // Send availability messages, this is required if the legacy_availability_payload option has been changed.
@@ -1134,18 +1140,19 @@ export default class HomeAssistant extends Extension {
         return discoveryEntries;
     }
 
-    @bind onDeviceRemoved(data: eventdata.DeviceRemoved): void {
+    @bind async onDeviceRemoved(data: eventdata.DeviceRemoved): Promise<void> {
         logger.debug(`Clearing Home Assistant discovery for '${data.name}'`);
         const discovered = this.getDiscovered(data.ieeeAddr);
-        Object.keys(discovered.messages).forEach(async (topic) => {
+
+        for (const topic of Object.keys(discovered.messages)) {
             await this.mqtt.publish(topic, null, {retain: true, qos: 1}, this.discoveryTopic, false, false);
-        });
+        }
 
         delete this.discovered[data.ieeeAddr];
     }
 
-    @bind onGroupMembersChanged(data: eventdata.GroupMembersChanged): void {
-        this.discover(data.group);
+    @bind async onGroupMembersChanged(data: eventdata.GroupMembersChanged): Promise<void> {
+        await this.discover(data.group);
     }
 
     @bind async onPublishEntityState(data: eventdata.PublishEntityState): Promise<void> {
@@ -1159,7 +1166,7 @@ export default class HomeAssistant extends Extension {
          */
         const entity = this.zigbee.resolveEntity(data.entity.name);
         if (entity.isDevice()) {
-            Object.keys(this.getDiscovered(entity).messages).forEach(async (topic) => {
+            for (const topic of Object.keys(this.getDiscovered(entity).messages)) {
                 const objectID = topic.match(this.discoveryRegexWoTopic)?.[3];
                 const lightMatch = /^light_(.*)/.exec(objectID);
                 const coverMatch = /^cover_(.*)/.exec(objectID);
@@ -1179,7 +1186,7 @@ export default class HomeAssistant extends Extension {
 
                     await this.mqtt.publish(`${data.entity.name}/${endpoint}`, stringify(payload), {});
                 }
-            });
+            }
         }
 
         /**
@@ -1227,7 +1234,7 @@ export default class HomeAssistant extends Extension {
             await utils.sleep(2);
         }
 
-        this.discover(data.entity);
+        await this.discover(data.entity);
 
         if (data.entity.isDevice()) {
             for (const config of this.getDiscovered(data.entity).triggers) {
@@ -1414,7 +1421,7 @@ export default class HomeAssistant extends Extension {
         return configs;
     }
 
-    private discover(entity: Device | Group | Bridge, publish: boolean = true): void {
+    private async discover(entity: Device | Group | Bridge, publish: boolean = true): Promise<void> {
         // Handle type differences.
         const isDevice = entity.isDevice();
         const isGroup = entity.isGroup();
@@ -1428,9 +1435,10 @@ export default class HomeAssistant extends Extension {
 
         const discovered = this.getDiscovered(entity);
         discovered.discovered = true;
-        const lastDiscoverdTopics = Object.keys(discovered.messages);
+        const lastDiscoveredTopics = Object.keys(discovered.messages);
         const newDiscoveredTopics: Set<string> = new Set();
-        this.getConfigs(entity).forEach(async (config) => {
+
+        for (const config of this.getConfigs(entity)) {
             const payload = {...config.discovery_payload};
             const baseTopic = `${settings.get().mqtt.base_topic}/${entity.name}`;
             let stateTopic = baseTopic;
@@ -1604,7 +1612,7 @@ export default class HomeAssistant extends Extension {
             }
 
             // Override configuration with user settings.
-            if (entity.options.hasOwnProperty('homeassistant')) {
+            if (entity.options.homeassistant != undefined) {
                 const add = (obj: KeyValue, ignoreName: boolean): void => {
                     Object.keys(obj).forEach((key) => {
                         if (['type', 'object_id'].includes(key)) {
@@ -1626,7 +1634,7 @@ export default class HomeAssistant extends Extension {
 
                 add(entity.options.homeassistant, true);
 
-                if (entity.options.homeassistant.hasOwnProperty(config.object_id)) {
+                if (entity.options.homeassistant[config.object_id] != undefined) {
                     add(entity.options.homeassistant[config.object_id], false);
                 }
             }
@@ -1646,13 +1654,14 @@ export default class HomeAssistant extends Extension {
                 logger.debug(`Skipping discovery of '${topic}', already discovered`);
             }
             config.mockProperties?.forEach((mockProperty) => discovered.mockProperties.add(mockProperty));
-        });
-        lastDiscoverdTopics.forEach(async (topic) => {
+        }
+
+        for (const topic of lastDiscoveredTopics) {
             const isDeviceAutomation = topic.match(this.discoveryRegexWoTopic)[1] === 'device_automation';
             if (!newDiscoveredTopics.has(topic) && !isDeviceAutomation) {
                 await this.mqtt.publish(topic, null, {retain: true, qos: 1}, this.discoveryTopic, false, false);
             }
-        });
+        }
     }
 
     @bind private async onMQTTMessage(data: eventdata.MQTTMessage): Promise<void> {
@@ -1719,9 +1728,9 @@ export default class HomeAssistant extends Extension {
         }
     }
 
-    @bind onZigbeeEvent(data: {device: Device}): void {
+    @bind async onZigbeeEvent(data: {device: Device}): Promise<void> {
         if (!this.getDiscovered(data.device).discovered) {
-            this.discover(data.device);
+            await this.discover(data.device);
         }
     }
 
@@ -1731,12 +1740,13 @@ export default class HomeAssistant extends Extension {
         // First, clear existing scene discovery topics
         logger.debug(`Clearing Home Assistant scene discovery for '${data.entity.name}'`);
         const discovered = this.getDiscovered(data.entity);
-        Object.keys(discovered.messages).forEach(async (topic) => {
+
+        for (const topic of Object.keys(discovered.messages)) {
             if (topic.startsWith('scene')) {
                 await this.mqtt.publish(topic, null, {retain: true, qos: 1}, this.discoveryTopic, false, false);
                 delete discovered.messages[topic];
             }
-        });
+        }
 
         // Make sure Home Assistant deletes the old entity first otherwise another one (_2) is created
         // https://github.com/Koenkk/zigbee2mqtt/issues/12610
@@ -1745,7 +1755,7 @@ export default class HomeAssistant extends Extension {
 
         // Re-discover entity (including any new scenes).
         logger.debug(`Re-discovering entities with their scenes.`);
-        this.discover(data.entity);
+        await this.discover(data.entity);
     }
 
     private getDevicePayload(entity: Device | Group | Bridge): KeyValue {

--- a/lib/extension/legacy/bridgeLegacy.ts
+++ b/lib/extension/legacy/bridgeLegacy.ts
@@ -45,13 +45,13 @@ export default class BridgeLegacy extends Extension {
         await this.publish();
     }
 
-    @bind whitelist(topic: string, message: string): void {
+    @bind async whitelist(topic: string, message: string): Promise<void> {
         try {
             const entity = settings.getDevice(message);
             assert(entity, `Entity '${message}' does not exist`);
             settings.addDeviceToPasslist(entity.ID.toString());
             logger.info(`Whitelisted '${entity.friendly_name}'`);
-            this.mqtt.publish(
+            await this.mqtt.publish(
                 'bridge/log',
                 stringify({type: 'device_whitelisted', message: {friendly_name: entity.friendly_name}}),
             );
@@ -82,7 +82,7 @@ export default class BridgeLegacy extends Extension {
 
     @bind async permitJoin(topic: string, message: string): Promise<void> {
         await this.zigbee.permitJoin(message.toLowerCase() === 'true');
-        this.publish();
+        await this.publish();
     }
 
     @bind async reset(): Promise<void> {
@@ -116,7 +116,7 @@ export default class BridgeLegacy extends Extension {
         logger.info(`Set elapsed to ${message}`);
     }
 
-    @bind logLevel(topic: string, message: string): void {
+    @bind async logLevel(topic: string, message: string): Promise<void> {
         const level = message.toLowerCase() as settings.LogLevel;
         if (settings.LOG_LEVELS.includes(level)) {
             logger.info(`Switching log level to '${level}'`);
@@ -125,7 +125,7 @@ export default class BridgeLegacy extends Extension {
             logger.error(`Could not set log level to '${level}'. Allowed level: '${settings.LOG_LEVELS.join(',')}'`);
         }
 
-        this.publish();
+        await this.publish();
     }
 
     @bind async devices(topic: string): Promise<void> {
@@ -162,23 +162,23 @@ export default class BridgeLegacy extends Extension {
         });
 
         if (topic.split('/').pop() == 'get') {
-            this.mqtt.publish(
+            await this.mqtt.publish(
                 `bridge/config/devices`, stringify(devices), {}, settings.get().mqtt.base_topic, false, false,
             );
         } else {
-            this.mqtt.publish('bridge/log', stringify({type: 'devices', message: devices}));
+            await this.mqtt.publish('bridge/log', stringify({type: 'devices', message: devices}));
         }
     }
 
-    @bind groups(): void {
+    @bind async groups(): Promise<void> {
         const payload = settings.getGroups().map((g) => {
             return {...g, ID: Number(g.ID)};
         });
 
-        this.mqtt.publish('bridge/log', stringify({type: 'groups', message: payload}));
+        await this.mqtt.publish('bridge/log', stringify({type: 'groups', message: payload}));
     }
 
-    @bind rename(topic: string, message: string): void {
+    @bind async rename(topic: string, message: string): Promise<void> {
         const invalid =
             `Invalid rename message format expected {"old": "friendly_name", "new": "new_name"} got ${message}`;
 
@@ -196,19 +196,19 @@ export default class BridgeLegacy extends Extension {
             return;
         }
 
-        this._renameInternal(json.old, json.new);
+        await this._renameInternal(json.old, json.new);
     }
 
-    @bind renameLast(topic: string, message: string): void {
+    @bind async renameLast(topic: string, message: string): Promise<void> {
         if (!this.lastJoinedDeviceName) {
             logger.error(`Cannot rename last joined device, no device has joined during this session`);
             return;
         }
 
-        this._renameInternal(this.lastJoinedDeviceName, message);
+        await this._renameInternal(this.lastJoinedDeviceName, message);
     }
 
-    _renameInternal(from: string, to: string): void {
+    async _renameInternal(from: string, to: string): Promise<void> {
         try {
             const isGroup = settings.getGroup(from) !== null;
             settings.changeFriendlyName(from, to);
@@ -218,7 +218,7 @@ export default class BridgeLegacy extends Extension {
                 this.eventBus.emitEntityRenamed({homeAssisantRename: false, from, to, entity});
             }
 
-            this.mqtt.publish(
+            await this.mqtt.publish(
                 'bridge/log',
                 stringify({type: `${isGroup ? 'group' : 'device'}_renamed`, message: {from, to}}),
             );
@@ -227,7 +227,7 @@ export default class BridgeLegacy extends Extension {
         }
     }
 
-    @bind addGroup(topic: string, message: string): void {
+    @bind async addGroup(topic: string, message: string): Promise<void> {
         let id = null;
         let name = null;
         try {
@@ -252,11 +252,11 @@ export default class BridgeLegacy extends Extension {
 
         const group = settings.addGroup(name, id);
         this.zigbee.createGroup(group.ID);
-        this.mqtt.publish('bridge/log', stringify({type: `group_added`, message: name}));
+        await this.mqtt.publish('bridge/log', stringify({type: `group_added`, message: name}));
         logger.info(`Added group '${name}'`);
     }
 
-    @bind removeGroup(topic: string, message: string): void {
+    @bind async removeGroup(topic: string, message: string): Promise<void> {
         const name = message;
         const entity = this.zigbee.resolveEntity(message) as Group;
         assert(entity && entity.isGroup(), `Group '${message}' does not exist`);
@@ -264,11 +264,11 @@ export default class BridgeLegacy extends Extension {
         if (topic.includes('force')) {
             entity.zh.removeFromDatabase();
         } else {
-            entity.zh.removeFromNetwork();
+            await entity.zh.removeFromNetwork();
         }
         settings.removeGroup(message);
 
-        this.mqtt.publish('bridge/log', stringify({type: `group_removed`, message}));
+        await this.mqtt.publish('bridge/log', stringify({type: `group_removed`, message}));
         logger.info(`Removed group '${name}'`);
     }
 
@@ -295,14 +295,14 @@ export default class BridgeLegacy extends Extension {
         if (!entity) {
             logger.error(`Cannot ${lookup[action][2]}, device '${message}' does not exist`);
 
-            this.mqtt.publish('bridge/log', stringify({type: `device_${lookup[action][0]}_failed`, message}));
+            await this.mqtt.publish('bridge/log', stringify({type: `device_${lookup[action][0]}_failed`, message}));
             return;
         }
 
         const ieeeAddr = entity.ieeeAddr;
         const name = entity.name;
 
-        const cleanup = (): void => {
+        const cleanup = async (): Promise<void> => {
             // Fire event
             this.eventBus.emitDeviceRemoved({ieeeAddr, name});
 
@@ -313,7 +313,7 @@ export default class BridgeLegacy extends Extension {
             this.state.remove(ieeeAddr);
 
             logger.info(`Successfully ${lookup[action][0]} ${entity.name}`);
-            this.mqtt.publish('bridge/log', stringify({type: `device_${lookup[action][0]}`, message}));
+            await this.mqtt.publish('bridge/log', stringify({type: `device_${lookup[action][0]}`, message}));
         };
 
         try {
@@ -324,13 +324,13 @@ export default class BridgeLegacy extends Extension {
                 await entity.zh.removeFromNetwork();
             }
 
-            cleanup();
+            await cleanup();
         } catch (error) {
             logger.error(`Failed to ${lookup[action][2]} ${entity.name} (${error})`);
             // eslint-disable-next-line
             logger.error(`See https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html#zigbee2mqtt-bridge-request for more info`);
 
-            this.mqtt.publish('bridge/log', stringify({type: `device_${lookup[action][0]}_failed`, message}));
+            await this.mqtt.publish('bridge/log', stringify({type: `device_${lookup[action][0]}_failed`, message}));
         }
 
         if (action === 'ban') {
@@ -371,13 +371,13 @@ export default class BridgeLegacy extends Extension {
         await this.mqtt.publish(topic, stringify(payload), {retain: true, qos: 0});
     }
 
-    onZigbeeEvent_(type: string, data: KeyValue, resolvedEntity: Device): void {
+    async onZigbeeEvent_(type: string, data: KeyValue, resolvedEntity: Device): Promise<void> {
         if (type === 'deviceJoined' && resolvedEntity) {
             this.lastJoinedDeviceName = resolvedEntity.name;
         }
 
         if (type === 'deviceJoined') {
-            this.mqtt.publish(
+            await this.mqtt.publish(
                 'bridge/log',
                 stringify({type: `device_connected`, message: {friendly_name: resolvedEntity.name}}),
             );
@@ -386,20 +386,20 @@ export default class BridgeLegacy extends Extension {
                 if (resolvedEntity.isSupported) {
                     const {vendor, description, model} = resolvedEntity.definition;
                     const log = {friendly_name: resolvedEntity.name, model, vendor, description, supported: true};
-                    this.mqtt.publish(
+                    await this.mqtt.publish(
                         'bridge/log',
                         stringify({type: `pairing`, message: 'interview_successful', meta: log}),
                     );
                 } else {
                     const meta = {friendly_name: resolvedEntity.name, supported: false};
-                    this.mqtt.publish(
+                    await this.mqtt.publish(
                         'bridge/log',
                         stringify({type: `pairing`, message: 'interview_successful', meta}),
                     );
                 }
             } else if (data.status === 'failed') {
                 const meta = {friendly_name: resolvedEntity.name};
-                this.mqtt.publish(
+                await this.mqtt.publish(
                     'bridge/log',
                     stringify({type: `pairing`, message: 'interview_failed', meta}),
                 );
@@ -407,7 +407,7 @@ export default class BridgeLegacy extends Extension {
                 /* istanbul ignore else */
                 if (data.status === 'started') {
                     const meta = {friendly_name: resolvedEntity.name};
-                    this.mqtt.publish(
+                    await this.mqtt.publish(
                         'bridge/log',
                         stringify({type: `pairing`, message: 'interview_started', meta}),
                     );
@@ -415,13 +415,13 @@ export default class BridgeLegacy extends Extension {
             }
         } else if (type === 'deviceAnnounce') {
             const meta = {friendly_name: resolvedEntity.name};
-            this.mqtt.publish('bridge/log', stringify({type: `device_announced`, message: 'announce', meta}));
+            await this.mqtt.publish('bridge/log', stringify({type: `device_announced`, message: 'announce', meta}));
         } else {
             /* istanbul ignore else */
             if (type === 'deviceLeave') {
                 const name = data.ieeeAddr;
                 const meta = {friendly_name: name};
-                this.mqtt.publish(
+                await this.mqtt.publish(
                     'bridge/log',
                     stringify({type: `device_removed`, message: 'left_network', meta}),
                 );
@@ -431,7 +431,7 @@ export default class BridgeLegacy extends Extension {
 
     @bind async touchlinkFactoryReset(): Promise<void> {
         logger.info('Starting touchlink factory reset...');
-        this.mqtt.publish(
+        await this.mqtt.publish(
             'bridge/log',
             stringify({type: `touchlink`, message: 'reset_started', meta: {status: 'started'}}),
         );
@@ -439,13 +439,13 @@ export default class BridgeLegacy extends Extension {
 
         if (result) {
             logger.info('Successfully factory reset device through Touchlink');
-            this.mqtt.publish(
+            await this.mqtt.publish(
                 'bridge/log',
                 stringify({type: `touchlink`, message: 'reset_success', meta: {status: 'success'}}),
             );
         } else {
             logger.warning('Failed to factory reset device through Touchlink');
-            this.mqtt.publish(
+            await this.mqtt.publish(
                 'bridge/log',
                 stringify({type: `touchlink`, message: 'reset_failed', meta: {status: 'failed'}}),
             );

--- a/lib/extension/legacy/deviceGroupMembership.ts
+++ b/lib/extension/legacy/deviceGroupMembership.ts
@@ -56,6 +56,6 @@ export default class DeviceGroupMembership extends Extension {
         }
         logger.info(`${msgGroupList} and ${msgCapacity}`);
 
-        this.publishEntityState(device, {group_list: grouplist, group_capacity: capacity});
+        await this.publishEntityState(device, {group_list: grouplist, group_capacity: capacity});
     }
 }

--- a/lib/extension/networkMap.ts
+++ b/lib/extension/networkMap.ts
@@ -47,7 +47,7 @@ export default class NetworkMap extends Extension {
                 const topology = await this.networkScan(includeRoutes);
                 let converted = this.supportedFormats[data.message](topology);
                 converted = data.message === 'raw' ? stringify(converted) : converted;
-                this.mqtt.publish(`bridge/networkmap/${data.message}`, converted as string, {});
+                await this.mqtt.publish(`bridge/networkmap/${data.message}`, converted as string, {});
             }
         }
 

--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -7,7 +7,7 @@ import Extension from './extension';
 export default class OnEvent extends Extension {
     override async start(): Promise<void> {
         for (const device of this.zigbee.devices(false)) {
-            this.callOnEvent(device, 'start', {});
+            await this.callOnEvent(device, 'start', {});
         }
 
         this.eventBus.onDeviceMessage(this, (data) => this.callOnEvent(data.device, 'message', this.convertData(data)));
@@ -20,9 +20,9 @@ export default class OnEvent extends Extension {
         this.eventBus.onDeviceNetworkAddressChanged(this,
             (data) => this.callOnEvent(data.device, 'deviceNetworkAddressChanged', this.convertData(data)));
         this.eventBus.onEntityOptionsChanged(this,
-            (data) => {
+            async (data) => {
                 if (data.entity.isDevice()) {
-                    this.callOnEvent(data.entity, 'deviceOptionsChanged', data)
+                    await this.callOnEvent(data.entity, 'deviceOptionsChanged', data)
                         .then(() => this.eventBus.emitDevicesChanged());
                 }
             });
@@ -33,7 +33,7 @@ export default class OnEvent extends Extension {
     }
 
     override async stop(): Promise<void> {
-        super.stop();
+        await super.stop();
         for (const device of this.zigbee.devices(false)) {
             await this.callOnEvent(device, 'stop', {});
         }
@@ -41,7 +41,7 @@ export default class OnEvent extends Extension {
 
     private async callOnEvent(device: Device, type: zhc.OnEventType, data: KeyValue): Promise<void> {
         const state = this.state.get(device);
-        zhc.onEvent(type, data, device.zh);
+        await zhc.onEvent(type, data, device.zh);
 
         if (device.definition?.onEvent) {
             const options: KeyValue = device.options;

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -85,10 +85,10 @@ export default class Publish extends Extension {
         }
     }
 
-    legacyLog(payload: KeyValue): void {
+    async legacyLog(payload: KeyValue): Promise<void> {
         /* istanbul ignore else */
         if (settings.get().advanced.legacy_api) {
-            this.mqtt.publish('bridge/log', stringify(payload));
+            await this.mqtt.publish('bridge/log', stringify(payload));
         }
     }
 
@@ -133,7 +133,7 @@ export default class Publish extends Extension {
 
         const re = this.zigbee.resolveEntity(parsedTopic.ID);
         if (re == null) {
-            this.legacyLog({type: `entity_not_found`, message: {friendly_name: parsedTopic.ID}});
+            await this.legacyLog({type: `entity_not_found`, message: {friendly_name: parsedTopic.ID}});
             logger.error(`Entity '${parsedTopic.ID}' is unknown`);
             return;
         }
@@ -293,7 +293,7 @@ export default class Publish extends Extension {
                     `Publish '${parsedTopic.type}' '${key}' to '${re.name}' failed: '${error}'`;
                 logger.error(message);
                 logger.debug(error.stack);
-                this.legacyLog({type: `zigbee_publish_error`, message, meta: {friendly_name: re.name}});
+                await this.legacyLog({type: `zigbee_publish_error`, message, meta: {friendly_name: re.name}});
             }
 
             usedConverters[endpointOrGroupID].push(converter);
@@ -301,7 +301,7 @@ export default class Publish extends Extension {
 
         for (const [ID, payload] of Object.entries(toPublish)) {
             if (Object.keys(payload).length != 0) {
-                this.publishEntityState(toPublishEntity[ID], payload);
+                await this.publishEntityState(toPublishEntity[ID], payload);
             }
         }
 

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -309,8 +309,8 @@ const hours = (hours: number): number => 1000 * 60 * 60 * hours;
 const minutes = (minutes: number): number => 1000 * 60 * minutes;
 const seconds = (seconds: number): number => 1000 * seconds;
 
-function publishLastSeen(data: eventdata.LastSeenChanged, settings: Settings, allowMessageEmitted: boolean,
-    publishEntityState: PublishEntityState): void {
+async function publishLastSeen(data: eventdata.LastSeenChanged, settings: Settings, allowMessageEmitted: boolean,
+    publishEntityState: PublishEntityState): Promise<void> {
     /**
      * Prevent 2 MQTT publishes when 1 message event is received;
      * - In case reason == messageEmitted, receive.ts will only call this when it did not publish a
@@ -320,7 +320,7 @@ function publishLastSeen(data: eventdata.LastSeenChanged, settings: Settings, al
      */
     const allow = data.reason !== 'messageEmitted' || (data.reason === 'messageEmitted' && allowMessageEmitted);
     if (settings.advanced.last_seen && settings.advanced.last_seen !== 'disable' && allow) {
-        publishEntityState(data.device, {}, 'lastSeenChanged');
+        await publishEntityState(data.device, {}, 'lastSeenChanged');
     }
 }
 

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -21,7 +21,7 @@ describe('HomeAssistant extension', () => {
         await controller.enableDisableExtension(true, 'HomeAssistant');
         extension = controller.extensions.find((e) => e.constructor.name === 'HomeAssistant');
         if (runTimers) {
-            jest.runOnlyPendingTimers();
+            await jest.runOnlyPendingTimersAsync();
         }
     }
 
@@ -473,7 +473,7 @@ describe('HomeAssistant extension', () => {
         await MQTT.events.message(topic1, payload1);
         await MQTT.events.message(topic2, payload2);
 
-        jest.runOnlyPendingTimers();        
+        await jest.runOnlyPendingTimersAsync();
 
         // Should unsubscribe to not receive all messages that are going to be published to `homeassistant/#` again.
         expect(MQTT.unsubscribe).toHaveBeenCalledWith(`homeassistant/#`);
@@ -1216,7 +1216,7 @@ describe('HomeAssistant extension', () => {
         MQTT.publish.mockClear();
         await MQTT.events.message('homeassistant/status', 'online');
         await flushPromises();
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb',
@@ -1246,7 +1246,7 @@ describe('HomeAssistant extension', () => {
         MQTT.publish.mockClear();
         await MQTT.events.message('hass/status', 'online');
         await flushPromises();
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb',
@@ -1270,7 +1270,7 @@ describe('HomeAssistant extension', () => {
         MQTT.publish.mockClear();
         await MQTT.events.message('hass/status', 'offline');
         await flushPromises();
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledTimes(0);
     });
@@ -1282,7 +1282,7 @@ describe('HomeAssistant extension', () => {
         MQTT.publish.mockClear();
         await MQTT.events.message('hass/status_different', 'offline');
         await flushPromises();
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         await flushPromises();
         expect(MQTT.publish).toHaveBeenCalledTimes(0);
     });
@@ -1367,7 +1367,7 @@ describe('HomeAssistant extension', () => {
         MQTT.publish.mockClear();
         MQTT.events.message('zigbee2mqtt/bridge/request/device/rename', stringify({"from": "weather_sensor", "to": "weather_sensor_renamed","homeassistant_rename":true}));
         await flushPromises();
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         await flushPromises();
 
         const payload = {
@@ -1435,7 +1435,7 @@ describe('HomeAssistant extension', () => {
         MQTT.publish.mockClear();
         MQTT.events.message('zigbee2mqtt/bridge/request/group/rename', stringify({"from": "ha_discovery_group", "to": "ha_discovery_group_new","homeassistant_rename":true}));
         await flushPromises();
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         await flushPromises();
 
         const payload = {
@@ -2239,7 +2239,7 @@ describe('HomeAssistant extension', () => {
             {retain: true, qos: 1},
             expect.any(Function),
         );
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         await flushPromises();
 
         let payload = {
@@ -2283,7 +2283,7 @@ describe('HomeAssistant extension', () => {
             {retain: true, qos: 1},
             expect.any(Function),
         );
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         await flushPromises();
 
         payload = {
@@ -2582,6 +2582,7 @@ describe('HomeAssistant extension', () => {
         const msg = {data, cluster: 'boschSpecific', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 10};
         resetDiscoveryPayloads('0x18fc26000000cafe');
         await zigbeeHerdsman.events.message(msg);
+        await flushPromises();
         const payload = {
             'availability':[{'topic':'zigbee2mqtt/bridge/state'}],
             'command_topic':'zigbee2mqtt/0x18fc26000000cafe/set/device_mode',

--- a/test/otaUpdate.test.js
+++ b/test/otaUpdate.test.js
@@ -87,10 +87,10 @@ describe('OTA update', () => {
         expect(logger.info).toHaveBeenCalledWith(`Update of 'bulb' at 0.00%`);
         expect(logger.info).toHaveBeenCalledWith(`Update of 'bulb' at 10.00%, ≈ 60 minutes remaining`);
         expect(logger.info).toHaveBeenCalledWith(`Finished update of 'bulb'`);
-        expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190103","softwareBuildID":3}'`);
+        expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190104","softwareBuildID":4}'`);
         expect(device.save).toHaveBeenCalledTimes(2);
         expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': 'immediate'});
-        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {});
+        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': undefined});
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bulb',
             stringify({"update_available":false,"update":{"state":"updating","progress":0}}),
@@ -108,7 +108,7 @@ describe('OTA update', () => {
         );
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/ota_update/update',
-            stringify({"data":{"from":{"date_code":"20190101","software_build_id":1},"id":"bulb","to":{"date_code":"20190103","software_build_id":3}},"status":"ok"}),
+            stringify({"data":{"from":{"date_code":"20190101","software_build_id":1},"id":"bulb","to":{"date_code":"20190104","software_build_id":4}},"status":"ok"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
         expect(MQTT.publish).toHaveBeenCalledWith(
@@ -389,10 +389,11 @@ describe('OTA update', () => {
         expect(logger.info).toHaveBeenCalledWith(`Update of 'bulb' at 0.00%`);
         expect(logger.info).toHaveBeenCalledWith(`Update of 'bulb' at 10.00%, ≈ 60 minutes remaining`);
         expect(logger.info).toHaveBeenCalledWith(`Finished update of 'bulb'`);
-        expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190103","softwareBuildID":3}'`);
+        expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190104","softwareBuildID":4}'`);
         expect(logger.error).toHaveBeenCalledTimes(0);
         expect(device.save).toHaveBeenCalledTimes(2);
         expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': 'immediate'});
+        expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': undefined});
     });
 
     it('Legacy api: Should handle when OTA update fails', async () => {

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -58,7 +58,7 @@ describe('Publish', () => {
     });
 
     afterAll(async () => {
-        jest.runOnlyPendingTimers();
+        await jest.runOnlyPendingTimersAsync();
         jest.useRealTimers();
         sleep.restore();
     });
@@ -1486,18 +1486,18 @@ describe('Publish', () => {
             {retain: false, qos: 0}, expect.any(Function)
         );
         expect(MQTT.publish).toHaveBeenNthCalledWith(3,
+            'zigbee2mqtt/ha_discovery_group',
+            stringify({"brightness":50,"color_mode":"color_temp","color_temp":290,"state":"ON"}),
+            {retain: false, qos: 0}, expect.any(Function)
+        );
+        expect(MQTT.publish).toHaveBeenNthCalledWith(4,
             'zigbee2mqtt/group_tradfri_remote',
             stringify({"brightness":100,"color_temp":290,"state":"ON","color_mode": "color_temp"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
-        expect(MQTT.publish).toHaveBeenNthCalledWith(4,
+        expect(MQTT.publish).toHaveBeenNthCalledWith(5,
             'zigbee2mqtt/bulb_2',
             stringify({"brightness":100,"color_mode":"color_temp","color_temp":290,"state":"ON"}),
-            {retain: false, qos: 0}, expect.any(Function)
-        );
-        expect(MQTT.publish).toHaveBeenNthCalledWith(5,
-            'zigbee2mqtt/ha_discovery_group',
-            stringify({"brightness":50,"color_mode":"color_temp","color_temp":290,"state":"ON"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
         expect(MQTT.publish).toHaveBeenNthCalledWith(6,


### PR DESCRIPTION
Everything was "blindly" awaited to identify occurrences.

Also:
- Adjusted lint max len to match zh/zhc
- Global ignore for `data` folder contents

TODO:
- [x] Refactor occurrences where `await` really needs to be awaited properly (`forEach` & co).
- [x] `void` where `await` not needed.