### PR TITLE
Do not send any event to disabled devices

### DIFF
--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -40,6 +40,7 @@ export default class OnEvent extends Extension {
     }
 
     private async callOnEvent(device: Device, type: zhc.OnEventType, data: KeyValue): Promise<void> {
+        if (device.options.disabled) return;
         const state = this.state.get(device);
         await zhc.onEvent(type, data, device.zh);
 


### PR DESCRIPTION
Some devices require active polling that is setup using onEvent triggers
When the device is disabled we should stop polling them to avoid unnecessary traffic, errors in logs etc

Following  up https://github.com/Koenkk/zigbee-herdsman-converters/pull/7619, rather than implement the test on a device level, handle it at Z2M level, avoiding the call for disabled devices 
As z2m requires a restart for  enable/disable to be effective, we don't need to handle changes at runtime (stop events etc)