### PR TITLE
fix: Fix availability blocking other extensions startup

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -69,12 +69,6 @@ export default class Availability extends Extension {
         index != -1 && this.pingQueue.splice(index, 1);
     }
 
-    private availabilityEnabledEntities(): (Device | Group)[] {
-        return [...this.zigbee.devices(false), ...this.zigbee.groups()].filter((entity) =>
-            utils.isAvailabilityEnabledForEntity(entity, settings.get()),
-        );
-    }
-
     private async pingQueueExecuteNext(): Promise<void> {
         if (this.pingQueue.length === 0 || this.pingQueueExecuting) {
             return;
@@ -145,11 +139,13 @@ export default class Availability extends Extension {
 
         // Start availability for the devices
         for (const device of this.zigbee.devices(false)) {
-            this.resetTimer(device);
+            if (utils.isAvailabilityEnabledForEntity(device, settings.get())) {
+                this.resetTimer(device);
 
-            // If an active device is unavailable on start, add it to the pingqueue immediately.
-            if (this.isActiveDevice(device) && !this.isAvailable(device)) {
-                this.addToPingQueue(device);
+                // If an active device is unavailable on start, add it to the pingqueue immediately.
+                if (this.isActiveDevice(device) && !this.isAvailable(device)) {
+                    this.addToPingQueue(device);
+                }
             }
         }
     }

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -140,25 +140,25 @@ export default class Availability extends Extension {
         this.eventBus.onLastSeenChanged(this, this.onLastSeenChanged);
         this.eventBus.onPublishAvailability(this, this.publishAvailabilityForAllEntities);
         this.eventBus.onGroupMembersChanged(this, (data) => this.publishAvailability(data.group, false));
+        // Publish initial availability
         await this.publishAvailabilityForAllEntities();
 
         // Start availability for the devices
-        for (const entity of this.availabilityEnabledEntities()) {
-            if (entity.isDevice()) {
-                this.resetTimer(entity);
+        for (const device of this.zigbee.devices(false)) {
+            this.resetTimer(device);
 
-                // If an active device is unavailable on start, add it to the pingqueue immediately.
-                if (this.isActiveDevice(entity) && !this.isAvailable(entity)) {
-                    this.addToPingQueue(entity);
-                }
+            // If an active device is unavailable on start, add it to the pingqueue immediately.
+            if (this.isActiveDevice(device) && !this.isAvailable(device)) {
+                this.addToPingQueue(device);
             }
         }
     }
 
     @bind private async publishAvailabilityForAllEntities(): Promise<void> {
-        for (const entity of this.availabilityEnabledEntities()) {
-            // Publish initial availability
-            await this.publishAvailability(entity, true, false, true);
+        for (const entity of [...this.zigbee.devices(false), ...this.zigbee.groups()]) {
+            if (utils.isAvailabilityEnabledForEntity(entity, settings.get())) {
+                await this.publishAvailability(entity, true, false, true);
+            }
         }
     }
 

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -396,6 +396,9 @@ function getScenes(entity: zh.Endpoint | zh.Group): Scene[] {
     return Object.values(scenes);
 }
 
+/* istanbul ignore next */
+const noop = (): void => {};
+
 export default {
     capitalize,
     getZigbee2MQTTVersion,
@@ -427,4 +430,5 @@ export default {
     flatten,
     arrayUnique,
     getScenes,
+    noop,
 };


### PR DESCRIPTION
Fixes the availability from blocking other extensions to startup when at least 1 device is unavailable on startup.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/23266