### PR TITLE
fix: Don't allow `homeassistant.discovery_topic` to be equal to `mqtt.base_topic` https://github.com/Koenkk/zigbee2mqtt/issues/23109

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -186,6 +186,10 @@ export default class HomeAssistant extends Extension {
         if (settings.get().advanced.output === 'attribute') {
             throw new Error('Home Assistant integration is not possible with attribute output!');
         }
+
+        if (settings.get().homeassistant.discovery_topic === settings.get().mqtt.base_topic) {
+            throw new Error(`'homeassistant.discovery_topic' cannot not be equal to the 'mqtt.base_topic' (got '${settings.get().mqtt.base_topic}')`);
+        }
     }
 
     override async start(): Promise<void> {

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -1020,8 +1020,15 @@ describe('HomeAssistant extension', () => {
         settings.set(['experimental', 'output'], 'attribute');
         settings.set(['homeassistant'], true);
         expect(() => {
-            const controller = new Controller(false);
-        }).toThrowError('Home Assistant integration is not possible with attribute output!');
+            new Controller(false);
+        }).toThrow('Home Assistant integration is not possible with attribute output!');
+    });
+
+    it('Should throw error when homeassistant.discovery_topic equals the mqtt.base_topic', async () => {
+        settings.set(['mqtt', 'base_topic'], 'homeassistant');
+        expect(() => {
+            new Controller(false);
+        }).toThrow("'homeassistant.discovery_topic' cannot not be equal to the 'mqtt.base_topic' (got 'homeassistant')");
     });
 
     it('Should warn when starting with cache_state false', async () => {


### PR DESCRIPTION
This PR adds a check to check wether the `homeassistant.discovery_topic` and `mqtt.base_topic` are not equal (and refuses to start when they are). This is not allowed since Zigbee2MQTT unsubscribes from this topic and thus makes devices uncontrollable.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/23109