### PR TITLE
Set voc_index icon to "mdi:molecule" to match other VOC icons in Home Assistant

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -849,7 +849,7 @@ export default class HomeAssistant extends Extension {
                 transition: {entity_category: 'config', icon: 'mdi:transition'},
                 trigger_count: {icon: 'mdi:counter', enabled_by_default: false},
                 voc: {device_class: 'volatile_organic_compounds', state_class: 'measurement'},
-                voc_index: {state_class: 'measurement'},
+                voc_index: {state_class: 'measurement', icon: 'mdi:molecule'},
                 voc_parts: {device_class: 'volatile_organic_compounds_parts', state_class: 'measurement'},
                 vibration_timeout: {entity_category: 'config', icon: 'mdi:timer'},
                 voltage: {


### PR DESCRIPTION
See https://github.com/home-assistant/core/blob/2a92f78453e763e7c50bf80be801e15a5bcf0fe7/homeassistant/components/number/icons.json#L123-L128