### PR TITLE
Fix group state change for open/close devices

### DIFF
--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -228,17 +228,17 @@ export default class Groups extends Extension {
     }
 
     private shouldPublishPayloadForGroup(group: Group, payload: KeyValue): boolean {
-        return group.options.off_state === 'last_member_state' || !payload || payload.state !== 'OFF' || this.areAllMembersOff(group);
+        return group.options.off_state === 'last_member_state' || !payload || (payload.state !== 'OFF' && payload.state !== "CLOSE" ) || this.areAllMembersOffOrClosed(group);
     }
 
-    private areAllMembersOff(group: Group): boolean {
+    private areAllMembersOffOrClosed(group: Group): boolean {
         for (const member of group.zh.members) {
             const device = this.zigbee.resolveEntity(member.getDevice())!;
 
             if (this.state.exists(device)) {
                 const state = this.state.get(device);
 
-                if (state.state === 'ON') {
+                if (state.state === 'ON' || state.state === 'OPEN') {
                     return false;
                 }
             }

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -228,7 +228,12 @@ export default class Groups extends Extension {
     }
 
     private shouldPublishPayloadForGroup(group: Group, payload: KeyValue): boolean {
-        return group.options.off_state === 'last_member_state' || !payload || (payload.state !== 'OFF' && payload.state !== "CLOSE" ) || this.areAllMembersOffOrClosed(group);
+        return (
+            group.options.off_state === 'last_member_state' ||
+            !payload ||
+            (payload.state !== 'OFF' && payload.state !== 'CLOSE') ||
+            this.areAllMembersOffOrClosed(group)
+        );
     }
 
     private areAllMembersOffOrClosed(group: Group): boolean {

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -950,7 +950,7 @@
                     "title": "Group off state",
                     "default": "auto",
                     "requiresRestart": true,
-                    "description": "Control when to publish state OFF for a group. 'all_members_off': only publish state OFF when all group members are in state OFF, 'last_member_state': publish state OFF whenever one of its members changes to OFF"
+                    "description": "Control when to publish state OFF or CLOSE for a group. 'all_members_off': only publish state OFF/CLOSE when all group members are in state OFF/CLOSE,  'last_member_state': publish state OFF whenever one of its members changes to OFF"
                 },
                 "filtered_attributes": {
                     "type": "array",


### PR DESCRIPTION
Fix group state changing for any device of the group updating it's state to open/close. <br>
This change bring the same behaviour of device on/off using the option `off_state: 'all_members_off'` also for the device with state open/close.<br>
Fix issue #24163 