### PR TITLE
fix: remove outdated `@types/debounce`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@babel/plugin-proposal-decorators": "^7.24.7",
         "@babel/preset-env": "^7.24.7",
         "@babel/preset-typescript": "^7.24.7",
-        "@types/debounce": "^1.2.4",
         "@types/finalhandler": "^1.2.3",
         "@types/humanize-duration": "^3.27.4",
         "@types/jest": "^29.5.12",
@@ -3187,12 +3186,6 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
-    },
-    "node_modules/@types/debounce": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.4.tgz",
-      "integrity": "sha512-jBqiORIzKDOToaF63Fm//haOCHuwQuLa2202RK4MozpA6lh93eCBc+/8+wZn5OzjJt3ySdc+74SXWXB55Ewtyw==",
-      "dev": true
     },
     "node_modules/@types/finalhandler": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
-    "@types/debounce": "^1.2.4",
     "@types/finalhandler": "^1.2.3",
     "@types/humanize-duration": "^3.27.4",
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
`debounce` now includes types.
https://github.com/sindresorhus/debounce/releases/tag/v2.0.0

### Reference

fixes #23062