### PR TITLE
fix: OTA should use develcoPrimarySwVersion for Develco devices

### DIFF
--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -280,6 +280,10 @@ export default class OTAUpdate extends Extension {
                     logger.info(`Device '${device.name}' was updated from '${fromS}' to '${toS}'`);
                     responseData.from = from_ ? utils.toSnakeCase(from_) : null;
                     responseData.to = to ? utils.toSnakeCase(to) : null;
+                    /**
+                     * Re-configure after reading software build ID and date code, some devices use a
+                     * custom attribute for this (e.g. Develco SMSZB-120)
+                     */
                     this.eventBus.emitReconfigure({device});
                     this.eventBus.emitDevicesChanged();
 

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -271,7 +271,6 @@ export default class OTAUpdate extends Extension {
                     const from_ = await this.readSoftwareBuildIDAndDateCode(device, 'immediate');
                     const fileVersion = await device.definition.ota.updateToLatest(device.zh, onProgress);
                     logger.info(`Finished update of '${device.name}'`);
-                    this.eventBus.emitReconfigure({device});
                     this.removeProgressAndRemainingFromState(device);
                     const payload = this.getEntityPublishPayload(device,
                         {available: false, currentFileVersion: fileVersion, otaFileVersion: fileVersion});
@@ -281,6 +280,7 @@ export default class OTAUpdate extends Extension {
                     logger.info(`Device '${device.name}' was updated from '${fromS}' to '${toS}'`);
                     responseData.from = from_ ? utils.toSnakeCase(from_) : null;
                     responseData.to = to ? utils.toSnakeCase(to) : null;
+                    this.eventBus.emitReconfigure({device});
                     this.eventBus.emitDevicesChanged();
 
                     /* istanbul ignore else */

--- a/test/otaUpdate.test.js
+++ b/test/otaUpdate.test.js
@@ -87,7 +87,7 @@ describe('OTA update', () => {
         expect(logger.info).toHaveBeenCalledWith(`Update of 'bulb' at 0.00%`);
         expect(logger.info).toHaveBeenCalledWith(`Update of 'bulb' at 10.00%, ≈ 60 minutes remaining`);
         expect(logger.info).toHaveBeenCalledWith(`Finished update of 'bulb'`);
-        expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190104","softwareBuildID":4}'`);
+        expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190102","softwareBuildID":2}'`);
         expect(device.save).toHaveBeenCalledTimes(2);
         expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': 'immediate'});
         expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': undefined});
@@ -108,7 +108,7 @@ describe('OTA update', () => {
         );
         expect(MQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/ota_update/update',
-            stringify({"data":{"from":{"date_code":"20190101","software_build_id":1},"id":"bulb","to":{"date_code":"20190104","software_build_id":4}},"status":"ok"}),
+            stringify({"data":{"from":{"date_code":"20190101","software_build_id":1},"id":"bulb","to":{"date_code":"20190102","software_build_id":2}},"status":"ok"}),
             {retain: false, qos: 0}, expect.any(Function)
         );
         expect(MQTT.publish).toHaveBeenCalledWith(
@@ -389,7 +389,7 @@ describe('OTA update', () => {
         expect(logger.info).toHaveBeenCalledWith(`Update of 'bulb' at 0.00%`);
         expect(logger.info).toHaveBeenCalledWith(`Update of 'bulb' at 10.00%, ≈ 60 minutes remaining`);
         expect(logger.info).toHaveBeenCalledWith(`Finished update of 'bulb'`);
-        expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190104","softwareBuildID":4}'`);
+        expect(logger.info).toHaveBeenCalledWith(`Device 'bulb' was updated from '{"dateCode":"20190101","softwareBuildID":1}' to '{"dateCode":"20190102","softwareBuildID":2}'`);
         expect(logger.error).toHaveBeenCalledTimes(0);
         expect(device.save).toHaveBeenCalledTimes(2);
         expect(endpoint.read).toHaveBeenCalledWith('genBasic', ['dateCode', 'swBuildId'], {'sendPolicy': 'immediate'});


### PR DESCRIPTION
@Koenkk as mentioned on discord, we need to read develcoPrimarySwVersion for develco/frient devices instead of swBuildId as that is always returns null otherwise.

I found no clean way to check if we have the develcoPrimarySwVersion on genBasic or not.

I opted to check for the Develco/Frient manufacturerID and just read the right attribute, currently we are hitting the catch branch. If the attributes move from zh -> zhc in the future and a new develco device would be missing the modernExtend we'd still have the same situation a today. I think for now this is fine to do.