### PR TITLE
Use 'occupancy' device_class instead of 'motion' for occupancy sensors

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -656,7 +656,7 @@ export default class HomeAssistant extends Extension {
                 moving: {device_class: 'moving'},
                 no_position_support: {entity_category: 'config', icon: 'mdi:minus-circle-outline'},
                 noise_detected: {device_class: 'sound'},
-                occupancy: {device_class: 'motion'},
+                occupancy: {device_class: 'occupancy'},
                 power_outage_memory: {entity_category: 'config', icon: 'mdi:memory'},
                 presence: {device_class: 'presence'},
                 setup: {device_class: 'running'},


### PR DESCRIPTION
'occupancy' matches the zigbee terminology more closely and is more consistent with other Home Assistant entities of this type.

https://www.home-assistant.io/integrations/binary_sensor/

In general, it looks like 'motion' is more for alarms, and 'occupancy' for non-alarm situations. Z2M currently makes no distinction between these concepts, but they could be separated (with a fair amount of work).