### PR TITLE
Optional watchdog for "adapter disconnected"-type events (non-node-crash)

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ async function start() {
 
     // consider next controller.stop() call as unsolicited, only after successful first start
     unsolicitedStop = true;
+    watchdogCount = 0;// reset
 }
 
 async function stop(restart) {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ async function currentHash() {
     const git = require('git-last-commit');
 
     return new Promise((resolve) => {
-        git.getLastCommit((err, commit) => (err) ? resolve('unknown') : resolve(commit.shortHash));
+        git.getLastCommit((err, commit) => err ? resolve('unknown') : resolve(commit.shortHash));
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -9,32 +9,56 @@ require('source-map-support').install();
 
 let controller;
 let stopping = false;
+let watchdog = process.argv.length >= 3 && process.argv[2] === 'watchdog';
+let watchdogCount = 0;
+let unsolicitedStop = false;
+// csv in minutes, default: 1min, 5min, 15min, 30min, 60min
+let watchdogDelays = watchdog && process.argv.length === 4 ? process.argv[3].split(',').map((v) => parseFloat(v) * 60000) : [60000, 300000, 900000, 1800000, 3600000];
 
 const hashFile = path.join(__dirname, 'dist', '.hash');
+
+async function triggerWatchdog(code) {
+    const delay = watchdogDelays[watchdogCount];
+    watchdogCount += 1;
+
+    if (delay) {
+        // garbage collector
+        controller = undefined;
+
+        console.log(`WATCHDOG: Waiting ${delay/60000}min before next start try.`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        await start();
+    } else {
+        process.exit(code);
+    }
+}
 
 async function restart() {
     await stop(true);
     await start();
 }
 
-async function exit(code, restart) {
+async function exit(code, restart = false) {
     if (!restart) {
-        process.exit(code);
+        if (watchdog && unsolicitedStop) {
+            await triggerWatchdog(code);
+        } else {
+            process.exit(code);
+        }
     }
 }
 
 async function currentHash() {
     const git = require('git-last-commit');
+
     return new Promise((resolve) => {
-        git.getLastCommit((err, commit) => {
-            if (err) resolve('unknown');
-            else resolve(commit.shortHash);
-        });
+        git.getLastCommit((err, commit) => (err) ? resolve('unknown') : resolve(commit.shortHash));
     });
 }
 
 async function writeHash() {
     const hash = await currentHash();
+
     fs.writeFileSync(hashFile, hash);
 }
 
@@ -42,8 +66,10 @@ async function build(reason) {
     return new Promise((resolve, reject) => {
         process.stdout.write(`Building Zigbee2MQTT... (${reason})`);
         rimrafSync('dist');
+
         const env = {...process.env};
         const _600mb = 629145600;
+
         if (_600mb > os.totalmem() && !env.NODE_OPTIONS) {
             // Prevent OOM on tsc compile for system with low memory
             // https://github.com/Koenkk/zigbee2mqtt/issues/12034
@@ -53,10 +79,11 @@ async function build(reason) {
         exec('npm run build', {env, cwd: __dirname}, async (err, stdout, stderr) => {
             if (err) {
                 process.stdout.write(', failed\n');
+
                 if (err.code === 134) {
-                    process.stderr.write(
-                        '\n\nBuild failed; ran out-of-memory, free some memory (RAM) and start again\n\n');
+                    process.stderr.write('\n\nBuild failed; ran out-of-memory, free some memory (RAM) and start again\n\n');
                 }
+
                 reject(err);
             } else {
                 process.stdout.write(', finished\n');
@@ -82,39 +109,60 @@ async function start() {
     await checkDist();
 
     const version = engines.node;
+
     if (!semver.satisfies(process.version, version)) {
-        console.log(`\t\tZigbee2MQTT requires node version ${version}, you are running ${process.version}!\n`); // eslint-disable-line
+        console.log(`\t\tZigbee2MQTT requires node version ${version}, you are running ${process.version}!\n`);
     }
 
     // Validate settings
     const settings = require('./dist/util/settings');
+
     settings.reRead();
+
     const errors = settings.validate();
+
     if (errors.length > 0) {
+        unsolicitedStop = false;
+
         console.log(`\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`);
         console.log('            READ THIS CAREFULLY\n');
         console.log(`Refusing to start because configuration is not valid, found the following errors:`);
+
         for (const error of errors) {
             console.log(`- ${error}`);
         }
-        console.log(`\nIf you don't know how to solve this, read https://www.zigbee2mqtt.io/guide/configuration`); // eslint-disable-line
+
+        console.log(`\nIf you don't know how to solve this, read https://www.zigbee2mqtt.io/guide/configuration`);
         console.log(`\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n\n`);
-        exit(1);
+
+        return exit(1);
     }
 
     const Controller = require('./dist/controller');
     controller = new Controller(restart, exit);
+
     await controller.start();
+
+    // consider next controller.stop() call as unsolicited, only after successful first start
+    unsolicitedStop = true;
 }
 
 async function stop(restart) {
+    // `handleQuit` or `restart` never unsolicited
+    unsolicitedStop = false;
+
     await controller.stop(restart);
 }
 
 async function handleQuit() {
-    if (!stopping && controller) {
-        stopping = true;
-        await stop(false);
+    if (!stopping) {
+        if (controller) {
+            stopping = true;
+
+            await stop(false);
+        } else {
+            process.exit(0);
+        }
     }
 }
 
@@ -129,5 +177,6 @@ if (require.main === module || require.main.filename.endsWith(path.sep + 'cli.js
 } else {
     process.on('SIGINT', handleQuit);
     process.on('SIGTERM', handleQuit);
+
     module.exports = {start};
 }


### PR DESCRIPTION
Add basic, optional, watchdog to handle "soft failures" for bare Z2M users instead of requiring the use of a process watchdog. Should handle any Z2M failure that would result in the node process being **stopped**  (like "adapter disconnected" event).

`npm run start` => no watchdog
`Z2M_WATCHDOG=default npm run start` => watchdog with default delays (1min, 5min, 15min, 30min, 60min)
`Z2M_WATCHDOG=minutes_csv npm run start` => watchdog with custom delays (example: `Z2M_WATCHDOG=0.5,3,6,15 npm run start`)

- The number of configured delays is the de facto number of times the watchdog will retry, past that, the node process will be stopped (to avoid endlessly retrying when clearly, something's requiring the user's attention). _With the default delays, the watchdog will retry after 1min on first failure, then after 5min on second failure, then after 15min on third failure, then after 30min on fourth failure, then after 60min on fifth failure, then exit if sixth start fails. Any successful start resets that to the beginning._
- The watchdog will only trigger on failure after the initial (manual) start is successful.
- A problem with settings will always ignore the watchdog and stop Z2M.
- A manual stop/restart will ignore the watchdog to comply with user intent.
- `Z2M_WATCHDOG` accepts `default` as value or a list of comma-separated integers/floats. Other values/formats (invalid) will prevent Z2M from starting.

Note: This does not handle node crashes, that's better suited for a process watchdog (and already widely available).


- Docs: https://github.com/Koenkk/zigbee2mqtt.io/pull/2825