### PR TITLE
Do not ping disabled devices at start

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -139,8 +139,8 @@ export default class Availability extends Extension {
                 if (entity.isDevice()) {
                     this.resetTimer(entity);
 
-                    // If an active device is initially unavailable, ping it.
-                    if (this.isActiveDevice(entity) && !this.isAvailable(entity)) {
+                    // If an active device is initially unavailable, ping it unless it is disabled.
+                    if (this.isActiveDevice(entity) && !this.isAvailable(entity) && !entity.options.disabled) {
                         await this.addToPingQueue(entity);
                     }
                 }


### PR DESCRIPTION
When devices have not been seen / not available at start, we ping them. 
We should skip disabled devices, because they are well... disabled.