### PR TITLE
fix: Fix expose category ignored by HA discovery

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -810,7 +810,7 @@ export default class HomeAssistant extends Extension {
                 ballast_minimum_level: {entity_category: 'config'},
                 ballast_physical_maximum_level: {entity_category: 'diagnostic'},
                 ballast_physical_minimum_level: {entity_category: 'diagnostic'},
-                battery: {device_class: 'battery', entity_category: 'diagnostic', state_class: 'measurement'},
+                battery: {device_class: 'battery', state_class: 'measurement'},
                 battery2: {device_class: 'battery', entity_category: 'diagnostic', state_class: 'measurement'},
                 battery_voltage: {device_class: 'voltage', entity_category: 'diagnostic', state_class: 'measurement', enabled_by_default: true},
                 boost_heating_countdown: {device_class: 'duration'},
@@ -1173,6 +1173,14 @@ export default class HomeAssistant extends Extension {
             }
         } else {
             throw new Error(`Unsupported exposes type: '${firstExpose.type}'`);
+        }
+
+        // Exposes with category 'config' or 'diagnostic' are always added to the respective category.
+        // This takes precedence over definitions in this file.
+        if (firstExpose.category === 'config') {
+            discoveryEntries.forEach((d) => (d.discovery_payload.entity_category = 'config'));
+        } else if (firstExpose.category === 'diagnostic') {
+            discoveryEntries.forEach((d) => (d.discovery_payload.entity_category = 'diagnostic'));
         }
 
         discoveryEntries.forEach((d) => {


### PR DESCRIPTION
In https://github.com/Koenkk/zigbee2mqtt/commit/6b9247c84d2e0b22006315463a843277761d83b0 I accidentally removed the code which applies the expose category to HA discovery.

This PR adds this code back and updates the tests accordingly (by updating https://github.com/Koenkk/zigbee2mqtt/pull/23494/files#diff-c63411dead8da381e5b5e1577175477e6536b9c8d4ad997cd701a3f10d46d233R813, https://github.com/Koenkk/zigbee2mqtt/blob/e132316ac494920910e8b0439e04fd6e5cf6ea25/test/homeassistant.test.js#L266 will fail now if removed)