### PR TITLE
[feat] Add support for Home Assistant `event` entities

### DIFF
--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -118,6 +118,7 @@ declare global {
             status_topic: string;
             legacy_entity_attributes: boolean;
             legacy_triggers: boolean;
+            experimental_event_entities: boolean;
         };
         permit_join: boolean;
         availability?: {

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -40,6 +40,12 @@
                             "description": "Home Assistant status topic",
                             "requiresRestart": true,
                             "examples": ["homeassistant/status"]
+                        },
+                        "experimental_event_entities": {
+                            "type": "boolean",
+                            "title": "Home Assistant experimental event entities",
+                            "description": "Home Assistant experimental event entities, when enabled Zigbee2MQTT will add event entities for exposed actions. The events and attributes are currently deemed experimental and subject to change.",
+                            "default": false
                         }
                     }
                 }

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -136,7 +136,13 @@ function loadSettingsWithDefaults(): void {
     }
 
     if (_settingsWithDefaults.homeassistant) {
-        const defaults = {discovery_topic: 'homeassistant', status_topic: 'hass/status', legacy_entity_attributes: true, legacy_triggers: true};
+        const defaults = {
+            discovery_topic: 'homeassistant',
+            status_topic: 'hass/status',
+            legacy_entity_attributes: true,
+            legacy_triggers: true,
+            experimental_event_entities: false,
+        };
         const sLegacy = {};
         if (_settingsWithDefaults.advanced) {
             for (const key of [

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -404,6 +404,52 @@ describe('HomeAssistant extension', () => {
             {retain: true, qos: 1},
             expect.any(Function),
         );
+
+        payload = {
+            availability: [{topic: 'zigbee2mqtt/bridge/state'}],
+            device: {
+                identifiers: ['zigbee2mqtt_0x0017880104e45520'],
+                manufacturer: 'Aqara',
+                model: 'Wireless mini switch (WXKG11LM)',
+                name: 'button',
+                sw_version: null,
+                via_device: 'zigbee2mqtt_bridge_0x00124b00120144ae',
+            },
+            event_types: ['single', 'double', 'triple', 'quadruple', 'hold', 'release'],
+            icon: 'mdi:gesture-double-tap',
+            json_attributes_topic: 'zigbee2mqtt/button',
+            name: 'Action',
+            object_id: 'button_action',
+            origin: origin,
+            state_topic: 'zigbee2mqtt/button',
+            unique_id: '0x0017880104e45520_action_zigbee2mqtt',
+            // Needs to be updated whenever one of the ACTION_*_PATTERN constants changes.
+            value_template:
+                '{%- set buttons = value_json.action|regex_findall_index(^(?P<button>[a-z]+)_(?P<action>(?:press|hold)(?:_release)?)$) -%}{%- set scenes = value_json.action|regex_findall_index(^(?P<action>recall|scene)_(?P<scene>[0-2][0-9]{0,2})$) -%}{%- set regions = value_json.action|regex_findall_index(^region_(?P<region>[1-9]|10)_(?P<action>enter|leave|occupied|unoccupied)$) -%}{%- if buttons -%}\n   {%- set d = dict(event_type = "{{buttons[1]}}", button = "{{buttons[0]}}_button" -%}\n{%- elif scenes -%}\n   {%- set d = dict(event_type = "{{scenes[0]}}", scene = "{{scenes[1]}}" -%}\n{%- elif regions -%}\n   {%- set d = dict(event_type = "region_{{regions[1]}}", region = "{{regions[0]}}" -%}\n{%- else -%}\n   {%- set d = dict(event_type = "{{value_json.action}}" ) -%}\n{%- endif -%}\n{{d|to_json}}',
+        };
+
+        expect(MQTT.publish).toHaveBeenCalledWith(
+            'homeassistant/event/0x0017880104e45520/action/config',
+            stringify(payload),
+            {retain: true, qos: 1},
+            expect.any(Function),
+        );
+    });
+
+    it.each([
+        ['recall_1', {action: 'recall', scene: '1'}],
+        ['recall_*', {action: 'recall', scene: 'wildcard'}],
+        ['on', {action: 'on'}],
+        ['on_1', {action: 'on_1'}],
+        ['release_left', {action: 'release_left'}],
+        ['region_1_enter', {action: 'region_enter', region: '1'}],
+        ['region_*_leave', {action: 'region_leave', region: 'wildcard'}],
+        ['left_press', {action: 'press', button: 'left'}],
+        ['left_press_release', {action: 'press_release', button: 'left'}],
+        ['right_hold', {action: 'hold', button: 'right'}],
+        ['right_hold_release', {action: 'hold_release', button: 'right'}],
+    ])('Should parse action names correctly', (action, expected) => {
+        expect(extension.parseActionValue(action)).toStrictEqual(expected);
     });
 
     it('Should not discovery devices which are already discovered', async () => {

--- a/test/homeassistant.test.js
+++ b/test/homeassistant.test.js
@@ -1673,9 +1673,10 @@ describe('HomeAssistant extension', () => {
 
     it('Should discover trigger when click is published', async () => {
         const discovered = MQTT.publish.mock.calls.filter((c) => c[0].includes('0x0017880104e45520')).map((c) => c[0]);
-        expect(discovered.length).toBe(7);
+        expect(discovered.length).toBe(8);
         expect(discovered).toContain('homeassistant/sensor/0x0017880104e45520/click/config');
         expect(discovered).toContain('homeassistant/sensor/0x0017880104e45520/action/config');
+        expect(discovered).toContain('homeassistant/event/0x0017880104e45520/action/config');
 
         MQTT.publish.mockClear();
 
@@ -1856,8 +1857,9 @@ describe('HomeAssistant extension', () => {
         await resetExtension();
 
         const discovered = MQTT.publish.mock.calls.filter((c) => c[0].includes('0x0017880104e45520')).map((c) => c[0]);
-        expect(discovered.length).toBe(6);
+        expect(discovered.length).toBe(7);
         expect(discovered).toContain('homeassistant/sensor/0x0017880104e45520/action/config');
+        expect(discovered).toContain('homeassistant/event/0x0017880104e45520/action/config');
         expect(discovered).toContain('homeassistant/sensor/0x0017880104e45520/battery/config');
         expect(discovered).toContain('homeassistant/sensor/0x0017880104e45520/linkquality/config');
     });
@@ -1867,9 +1869,10 @@ describe('HomeAssistant extension', () => {
         await resetExtension();
 
         const discovered = MQTT.publish.mock.calls.filter((c) => c[0].includes('0x0017880104e45520')).map((c) => c[0]);
-        expect(discovered.length).toBe(5);
+        expect(discovered.length).toBe(6);
         expect(discovered).not.toContain('homeassistant/sensor/0x0017880104e45520/click/config');
         expect(discovered).not.toContain('homeassistant/sensor/0x0017880104e45520/action/config');
+        expect(discovered).toContain('homeassistant/event/0x0017880104e45520/action/config');
 
         MQTT.publish.mockClear();
 

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1026,6 +1026,7 @@ describe('Settings', () => {
         settings.reRead();
         expect(settings.get().homeassistant).toStrictEqual({
             discovery_topic: 'new',
+            experimental_event_entities: false,
             legacy_entity_attributes: true,
             legacy_triggers: true,
             status_topic: 'olds',


### PR DESCRIPTION
Adds support for [Home Assistant's new-ish `event` entities](https://www.home-assistant.io/integrations/event.mqtt). Fixes #18389.