### PR TITLE
Differenciate the MQTT publish/ received from regular mqtt logs

### DIFF
--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -24,7 +24,7 @@ export default class MQTT {
 
     async connect(): Promise<void> {
         const mqttSettings = settings.get().mqtt;
-        logger.info(`Connecting to MQTT server at ${mqttSettings.server}`, NS);
+        logger.info(`Connecting to MQTT server at ${mqttSettings.server}`);
 
         const options: mqtt.IClientOptions = {
             will: {
@@ -40,37 +40,37 @@ export default class MQTT {
         }
 
         if (mqttSettings.keepalive) {
-            logger.debug(`Using MQTT keepalive: ${mqttSettings.keepalive}`, NS);
+            logger.debug(`Using MQTT keepalive: ${mqttSettings.keepalive}`);
             options.keepalive = mqttSettings.keepalive;
         }
 
         if (mqttSettings.ca) {
-            logger.debug(`MQTT SSL/TLS: Path to CA certificate = ${mqttSettings.ca}`, NS);
+            logger.debug(`MQTT SSL/TLS: Path to CA certificate = ${mqttSettings.ca}`);
             options.ca = fs.readFileSync(mqttSettings.ca);
         }
 
         if (mqttSettings.key && mqttSettings.cert) {
-            logger.debug(`MQTT SSL/TLS: Path to client key = ${mqttSettings.key}`, NS);
-            logger.debug(`MQTT SSL/TLS: Path to client certificate = ${mqttSettings.cert}`, NS);
+            logger.debug(`MQTT SSL/TLS: Path to client key = ${mqttSettings.key}`);
+            logger.debug(`MQTT SSL/TLS: Path to client certificate = ${mqttSettings.cert}`);
             options.key = fs.readFileSync(mqttSettings.key);
             options.cert = fs.readFileSync(mqttSettings.cert);
         }
 
         if (mqttSettings.user && mqttSettings.password) {
-            logger.debug(`Using MQTT login with username: ${mqttSettings.user}`, NS);
+            logger.debug(`Using MQTT login with username: ${mqttSettings.user}`);
             options.username = mqttSettings.user;
             options.password = mqttSettings.password;
         } else {
-            logger.debug(`Using MQTT anonymous login`, NS);
+            logger.debug(`Using MQTT anonymous login`);
         }
 
         if (mqttSettings.client_id) {
-            logger.debug(`Using MQTT client ID: '${mqttSettings.client_id}'`, NS);
+            logger.debug(`Using MQTT client ID: '${mqttSettings.client_id}'`);
             options.clientId = mqttSettings.client_id;
         }
 
         if (mqttSettings.hasOwnProperty('reject_unauthorized') && !mqttSettings.reject_unauthorized) {
-            logger.debug(`MQTT reject_unauthorized set false, ignoring certificate warnings.`, NS);
+            logger.debug(`MQTT reject_unauthorized set false, ignoring certificate warnings.`);
             options.rejectUnauthorized = false;
         }
 
@@ -87,7 +87,7 @@ export default class MQTT {
             });
 
             this.client.on('error', (err) => {
-                logger.error(`MQTT error: ${err.message}`, NS);
+                logger.error(`MQTT error: ${err.message}`);
                 reject(err);
             });
             this.client.on('message', this.onMessage);
@@ -99,11 +99,11 @@ export default class MQTT {
         clearTimeout(this.connectionTimer);
         this.connectionTimer = setInterval(() => {
             if (this.client.reconnecting) {
-                logger.error('Not connected to MQTT server!', NS);
+                logger.error('Not connected to MQTT server!');
             }
         }, utils.seconds(10));
 
-        logger.info('Connected to MQTT server', NS);
+        logger.info('Connected to MQTT server');
         await this.publishStateOnline();
 
         if (!this.initialConnect) {
@@ -128,7 +128,7 @@ export default class MQTT {
         await this.publish('bridge/state', utils.availabilityPayload('offline', settings.get()),
             {retain: true, qos: 0});
         this.eventBus.removeListeners(this);
-        logger.info('Disconnecting from MQTT server', NS);
+        logger.info('Disconnecting from MQTT server');
         this.client?.end();
     }
 
@@ -181,8 +181,8 @@ export default class MQTT {
         if (!this.isConnected()) {
             /* istanbul ignore else */
             if (!skipLog) {
-                logger.error(`Not connected to MQTT server!`, NS);
-                logger.error(`Cannot send message: topic: '${topic}', payload: '${payload}`, NS);
+                logger.error(`Not connected to MQTT server!`);
+                logger.error(`Cannot send message: topic: '${topic}', payload: '${payload}`);
             }
             return;
         }

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -163,7 +163,7 @@ describe('Controller', () => {
         logger.error.mockClear();
         controller.mqtt.client.reconnecting = true;
         jest.advanceTimersByTime(11 * 1000);
-        expect(logger.error).toHaveBeenCalledWith("Not connected to MQTT server!", LOG_MQTT_NS);
+        expect(logger.error).toHaveBeenCalledWith("Not connected to MQTT server!");
         controller.mqtt.client.reconnecting = false;
     });
 
@@ -176,8 +176,8 @@ describe('Controller', () => {
         await controller.publishEntityState(device, {state: 'ON', brightness: 50, color_temp: 370, color: {r: 100, g: 50, b: 10}, dummy: {1: 'yes', 2: 'no'}});
         await flushPromises();
         expect(logger.error).toHaveBeenCalledTimes(2);
-        expect(logger.error).toHaveBeenCalledWith("Not connected to MQTT server!", LOG_MQTT_NS);
-        expect(logger.error).toHaveBeenCalledWith("Cannot send message: topic: 'zigbee2mqtt/bulb', payload: '{\"brightness\":50,\"color\":{\"b\":10,\"g\":50,\"r\":100},\"color_temp\":370,\"dummy\":{\"1\":\"yes\",\"2\":\"no\"},\"linkquality\":99,\"state\":\"ON\"}", LOG_MQTT_NS);
+        expect(logger.error).toHaveBeenCalledWith("Not connected to MQTT server!");
+        expect(logger.error).toHaveBeenCalledWith("Cannot send message: topic: 'zigbee2mqtt/bulb', payload: '{\"brightness\":50,\"color\":{\"b\":10,\"g\":50,\"r\":100},\"color_temp\":370,\"dummy\":{\"1\":\"yes\",\"2\":\"no\"},\"linkquality\":99,\"state\":\"ON\"}");
         controller.mqtt.client.reconnecting = false;
     });
 
@@ -217,7 +217,7 @@ describe('Controller', () => {
         });
         await controller.start();
         await flushPromises();
-        expect(logger.error).toHaveBeenCalledWith('MQTT error: addr not found', LOG_MQTT_NS);
+        expect(logger.error).toHaveBeenCalledWith('MQTT error: addr not found');
         expect(logger.error).toHaveBeenCalledWith('MQTT failed to connect, exiting...');
         expect(mockExit).toHaveBeenCalledTimes(1);
         expect(mockExit).toHaveBeenCalledWith(1, false);


### PR DESCRIPTION
Follow up to https://github.com/Koenkk/zigbee2mqtt/pull/22975 
Rather than creating subnamespaces, keep the  ``z2m:mqtt`` logger namespace only for those 2, moving back to the ``z2m`` default for the rest like connection info

