### PR TITLE
Invoke chart ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
                     -H "Content-Type: application/json" \
                     https://api.github.com/repos/zigbee2mqtt/hassio-zigbee2mqtt/dispatches \
                     --data "{\"event_type\": \"release\", \"client_payload\": { \"version\": \"$TAG-1\"}}"
-            - name: 'release: Trigger zigbee2mqtt-chart release'
+            - name: 'release: Trigger zigbee2mqtt-chart image update'
               if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
               run: |
                   TAG=${GITHUB_REF#refs/*/}
@@ -108,8 +108,8 @@ jobs:
                     -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
                     -H "Accept: application/vnd.github.everest-preview+json" \
                     -H "Content-Type: application/json" \
-                    https://api.github.com/repos/Koenkk/zigbee2mqtt-chart/dispatches \
-                    --data "{\"event_type\": \"release\", \"client_payload\": { \"version\": \"$TAG\"}}"
+                    https://api.github.com/repos/Koenkk/zigbee2mqtt-chart/actions/workflows/OnZigbee2MQTTRelease/dispatches \
+                    -d '{"ref":"main","inputs":{"zigbee2mqtt_version":"${{TAG}}" }}'
             - name: 'release: merge dev -> master and promote dev'
               if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
               run: |


### PR DESCRIPTION
The workflow name on the chart repository is OnZigbee2MQTTRelease, this event means that a new version of zigbe2mqtt is has been released, it should probably trigger the release too, but that is a chart repo concern.

https://github.com/Koenkk/zigbee2mqtt-chart/pull/9
