### PR TITLE
fix: Fix Home Assistant `Invalid state message` error when state is too long

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1203,7 +1203,7 @@ export default class HomeAssistant extends Extension {
                             name: endpoint ? `${firstExposeTyped.label} ${endpoint}` : firstExposeTyped.label,
                             // Truncate text if it's too long
                             // https://github.com/Koenkk/zigbee2mqtt/issues/23199
-                            value_template: `{{ value_json.${firstExposeTyped.property}|default('',True) | truncate(254, True, '', 0) }}`,
+                            value_template: `{{ value_json.${firstExposeTyped.property} | default('',True) | string | truncate(254, True, '', 0) }}`,
                             enabled_by_default: !settableText,
                             ...LIST_DISCOVERY_LOOKUP[firstExposeTyped.name],
                         },


### PR DESCRIPTION
This is due to `truncate` not working when the the input is an object, this PR ensures the input to `truncate` is always a string.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/23199