### PR TITLE
fix: Ignore cache when re-interviewing device

### DIFF
--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -536,14 +536,14 @@ export default class Bridge extends Extension {
         try {
             await device.zh.interview(true);
             logger.info(`Successfully interviewed '${device.name}'`);
-            // A re-interview can for example result in a different modelId, therefore reconsider the definition.
-            await device.resolveDefinition(true);
         } catch (error) {
             throw new Error(`interview of '${device.name}' (${device.ieeeAddr}) failed: ${error}`, {cause: error});
         }
 
-        // publish devices so that the front-end has up-to-date info.
-        await this.publishDevices();
+        // A re-interview can for example result in a different modelId, therefore reconsider the definition.
+        await device.resolveDefinition(true);
+        this.eventBus.emitDevicesChanged();
+        this.eventBus.emitExposesChanged({device});
 
         return utils.getResponse(message, {id: message.id}, null);
     }

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -534,8 +534,10 @@ export default class Bridge extends Extension {
         logger.info(`Interviewing '${device.name}'`);
 
         try {
-            await device.zh.interview();
+            await device.zh.interview(true);
             logger.info(`Successfully interviewed '${device.name}'`);
+            // A re-interview can for example result in a different modelId, therefore reconsider the definition.
+            await device.resolveDefinition(true);
         } catch (error) {
             throw new Error(`interview of '${device.name}' (${device.ieeeAddr}) failed: ${error}`, {cause: error});
         }

--- a/lib/model/device.ts
+++ b/lib/model/device.ts
@@ -42,8 +42,8 @@ export default class Device {
         }
     }
 
-    async resolveDefinition(): Promise<void> {
-        if (!this.zh.interviewing && (!this.definition || this._definitionModelID !== this.zh.modelID)) {
+    async resolveDefinition(ignoreCache = false): Promise<void> {
+        if (!this.zh.interviewing && (!this.definition || this._definitionModelID !== this.zh.modelID || ignoreCache)) {
             this.definition = await zhc.findByDevice(this.zh, true);
             this._definitionModelID = this.zh.modelID;
         }


### PR DESCRIPTION
This PR fixes the following issues with re-interviewing:
- When due to a re-interview the device fingerprint changes, the device definition is not reconsidered.
- Properties like device manufacturerName and modelID are not updated. This is fixed by passing `ignoreCache=true` to `device.interview()`

Requires: https://github.com/Koenkk/zigbee-herdsman/pull/1109 