### PR TITLE
fix!: Improve bind/bridge/groups parsing and resolving consistency

### DIFF
--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -195,15 +195,23 @@ const POLL_ON_MESSAGE: Readonly<PollOnMessage> = [
 
 interface ParsedMQTTMessage {
     type: 'bind' | 'unbind';
-    sourceKey: string;
-    targetKey: string;
+    sourceKey?: string;
+    sourceEndpointKey?: string;
+    targetKey?: string;
+    targetEndpointKey?: string;
     clusters?: string[];
     skipDisableReporting: boolean;
+    resolvedSource?: Device;
+    resolvedTarget?: Device | Group | typeof DEFAULT_BIND_GROUP;
+    resolvedSourceEndpoint?: zh.Endpoint;
+    resolvedBindTarget?: number | zh.Endpoint | zh.Group;
 }
 
 interface DataMessage {
     from: ParsedMQTTMessage['sourceKey'];
+    fromEndpoint?: ParsedMQTTMessage['sourceEndpointKey'];
     to: ParsedMQTTMessage['targetKey'];
+    toEndpoint: ParsedMQTTMessage['targetEndpointKey'];
     clusters: ParsedMQTTMessage['clusters'];
     skip_disable_reporting?: ParsedMQTTMessage['skipDisableReporting'];
 }
@@ -217,128 +225,199 @@ export default class Bind extends Extension {
         this.eventBus.onGroupMembersChanged(this, this.onGroupMembersChanged);
     }
 
-    private parseMQTTMessage(data: eventdata.MQTTMessage): ParsedMQTTMessage | undefined {
-        let type: ParsedMQTTMessage['type'] | undefined;
-        let sourceKey: ParsedMQTTMessage['sourceKey'] | undefined;
-        let targetKey: ParsedMQTTMessage['targetKey'] | undefined;
-        let clusters: ParsedMQTTMessage['clusters'] | undefined;
-        let skipDisableReporting: ParsedMQTTMessage['skipDisableReporting'] = false;
-
+    private parseMQTTMessage(
+        data: eventdata.MQTTMessage,
+    ): [raw: KeyValue | undefined, parsed: ParsedMQTTMessage | undefined, error: string | undefined] {
         if (data.topic.match(TOPIC_REGEX)) {
-            type = data.topic.endsWith('unbind') ? 'unbind' : 'bind';
+            const type = data.topic.endsWith('unbind') ? 'unbind' : 'bind';
+            let skipDisableReporting = false;
             const message: DataMessage = JSON.parse(data.message);
-            sourceKey = message.from;
-            targetKey = message.to;
-            clusters = message.clusters;
-            skipDisableReporting = message.skip_disable_reporting != undefined ? message.skip_disable_reporting : false;
-        } else {
-            return undefined;
-        }
 
-        return {type, sourceKey, targetKey, clusters, skipDisableReporting};
+            if (typeof message !== 'object' || message.from == undefined || message.to == undefined) {
+                return [message, {type, skipDisableReporting}, `Invalid payload`];
+            }
+
+            const sourceKey = message.from;
+            const sourceEndpointKey = message.fromEndpoint ?? 'default';
+            const targetKey = message.to;
+            const targetEndpointKey = message.toEndpoint;
+            const clusters = message.clusters;
+            skipDisableReporting = message.skip_disable_reporting != undefined ? message.skip_disable_reporting : false;
+            const resolvedSource = this.zigbee.resolveEntity(message.from) as Device;
+
+            if (!resolvedSource || !(resolvedSource instanceof Device)) {
+                return [message, {type, skipDisableReporting}, `Source device '${message.from}' does not exist`];
+            }
+
+            const resolvedTarget = message.to === DEFAULT_BIND_GROUP.name ? DEFAULT_BIND_GROUP : this.zigbee.resolveEntity(message.to);
+
+            if (!resolvedTarget) {
+                return [message, {type, skipDisableReporting}, `Target device or group '${message.to}' does not exist`];
+            }
+
+            const resolvedSourceEndpoint = resolvedSource.endpoint(sourceEndpointKey);
+
+            if (!resolvedSourceEndpoint) {
+                return [
+                    message,
+                    {type, skipDisableReporting},
+                    `Source device '${resolvedSource.name}' does not have endpoint '${sourceEndpointKey}'`,
+                ];
+            }
+
+            // resolves to 'default' endpoint if targetEndpointKey is invalid (used by frontend for 'Coordinator')
+            const resolvedBindTarget =
+                resolvedTarget instanceof Device
+                    ? resolvedTarget.endpoint(targetEndpointKey)
+                    : resolvedTarget instanceof Group
+                      ? resolvedTarget.zh
+                      : Number(resolvedTarget.ID);
+
+            if (resolvedTarget instanceof Device && !resolvedBindTarget) {
+                return [
+                    message,
+                    {type, skipDisableReporting},
+                    `Target device '${resolvedTarget.name}' does not have endpoint '${targetEndpointKey}'`,
+                ];
+            }
+
+            return [
+                message,
+                {
+                    type,
+                    sourceKey,
+                    sourceEndpointKey,
+                    targetKey,
+                    targetEndpointKey,
+                    clusters,
+                    skipDisableReporting,
+                    resolvedSource,
+                    resolvedTarget,
+                    resolvedSourceEndpoint,
+                    resolvedBindTarget,
+                },
+                undefined,
+            ];
+        } else {
+            return [undefined, undefined, undefined];
+        }
     }
 
     @bind private async onMQTTMessage(data: eventdata.MQTTMessage): Promise<void> {
-        const parsed = this.parseMQTTMessage(data);
+        const [raw, parsed, error] = this.parseMQTTMessage(data);
 
-        if (!parsed || !parsed.type) {
+        if (!raw || !parsed) {
             return;
         }
 
-        const {type, sourceKey, targetKey, clusters, skipDisableReporting} = parsed;
-        const message = utils.parseJSON(data.message, data.message);
+        if (error) {
+            await this.publishResponse(parsed.type, raw, {}, error);
+            return;
+        }
 
-        let error: string | undefined;
-        const parsedSource = this.zigbee.resolveEntityAndEndpoint(sourceKey);
-        const parsedTarget = this.zigbee.resolveEntityAndEndpoint(targetKey);
-        const source = parsedSource.entity;
-        const target = targetKey === DEFAULT_BIND_GROUP.name ? DEFAULT_BIND_GROUP : parsedTarget.entity;
-        const responseData: KeyValue = {from: sourceKey, to: targetKey};
+        const {
+            type,
+            sourceKey,
+            sourceEndpointKey,
+            targetKey,
+            targetEndpointKey,
+            clusters,
+            skipDisableReporting,
+            resolvedSource,
+            resolvedTarget,
+            resolvedSourceEndpoint,
+            resolvedBindTarget,
+        } = parsed;
 
-        if (!source || !(source instanceof Device)) {
-            error = `Source device '${sourceKey}' does not exist`;
-        } else if (parsedSource.endpointID && !parsedSource.endpoint) {
-            error = `Source device '${parsedSource.ID}' does not have endpoint '${parsedSource.endpointID}'`;
-        } else if (!target) {
-            error = `Target device or group '${targetKey}' does not exist`;
-        } else if (target instanceof Device && parsedTarget.endpointID && !parsedTarget.endpoint) {
-            error = `Target device '${parsedTarget.ID}' does not have endpoint '${parsedTarget.endpointID}'`;
-        } else {
-            const successfulClusters: string[] = [];
-            const failedClusters = [];
-            const attemptedClusters = [];
+        assert(resolvedSource, '`resolvedSource` is missing');
+        assert(resolvedTarget, '`resolvedTarget` is missing');
+        assert(resolvedSourceEndpoint, '`resolvedSourceEndpoint` is missing');
+        assert(resolvedBindTarget != undefined, '`resolvedBindTarget` is missing');
 
-            const bindSource = parsedSource.endpoint;
-            const bindTarget = target instanceof Device ? parsedTarget.endpoint : target instanceof Group ? target.zh : Number(target.ID);
+        const successfulClusters: string[] = [];
+        const failedClusters = [];
+        const attemptedClusters = [];
+        // Find which clusters are supported by both the source and target.
+        // Groups are assumed to support all clusters.
+        const clusterCandidates = clusters ?? ALL_CLUSTER_CANDIDATES;
 
-            assert(bindSource != undefined && bindTarget != undefined);
+        for (const cluster of clusterCandidates) {
+            let matchingClusters = false;
 
-            // Find which clusters are supported by both the source and target.
-            // Groups are assumed to support all clusters.
-            const clusterCandidates = clusters ?? ALL_CLUSTER_CANDIDATES;
+            const anyClusterValid =
+                utils.isZHGroup(resolvedBindTarget) ||
+                typeof resolvedBindTarget === 'number' ||
+                (resolvedTarget instanceof Device && resolvedTarget.zh.type === 'Coordinator');
 
-            for (const cluster of clusterCandidates) {
-                let matchingClusters = false;
+            if (!anyClusterValid && utils.isZHEndpoint(resolvedBindTarget)) {
+                matchingClusters =
+                    (resolvedBindTarget.supportsInputCluster(cluster) && resolvedSourceEndpoint.supportsOutputCluster(cluster)) ||
+                    (resolvedSourceEndpoint.supportsInputCluster(cluster) && resolvedBindTarget.supportsOutputCluster(cluster));
+            }
 
-                const anyClusterValid = utils.isZHGroup(bindTarget) || typeof bindTarget === 'number' || (target as Device).zh.type === 'Coordinator';
+            const sourceValid = resolvedSourceEndpoint.supportsInputCluster(cluster) || resolvedSourceEndpoint.supportsOutputCluster(cluster);
 
-                if (!anyClusterValid && utils.isZHEndpoint(bindTarget)) {
-                    matchingClusters =
-                        (bindTarget.supportsInputCluster(cluster) && bindSource.supportsOutputCluster(cluster)) ||
-                        (bindSource.supportsInputCluster(cluster) && bindTarget.supportsOutputCluster(cluster));
-                }
+            if (sourceValid && (anyClusterValid || matchingClusters)) {
+                logger.debug(`${type}ing cluster '${cluster}' from '${resolvedSource.name}' to '${resolvedTarget.name}'`);
+                attemptedClusters.push(cluster);
 
-                const sourceValid = bindSource.supportsInputCluster(cluster) || bindSource.supportsOutputCluster(cluster);
-
-                if (sourceValid && (anyClusterValid || matchingClusters)) {
-                    logger.debug(`${type}ing cluster '${cluster}' from '${source.name}' to '${target.name}'`);
-                    attemptedClusters.push(cluster);
-
-                    try {
-                        if (type === 'bind') {
-                            await bindSource.bind(cluster, bindTarget);
-                        } else {
-                            await bindSource.unbind(cluster, bindTarget);
-                        }
-
-                        successfulClusters.push(cluster);
-                        logger.info(
-                            `Successfully ${type === 'bind' ? 'bound' : 'unbound'} cluster '${cluster}' from '${source.name}' to '${target.name}'`,
-                        );
-                    } catch (error) {
-                        failedClusters.push(cluster);
-                        logger.error(`Failed to ${type} cluster '${cluster}' from '${source.name}' to '${target.name}' (${error})`);
+                try {
+                    if (type === 'bind') {
+                        await resolvedSourceEndpoint.bind(cluster, resolvedBindTarget);
+                    } else {
+                        await resolvedSourceEndpoint.unbind(cluster, resolvedBindTarget);
                     }
-                }
-            }
 
-            if (attemptedClusters.length === 0) {
-                logger.error(`Nothing to ${type} from '${source.name}' to '${target.name}'`);
-                error = `Nothing to ${type}`;
-            } else if (failedClusters.length === attemptedClusters.length) {
-                error = `Failed to ${type}`;
-            }
-
-            responseData[`clusters`] = successfulClusters;
-            responseData[`failed`] = failedClusters;
-
-            if (successfulClusters.length !== 0) {
-                if (type === 'bind') {
-                    await this.setupReporting(bindSource.binds.filter((b) => successfulClusters.includes(b.cluster.name) && b.target === bindTarget));
-                } else if (typeof bindTarget !== 'number' && !skipDisableReporting) {
-                    await this.disableUnnecessaryReportings(bindTarget);
+                    successfulClusters.push(cluster);
+                    logger.info(
+                        `Successfully ${type === 'bind' ? 'bound' : 'unbound'} cluster '${cluster}' from '${resolvedSource.name}' to '${resolvedTarget.name}'`,
+                    );
+                } catch (error) {
+                    failedClusters.push(cluster);
+                    logger.error(`Failed to ${type} cluster '${cluster}' from '${resolvedSource.name}' to '${resolvedTarget.name}' (${error})`);
                 }
             }
         }
 
-        const response = utils.getResponse(message, responseData, error);
+        if (attemptedClusters.length === 0) {
+            logger.error(`Nothing to ${type} from '${resolvedSource.name}' to '${resolvedTarget.name}'`);
+            await this.publishResponse(parsed.type, raw, {}, `Nothing to ${type}`);
+            return;
+        } else if (failedClusters.length === attemptedClusters.length) {
+            await this.publishResponse(parsed.type, raw, {}, `Failed to ${type}`);
+            return;
+        }
 
-        await this.mqtt.publish(`bridge/response/device/${type}`, stringify(response));
+        const responseData: KeyValue = {
+            from: sourceKey,
+            fromEndpoint: sourceEndpointKey,
+            to: targetKey,
+            toEndpoint: targetEndpointKey,
+            clusters: successfulClusters,
+            failed: failedClusters,
+        };
+
+        /* istanbul ignore else */
+        if (successfulClusters.length !== 0) {
+            if (type === 'bind') {
+                await this.setupReporting(
+                    resolvedSourceEndpoint.binds.filter((b) => successfulClusters.includes(b.cluster.name) && b.target === resolvedBindTarget),
+                );
+            } else if (typeof resolvedBindTarget !== 'number' && !skipDisableReporting) {
+                await this.disableUnnecessaryReportings(resolvedBindTarget);
+            }
+        }
+
+        await this.publishResponse(parsed.type, raw, responseData);
+        this.eventBus.emitDevicesChanged();
+    }
+
+    private async publishResponse(type: ParsedMQTTMessage['type'], request: KeyValue, data: KeyValue, error?: string): Promise<void> {
+        const response = stringify(utils.getResponse(request, data, error));
+        await this.mqtt.publish(`bridge/response/device/${type}`, response);
 
         if (error) {
             logger.error(error);
-        } else {
-            this.eventBus.emitDevicesChanged();
         }
     }
 

--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -196,9 +196,9 @@ const POLL_ON_MESSAGE: Readonly<PollOnMessage> = [
 interface ParsedMQTTMessage {
     type: 'bind' | 'unbind';
     sourceKey?: string;
-    sourceEndpointKey?: string;
+    sourceEndpointKey?: string | number;
     targetKey?: string;
-    targetEndpointKey?: string;
+    targetEndpointKey?: string | number;
     clusters?: string[];
     skipDisableReporting: boolean;
     resolvedSource?: Device;
@@ -209,9 +209,9 @@ interface ParsedMQTTMessage {
 
 interface DataMessage {
     from: ParsedMQTTMessage['sourceKey'];
-    fromEndpoint?: ParsedMQTTMessage['sourceEndpointKey'];
+    from_endpoint?: ParsedMQTTMessage['sourceEndpointKey'];
     to: ParsedMQTTMessage['targetKey'];
-    toEndpoint: ParsedMQTTMessage['targetEndpointKey'];
+    to_endpoint: ParsedMQTTMessage['targetEndpointKey'];
     clusters: ParsedMQTTMessage['clusters'];
     skip_disable_reporting?: ParsedMQTTMessage['skipDisableReporting'];
 }
@@ -238,9 +238,9 @@ export default class Bind extends Extension {
             }
 
             const sourceKey = message.from;
-            const sourceEndpointKey = message.fromEndpoint ?? 'default';
+            const sourceEndpointKey = message.from_endpoint ?? 'default';
             const targetKey = message.to;
-            const targetEndpointKey = message.toEndpoint;
+            const targetEndpointKey = message.to_endpoint;
             const clusters = message.clusters;
             skipDisableReporting = message.skip_disable_reporting != undefined ? message.skip_disable_reporting : false;
             const resolvedSource = this.zigbee.resolveEntity(message.from) as Device;
@@ -390,9 +390,9 @@ export default class Bind extends Extension {
 
         const responseData: KeyValue = {
             from: sourceKey,
-            fromEndpoint: sourceEndpointKey,
+            from_endpoint: sourceEndpointKey,
             to: targetKey,
-            toEndpoint: targetEndpointKey,
+            to_endpoint: targetEndpointKey,
             clusters: successfulClusters,
             failed: failedClusters,
         };

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -221,11 +221,11 @@ export default class Groups extends Extension {
                 return [message, {type, skipDisableReporting}, `Device '${message.device}' does not exist`];
             }
 
-            const endpointKey = message.endpoint;
+            const endpointKey = message.endpoint ?? 'default';
             const resolvedEndpoint = resolvedDevice.endpoint(message.endpoint);
 
             if (!resolvedEndpoint) {
-                return [message, {type, skipDisableReporting}, `Device '${resolvedDevice.name}' does not have endpoint '${message.endpoint}'`];
+                return [message, {type, skipDisableReporting}, `Device '${resolvedDevice.name}' does not have endpoint '${endpointKey}'`];
             }
 
             return [
@@ -293,14 +293,10 @@ export default class Groups extends Extension {
             return;
         }
 
-        const responseData: KeyValue = {device: deviceKey};
+        const responseData: KeyValue = {device: deviceKey, endpoint: endpointKey};
 
         if (groupKey) {
             responseData.group = groupKey;
-        }
-
-        if (endpointKey) {
-            responseData.endpoint = endpointKey;
         }
 
         await this.publishResponse(parsed.type, raw, responseData);

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -35,7 +35,7 @@ interface ParsedMQTTMessage {
     resolvedEndpoint?: zh.Endpoint;
     groupKey?: string;
     deviceKey?: string;
-    endpointKey?: string;
+    endpointKey?: string | number;
     skipDisableReporting: boolean;
 }
 

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -30,13 +30,20 @@ const STATE_PROPERTIES: Readonly<Record<string, (value: string, exposes: zhc.Exp
 
 interface ParsedMQTTMessage {
     type: 'remove' | 'add' | 'remove_all';
-    resolvedEntityGroup?: Group;
-    resolvedEntityDevice: Device;
-    error?: string;
+    resolvedGroup?: Group;
+    resolvedDevice?: Device;
+    resolvedEndpoint?: zh.Endpoint;
     groupKey?: string;
     deviceKey?: string;
+    endpointKey?: string;
     skipDisableReporting: boolean;
-    resolvedEntityEndpoint?: zh.Endpoint;
+}
+
+interface DataMessage {
+    device: ParsedMQTTMessage['deviceKey'];
+    group: ParsedMQTTMessage['groupKey'];
+    endpoint: ParsedMQTTMessage['endpointKey'];
+    skip_disable_reporting?: ParsedMQTTMessage['skipDisableReporting'];
 }
 
 export default class Groups extends Extension {
@@ -248,142 +255,159 @@ export default class Groups extends Extension {
         return true;
     }
 
-    private async parseMQTTMessage(data: eventdata.MQTTMessage): Promise<ParsedMQTTMessage | undefined> {
-        let type: ParsedMQTTMessage['type'] | undefined;
-        let resolvedEntityGroup: ParsedMQTTMessage['resolvedEntityGroup'] | undefined;
-        let resolvedEntityDevice: ParsedMQTTMessage['resolvedEntityDevice'] | undefined;
-        let resolvedEntityEndpoint: ParsedMQTTMessage['resolvedEntityEndpoint'] | undefined;
-        let error: ParsedMQTTMessage['error'] | undefined;
-        let groupKey: ParsedMQTTMessage['groupKey'] | undefined;
-        let deviceKey: ParsedMQTTMessage['deviceKey'] | undefined;
-        let skipDisableReporting: ParsedMQTTMessage['skipDisableReporting'] = false;
-
-        /* istanbul ignore else */
+    private parseMQTTMessage(
+        data: eventdata.MQTTMessage,
+    ): [raw: KeyValue | undefined, parsed: ParsedMQTTMessage | undefined, error: string | undefined] {
         const topicRegexMatch = data.topic.match(TOPIC_REGEX);
 
         if (topicRegexMatch) {
-            type = topicRegexMatch[1] as 'remove' | 'add' | 'remove_all';
-            const message = JSON.parse(data.message);
-            deviceKey = message.device;
-            skipDisableReporting = 'skip_disable_reporting' in message ? message.skip_disable_reporting : false;
+            const type = topicRegexMatch[1] as 'remove' | 'add' | 'remove_all';
+            let resolvedGroup;
+            let groupKey;
+            let skipDisableReporting = false;
+            const message: DataMessage = JSON.parse(data.message);
+
+            if (typeof message !== 'object' || message.device == undefined) {
+                return [message, {type, skipDisableReporting}, 'Invalid payload'];
+            }
+
+            const deviceKey = message.device;
+            skipDisableReporting = message.skip_disable_reporting != undefined ? message.skip_disable_reporting : false;
 
             if (type !== 'remove_all') {
                 groupKey = message.group;
-                resolvedEntityGroup = this.zigbee.resolveEntity(message.group) as Group;
 
-                if (!resolvedEntityGroup || !(resolvedEntityGroup instanceof Group)) {
-                    error = `Group '${message.group}' does not exist`;
+                if (message.group == undefined) {
+                    return [message, {type, skipDisableReporting}, `Invalid payload`];
+                }
+
+                resolvedGroup = this.zigbee.resolveEntity(message.group);
+
+                if (!resolvedGroup || !(resolvedGroup instanceof Group)) {
+                    return [message, {type, skipDisableReporting}, `Group '${message.group}' does not exist`];
                 }
             }
 
-            const parsed = this.zigbee.resolveEntityAndEndpoint(message.device);
-            resolvedEntityDevice = parsed?.entity as Device;
+            const resolvedDevice = this.zigbee.resolveEntity(message.device);
 
-            if (!error && (!resolvedEntityDevice || !(resolvedEntityDevice instanceof Device))) {
-                error = `Device '${message.device}' does not exist`;
+            if (!resolvedDevice || !(resolvedDevice instanceof Device)) {
+                return [message, {type, skipDisableReporting}, `Device '${message.device}' does not exist`];
             }
 
-            if (!error) {
-                resolvedEntityEndpoint = parsed.endpoint;
+            const endpointKey = message.endpoint;
+            const resolvedEndpoint = resolvedDevice.endpoint(message.endpoint);
 
-                if (parsed.endpointID && !resolvedEntityEndpoint) {
-                    error = `Device '${parsed.ID}' does not have endpoint '${parsed.endpointID}'`;
-                }
+            if (!resolvedEndpoint) {
+                return [message, {type, skipDisableReporting}, `Device '${resolvedDevice.name}' does not have endpoint '${message.endpoint}'`];
             }
+
+            return [
+                message,
+                {
+                    resolvedGroup,
+                    resolvedDevice,
+                    resolvedEndpoint,
+                    type,
+                    groupKey,
+                    deviceKey,
+                    endpointKey,
+                    skipDisableReporting,
+                },
+                undefined,
+            ];
         } else {
-            return undefined;
+            return [undefined, undefined, undefined];
         }
-
-        return {
-            resolvedEntityGroup,
-            resolvedEntityDevice,
-            type,
-            error,
-            groupKey,
-            deviceKey,
-            skipDisableReporting,
-            resolvedEntityEndpoint,
-        };
     }
 
     @bind private async onMQTTMessage(data: eventdata.MQTTMessage): Promise<void> {
-        const parsed = await this.parseMQTTMessage(data);
+        const [raw, parsed, error] = this.parseMQTTMessage(data);
 
-        if (!parsed || !parsed.type) {
+        if (!raw || !parsed) {
             return;
         }
 
-        const {resolvedEntityGroup, resolvedEntityDevice, type, groupKey, deviceKey, skipDisableReporting, resolvedEntityEndpoint} = parsed;
-        let error = parsed.error;
-        const changedGroups: Group[] = [];
-
-        if (!error) {
-            assert(resolvedEntityEndpoint, '`resolvedEntityEndpoint` is missing');
-            try {
-                const keys = [
-                    `${resolvedEntityDevice.ieeeAddr}/${resolvedEntityEndpoint.ID}`,
-                    `${resolvedEntityDevice.name}/${resolvedEntityEndpoint.ID}`,
-                ];
-                const endpointNameLocal = resolvedEntityDevice.endpointName(resolvedEntityEndpoint);
-
-                if (endpointNameLocal) {
-                    keys.push(`${resolvedEntityDevice.ieeeAddr}/${endpointNameLocal}`);
-                    keys.push(`${resolvedEntityDevice.name}/${endpointNameLocal}`);
-                }
-
-                if (!endpointNameLocal) {
-                    keys.push(resolvedEntityDevice.name);
-                    keys.push(resolvedEntityDevice.ieeeAddr);
-                }
-
-                if (type === 'add') {
-                    assert(resolvedEntityGroup, '`resolvedEntityGroup` is missing');
-                    logger.info(`Adding '${resolvedEntityDevice.name}' to '${resolvedEntityGroup.name}'`);
-                    await resolvedEntityEndpoint.addToGroup(resolvedEntityGroup.zh);
-                    settings.addDeviceToGroup(resolvedEntityGroup.ID.toString(), keys);
-                    changedGroups.push(resolvedEntityGroup);
-                } else if (type === 'remove') {
-                    assert(resolvedEntityGroup, '`resolvedEntityGroup` is missing');
-                    logger.info(`Removing '${resolvedEntityDevice.name}' from '${resolvedEntityGroup.name}'`);
-                    await resolvedEntityEndpoint.removeFromGroup(resolvedEntityGroup.zh);
-                    settings.removeDeviceFromGroup(resolvedEntityGroup.ID.toString(), keys);
-                    changedGroups.push(resolvedEntityGroup);
-                } else {
-                    // remove_all
-                    logger.info(`Removing '${resolvedEntityDevice.name}' from all groups`);
-
-                    for (const group of this.zigbee.groupsIterator((g) => g.members.includes(resolvedEntityEndpoint))) {
-                        changedGroups.push(group);
-                    }
-
-                    await resolvedEntityEndpoint.removeFromAllGroups();
-
-                    for (const settingsGroup of settings.getGroups()) {
-                        settings.removeDeviceFromGroup(settingsGroup.ID.toString(), keys);
-                    }
-                }
-            } catch (e) {
-                error = `Failed to ${type} from group (${(e as Error).message})`;
-                logger.debug((e as Error).stack!);
-            }
+        if (error) {
+            await this.publishResponse(parsed.type, raw, {}, error);
+            return;
         }
 
-        const message = utils.parseJSON(data.message, data.message);
+        const {resolvedGroup, resolvedDevice, resolvedEndpoint, type, groupKey, deviceKey, endpointKey, skipDisableReporting} = parsed;
+        const changedGroups: Group[] = [];
+
+        assert(resolvedDevice, '`resolvedDevice` is missing');
+        assert(resolvedEndpoint, '`resolvedEndpoint` is missing');
+
+        try {
+            const keys = [`${resolvedDevice.ieeeAddr}/${resolvedEndpoint.ID}`, `${resolvedDevice.name}/${resolvedEndpoint.ID}`];
+            const endpointNameLocal = resolvedDevice.endpointName(resolvedEndpoint);
+
+            if (endpointNameLocal) {
+                keys.push(`${resolvedDevice.ieeeAddr}/${endpointNameLocal}`);
+                keys.push(`${resolvedDevice.name}/${endpointNameLocal}`);
+            }
+
+            if (!endpointNameLocal) {
+                keys.push(resolvedDevice.name);
+                keys.push(resolvedDevice.ieeeAddr);
+            }
+
+            if (type === 'add') {
+                assert(resolvedGroup, '`resolvedGroup` is missing');
+                logger.info(`Adding '${resolvedDevice.name}' to '${resolvedGroup.name}'`);
+                await resolvedEndpoint.addToGroup(resolvedGroup.zh);
+                settings.addDeviceToGroup(resolvedGroup.ID.toString(), keys);
+                changedGroups.push(resolvedGroup);
+            } else if (type === 'remove') {
+                assert(resolvedGroup, '`resolvedGroup` is missing');
+                logger.info(`Removing '${resolvedDevice.name}' from '${resolvedGroup.name}'`);
+                await resolvedEndpoint.removeFromGroup(resolvedGroup.zh);
+                settings.removeDeviceFromGroup(resolvedGroup.ID.toString(), keys);
+                changedGroups.push(resolvedGroup);
+            } else {
+                // remove_all
+                logger.info(`Removing '${resolvedDevice.name}' from all groups`);
+
+                for (const group of this.zigbee.groupsIterator((g) => g.members.includes(resolvedEndpoint))) {
+                    changedGroups.push(group);
+                }
+
+                await resolvedEndpoint.removeFromAllGroups();
+
+                for (const settingsGroup of settings.getGroups()) {
+                    settings.removeDeviceFromGroup(settingsGroup.ID.toString(), keys);
+                }
+            }
+        } catch (e) {
+            const errorMsg = `Failed to ${type} from group (${(e as Error).message})`;
+            await this.publishResponse(parsed.type, raw, {}, errorMsg);
+            logger.debug((e as Error).stack!);
+            return;
+        }
+
         const responseData: KeyValue = {device: deviceKey};
 
         if (groupKey) {
             responseData.group = groupKey;
         }
 
-        await this.mqtt.publish(`bridge/response/group/members/${type}`, stringify(utils.getResponse(message, responseData, error)));
+        if (endpointKey) {
+            responseData.endpoint = endpointKey;
+        }
+
+        await this.publishResponse(parsed.type, raw, responseData);
+
+        for (const group of changedGroups) {
+            this.eventBus.emitGroupMembersChanged({group, action: type, endpoint: resolvedEndpoint, skipDisableReporting});
+        }
+    }
+
+    private async publishResponse(type: ParsedMQTTMessage['type'], request: KeyValue, data: KeyValue, error?: string): Promise<void> {
+        const response = stringify(utils.getResponse(request, data, error));
+        await this.mqtt.publish(`bridge/response/group/members/${type}`, response);
 
         if (error) {
             logger.error(error);
-        } else {
-            assert(resolvedEntityEndpoint, '`resolvedEntityEndpoint` is missing');
-            for (const group of changedGroups) {
-                this.eventBus.emitGroupMembersChanged({group, action: type, endpoint: resolvedEntityEndpoint, skipDisableReporting});
-            }
         }
     }
 }

--- a/test/extensions/bind.test.ts
+++ b/test/extensions/bind.test.ts
@@ -96,7 +96,13 @@ describe('Extension: Bind', () => {
             'zigbee2mqtt/bridge/response/device/bind',
             stringify({
                 transaction: '1234',
-                data: {from: 'remote', to: 'bulb_color', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'], failed: []},
+                data: {
+                    from: 'remote',
+                    fromEndpoint: 'default',
+                    to: 'bulb_color',
+                    clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'],
+                    failed: [],
+                },
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -108,6 +114,18 @@ describe('Extension: Bind', () => {
         // Teardown
         target.binds = originalTargetBinds;
         device.getEndpoint(1)!.outputClusters = originalDeviceOutputClusters;
+    });
+
+    it('Should throw error on invalid payload', async () => {
+        mockMQTT.publish.mockClear();
+        mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/bind', stringify({fromz: 'remote', to: 'bulb_color'}));
+        await flushPromises();
+        expect(mockMQTT.publish).toHaveBeenCalledWith(
+            'zigbee2mqtt/bridge/response/device/bind',
+            stringify({data: {}, status: 'error', error: 'Invalid payload'}),
+            {retain: false, qos: 0},
+            expect.any(Function),
+        );
     });
 
     it('Filters out unsupported clusters for reporting setup', async () => {
@@ -156,7 +174,13 @@ describe('Extension: Bind', () => {
             'zigbee2mqtt/bridge/response/device/bind',
             stringify({
                 transaction: '1234',
-                data: {from: 'remote', to: 'bulb_color', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'], failed: []},
+                data: {
+                    from: 'remote',
+                    fromEndpoint: 'default',
+                    to: 'bulb_color',
+                    clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'],
+                    failed: [],
+                },
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -221,7 +245,13 @@ describe('Extension: Bind', () => {
             'zigbee2mqtt/bridge/response/device/bind',
             stringify({
                 transaction: '1234',
-                data: {from: 'remote', to: 'bulb_color', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'], failed: []},
+                data: {
+                    from: 'remote',
+                    fromEndpoint: 'default',
+                    to: 'bulb_color',
+                    clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'],
+                    failed: [],
+                },
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -247,7 +277,7 @@ describe('Extension: Bind', () => {
         expect(endpoint.bind).toHaveBeenCalledWith('genOnOff', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'remote', to: 'bulb_color', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
+            stringify({data: {from: 'remote', fromEndpoint: 'default', to: 'bulb_color', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -263,7 +293,7 @@ describe('Extension: Bind', () => {
         expect(endpoint.bind).toHaveBeenCalledTimes(0);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'remote', to: 'button', clusters: [], failed: []}, status: 'error', error: 'Nothing to bind'}),
+            stringify({data: {}, status: 'error', error: 'Nothing to bind'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -313,7 +343,10 @@ describe('Extension: Bind', () => {
         expect(devices.bulb_color.meta.configured).toBe(332242049);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/unbind',
-            stringify({data: {from: 'remote', to: 'bulb_color', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []}, status: 'ok'}),
+            stringify({
+                data: {from: 'remote', fromEndpoint: 'default', to: 'bulb_color', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                status: 'ok',
+            }),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -337,7 +370,10 @@ describe('Extension: Bind', () => {
         expect(endpoint.unbind).toHaveBeenCalledWith('genScenes', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/unbind',
-            stringify({data: {from: 'remote', to: 'Coordinator', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []}, status: 'ok'}),
+            stringify({
+                data: {from: 'remote', fromEndpoint: 'default', to: 'Coordinator', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                status: 'ok',
+            }),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -366,7 +402,10 @@ describe('Extension: Bind', () => {
         ]);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'remote', to: 'group_1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []}, status: 'ok'}),
+            stringify({
+                data: {from: 'remote', fromEndpoint: 'default', to: 'group_1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                status: 'ok',
+            }),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -400,7 +439,10 @@ describe('Extension: Bind', () => {
         expect(endpoint.unbind).toHaveBeenCalledWith('genScenes', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/unbind',
-            stringify({data: {from: 'remote', to: 'group_1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []}, status: 'ok'}),
+            stringify({
+                data: {from: 'remote', fromEndpoint: 'default', to: 'group_1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                status: 'ok',
+            }),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -475,7 +517,10 @@ describe('Extension: Bind', () => {
         expect(endpoint.bind).toHaveBeenCalledWith('genScenes', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'remote', to: '1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []}, status: 'ok'}),
+            stringify({
+                data: {from: 'remote', fromEndpoint: 'default', to: '1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                status: 'ok',
+            }),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -494,11 +539,7 @@ describe('Extension: Bind', () => {
         expect(endpoint.bind).toHaveBeenCalledTimes(3);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({
-                data: {from: 'remote', to: 'bulb_color', clusters: [], failed: ['genScenes', 'genOnOff', 'genLevelCtrl']},
-                status: 'error',
-                error: 'Failed to bind',
-            }),
+            stringify({data: {}, status: 'error', error: 'Failed to bind'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -509,13 +550,19 @@ describe('Extension: Bind', () => {
         const target = devices.QBKG03LM.getEndpoint(3)!;
         const endpoint = device.getEndpoint(2)!;
         mockClear(device);
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/bind', stringify({from: 'remote/ep2', to: 'wall_switch_double/right'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/device/bind',
+            stringify({from: 'remote', fromEndpoint: 'ep2', to: 'wall_switch_double', toEndpoint: 'right'}),
+        );
         await flushPromises();
         expect(endpoint.bind).toHaveBeenCalledTimes(1);
         expect(endpoint.bind).toHaveBeenCalledWith('genOnOff', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'remote/ep2', to: 'wall_switch_double/right', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
+            stringify({
+                data: {from: 'remote', fromEndpoint: 'ep2', to: 'wall_switch_double', toEndpoint: 'right', clusters: ['genOnOff'], failed: []},
+                status: 'ok',
+            }),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -532,7 +579,16 @@ describe('Extension: Bind', () => {
         expect(endpoint.bind).toHaveBeenCalledWith('msTemperatureMeasurement', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'temperature_sensor', to: 'heating_actuator', clusters: ['msTemperatureMeasurement'], failed: []}, status: 'ok'}),
+            stringify({
+                data: {
+                    from: 'temperature_sensor',
+                    fromEndpoint: 'default',
+                    to: 'heating_actuator',
+                    clusters: ['msTemperatureMeasurement'],
+                    failed: [],
+                },
+                status: 'ok',
+            }),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -543,13 +599,13 @@ describe('Extension: Bind', () => {
         const target = devices.QBKG04LM.getEndpoint(2)!;
         const endpoint = device.getEndpoint(2)!;
         mockClear(device);
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/bind', stringify({from: 'remote/ep2', to: 'wall_switch'}));
+        mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/bind', stringify({from: 'remote', fromEndpoint: 'ep2', to: 'wall_switch'}));
         await flushPromises();
         expect(endpoint.bind).toHaveBeenCalledTimes(1);
         expect(endpoint.bind).toHaveBeenCalledWith('genOnOff', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'remote/ep2', to: 'wall_switch', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
+            stringify({data: {from: 'remote', fromEndpoint: 'ep2', to: 'wall_switch', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -569,7 +625,13 @@ describe('Extension: Bind', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/unbind',
             stringify({
-                data: {from: 'remote', to: 'default_bind_group', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                data: {
+                    from: 'remote',
+                    fromEndpoint: 'default',
+                    to: 'default_bind_group',
+                    clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'],
+                    failed: [],
+                },
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -584,11 +646,7 @@ describe('Extension: Bind', () => {
         await flushPromises();
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({
-                data: {from: 'remote_not_existing', to: 'bulb_color'},
-                status: 'error',
-                error: "Source device 'remote_not_existing' does not exist",
-            }),
+            stringify({data: {}, status: 'error', error: "Source device 'remote_not_existing' does not exist"}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -597,15 +655,14 @@ describe('Extension: Bind', () => {
     it("Error bind fails when source device's endpoint does not exist", async () => {
         const device = devices.remote;
         mockClear(device);
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/bind', stringify({from: 'remote/not_existing_endpoint', to: 'bulb_color'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/device/bind',
+            stringify({from: 'remote', fromEndpoint: 'not_existing_endpoint', to: 'bulb_color'}),
+        );
         await flushPromises();
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({
-                data: {from: 'remote/not_existing_endpoint', to: 'bulb_color'},
-                status: 'error',
-                error: "Source device 'remote' does not have endpoint 'not_existing_endpoint'",
-            }),
+            stringify({data: {}, status: 'error', error: "Source device 'remote' does not have endpoint 'not_existing_endpoint'"}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -618,11 +675,7 @@ describe('Extension: Bind', () => {
         await flushPromises();
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({
-                data: {from: 'remote', to: 'bulb_color_not_existing'},
-                status: 'error',
-                error: "Target device or group 'bulb_color_not_existing' does not exist",
-            }),
+            stringify({data: {}, status: 'error', error: "Target device or group 'bulb_color_not_existing' does not exist"}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -631,15 +684,14 @@ describe('Extension: Bind', () => {
     it("Error bind fails when target device's endpoint does not exist", async () => {
         const device = devices.remote;
         mockClear(device);
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/bind', stringify({from: 'remote', to: 'bulb_color/not_existing_endpoint'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/device/bind',
+            stringify({from: 'remote', to: 'bulb_color', toEndpoint: 'not_existing_endpoint'}),
+        );
         await flushPromises();
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({
-                data: {from: 'remote', to: 'bulb_color/not_existing_endpoint'},
-                status: 'error',
-                error: "Target device 'bulb_color' does not have endpoint 'not_existing_endpoint'",
-            }),
+            stringify({data: {}, status: 'error', error: "Target device 'bulb_color' does not have endpoint 'not_existing_endpoint'"}),
             {retain: false, qos: 0},
             expect.any(Function),
         );

--- a/test/extensions/bind.test.ts
+++ b/test/extensions/bind.test.ts
@@ -545,7 +545,7 @@ describe('Extension: Bind', () => {
         );
     });
 
-    it('Should bind from non default endpoints', async () => {
+    it('Should bind from non default endpoint names', async () => {
         const device = devices.remote;
         const target = devices.QBKG03LM.getEndpoint(3)!;
         const endpoint = device.getEndpoint(2)!;
@@ -561,6 +561,29 @@ describe('Extension: Bind', () => {
             'zigbee2mqtt/bridge/response/device/bind',
             stringify({
                 data: {from: 'remote', from_endpoint: 'ep2', to: 'wall_switch_double', to_endpoint: 'right', clusters: ['genOnOff'], failed: []},
+                status: 'ok',
+            }),
+            {retain: false, qos: 0},
+            expect.any(Function),
+        );
+    });
+
+    it('Should bind from non default endpoint IDs', async () => {
+        const device = devices.remote;
+        const target = devices.QBKG03LM.getEndpoint(3)!;
+        const endpoint = device.getEndpoint(2)!;
+        mockClear(device);
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/device/bind',
+            stringify({from: 'remote', from_endpoint: 2, to: 'wall_switch_double', to_endpoint: 3}),
+        );
+        await flushPromises();
+        expect(endpoint.bind).toHaveBeenCalledTimes(1);
+        expect(endpoint.bind).toHaveBeenCalledWith('genOnOff', target);
+        expect(mockMQTT.publish).toHaveBeenCalledWith(
+            'zigbee2mqtt/bridge/response/device/bind',
+            stringify({
+                data: {from: 'remote', from_endpoint: 2, to: 'wall_switch_double', to_endpoint: 3, clusters: ['genOnOff'], failed: []},
                 status: 'ok',
             }),
             {retain: false, qos: 0},

--- a/test/extensions/bind.test.ts
+++ b/test/extensions/bind.test.ts
@@ -98,7 +98,7 @@ describe('Extension: Bind', () => {
                 transaction: '1234',
                 data: {
                     from: 'remote',
-                    fromEndpoint: 'default',
+                    from_endpoint: 'default',
                     to: 'bulb_color',
                     clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'],
                     failed: [],
@@ -176,7 +176,7 @@ describe('Extension: Bind', () => {
                 transaction: '1234',
                 data: {
                     from: 'remote',
-                    fromEndpoint: 'default',
+                    from_endpoint: 'default',
                     to: 'bulb_color',
                     clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'],
                     failed: [],
@@ -247,7 +247,7 @@ describe('Extension: Bind', () => {
                 transaction: '1234',
                 data: {
                     from: 'remote',
-                    fromEndpoint: 'default',
+                    from_endpoint: 'default',
                     to: 'bulb_color',
                     clusters: ['genScenes', 'genOnOff', 'genLevelCtrl', 'lightingColorCtrl'],
                     failed: [],
@@ -277,7 +277,7 @@ describe('Extension: Bind', () => {
         expect(endpoint.bind).toHaveBeenCalledWith('genOnOff', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'remote', fromEndpoint: 'default', to: 'bulb_color', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
+            stringify({data: {from: 'remote', from_endpoint: 'default', to: 'bulb_color', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -344,7 +344,7 @@ describe('Extension: Bind', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/unbind',
             stringify({
-                data: {from: 'remote', fromEndpoint: 'default', to: 'bulb_color', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                data: {from: 'remote', from_endpoint: 'default', to: 'bulb_color', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -371,7 +371,7 @@ describe('Extension: Bind', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/unbind',
             stringify({
-                data: {from: 'remote', fromEndpoint: 'default', to: 'Coordinator', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                data: {from: 'remote', from_endpoint: 'default', to: 'Coordinator', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -403,7 +403,7 @@ describe('Extension: Bind', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
             stringify({
-                data: {from: 'remote', fromEndpoint: 'default', to: 'group_1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                data: {from: 'remote', from_endpoint: 'default', to: 'group_1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -440,7 +440,7 @@ describe('Extension: Bind', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/unbind',
             stringify({
-                data: {from: 'remote', fromEndpoint: 'default', to: 'group_1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                data: {from: 'remote', from_endpoint: 'default', to: 'group_1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -518,7 +518,7 @@ describe('Extension: Bind', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
             stringify({
-                data: {from: 'remote', fromEndpoint: 'default', to: '1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
+                data: {from: 'remote', from_endpoint: 'default', to: '1', clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'], failed: []},
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -552,7 +552,7 @@ describe('Extension: Bind', () => {
         mockClear(device);
         mockMQTTEvents.message(
             'zigbee2mqtt/bridge/request/device/bind',
-            stringify({from: 'remote', fromEndpoint: 'ep2', to: 'wall_switch_double', toEndpoint: 'right'}),
+            stringify({from: 'remote', from_endpoint: 'ep2', to: 'wall_switch_double', to_endpoint: 'right'}),
         );
         await flushPromises();
         expect(endpoint.bind).toHaveBeenCalledTimes(1);
@@ -560,7 +560,7 @@ describe('Extension: Bind', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
             stringify({
-                data: {from: 'remote', fromEndpoint: 'ep2', to: 'wall_switch_double', toEndpoint: 'right', clusters: ['genOnOff'], failed: []},
+                data: {from: 'remote', from_endpoint: 'ep2', to: 'wall_switch_double', to_endpoint: 'right', clusters: ['genOnOff'], failed: []},
                 status: 'ok',
             }),
             {retain: false, qos: 0},
@@ -582,7 +582,7 @@ describe('Extension: Bind', () => {
             stringify({
                 data: {
                     from: 'temperature_sensor',
-                    fromEndpoint: 'default',
+                    from_endpoint: 'default',
                     to: 'heating_actuator',
                     clusters: ['msTemperatureMeasurement'],
                     failed: [],
@@ -599,13 +599,13 @@ describe('Extension: Bind', () => {
         const target = devices.QBKG04LM.getEndpoint(2)!;
         const endpoint = device.getEndpoint(2)!;
         mockClear(device);
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/bind', stringify({from: 'remote', fromEndpoint: 'ep2', to: 'wall_switch'}));
+        mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/bind', stringify({from: 'remote', from_endpoint: 'ep2', to: 'wall_switch'}));
         await flushPromises();
         expect(endpoint.bind).toHaveBeenCalledTimes(1);
         expect(endpoint.bind).toHaveBeenCalledWith('genOnOff', target);
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/bind',
-            stringify({data: {from: 'remote', fromEndpoint: 'ep2', to: 'wall_switch', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
+            stringify({data: {from: 'remote', from_endpoint: 'ep2', to: 'wall_switch', clusters: ['genOnOff'], failed: []}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -627,7 +627,7 @@ describe('Extension: Bind', () => {
             stringify({
                 data: {
                     from: 'remote',
-                    fromEndpoint: 'default',
+                    from_endpoint: 'default',
                     to: 'default_bind_group',
                     clusters: ['genScenes', 'genOnOff', 'genLevelCtrl'],
                     failed: [],
@@ -657,7 +657,7 @@ describe('Extension: Bind', () => {
         mockClear(device);
         mockMQTTEvents.message(
             'zigbee2mqtt/bridge/request/device/bind',
-            stringify({from: 'remote', fromEndpoint: 'not_existing_endpoint', to: 'bulb_color'}),
+            stringify({from: 'remote', from_endpoint: 'not_existing_endpoint', to: 'bulb_color'}),
         );
         await flushPromises();
         expect(mockMQTT.publish).toHaveBeenCalledWith(
@@ -686,7 +686,7 @@ describe('Extension: Bind', () => {
         mockClear(device);
         mockMQTTEvents.message(
             'zigbee2mqtt/bridge/request/device/bind',
-            stringify({from: 'remote', to: 'bulb_color', toEndpoint: 'not_existing_endpoint'}),
+            stringify({from: 'remote', to: 'bulb_color', to_endpoint: 'not_existing_endpoint'}),
         );
         await flushPromises();
         expect(mockMQTT.publish).toHaveBeenCalledWith(

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -3563,7 +3563,8 @@ describe('Extension: Bridge', () => {
         mockMQTTEvents.message(
             'zigbee2mqtt/bridge/request/device/configure_reporting',
             stringify({
-                id: '0x000b57fffec6a5b2/1',
+                id: '0x000b57fffec6a5b2',
+                endpoint: '1',
                 cluster: 'genLevelCtrl',
                 attribute: 'currentLevel',
                 maximum_report_interval: 10,
@@ -3584,7 +3585,8 @@ describe('Extension: Bridge', () => {
             'zigbee2mqtt/bridge/response/device/configure_reporting',
             stringify({
                 data: {
-                    id: '0x000b57fffec6a5b2/1',
+                    id: '0x000b57fffec6a5b2',
+                    endpoint: '1',
                     cluster: 'genLevelCtrl',
                     attribute: 'currentLevel',
                     maximum_report_interval: 10,
@@ -3608,8 +3610,9 @@ describe('Extension: Bridge', () => {
             'zigbee2mqtt/bridge/request/device/configure_reporting',
             stringify({
                 id: 'bulb',
+                // endpoint: '1',
                 cluster: 'genLevelCtrl',
-                attribute_lala: 'currentLevel',
+                attribute: 'currentLevel',
                 maximum_report_interval: 10,
                 minimum_report_interval: 1,
                 reportable_change: 1,
@@ -3634,6 +3637,7 @@ describe('Extension: Bridge', () => {
             'zigbee2mqtt/bridge/request/device/configure_reporting',
             stringify({
                 id: 'non_existing_device',
+                endpoint: '1',
                 cluster: 'genLevelCtrl',
                 attribute: 'currentLevel',
                 maximum_report_interval: 10,
@@ -3659,7 +3663,8 @@ describe('Extension: Bridge', () => {
         mockMQTTEvents.message(
             'zigbee2mqtt/bridge/request/device/configure_reporting',
             stringify({
-                id: '0x000b57fffec6a5b2/non_existing_endpoint',
+                id: '0x000b57fffec6a5b2',
+                endpoint: 'non_existing_endpoint',
                 cluster: 'genLevelCtrl',
                 attribute: 'currentLevel',
                 maximum_report_interval: 10,

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -527,7 +527,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/add',
-            stringify({data: {device: 'bulb_color', group: 'group_1'}, transaction: '123', status: 'ok'}),
+            stringify({data: {device: 'bulb_color', endpoint: 'default', group: 'group_1'}, transaction: '123', status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -568,7 +568,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/add',
-            stringify({data: {device: 'bulb_color', group: 'group/with/slashes'}, status: 'ok'}),
+            stringify({data: {device: 'bulb_color', endpoint: 'default', group: 'group/with/slashes'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -633,7 +633,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/remove',
-            stringify({data: {device: 'bulb_color', group: 'group_1'}, status: 'ok'}),
+            stringify({data: {device: 'bulb_color', endpoint: 'default', group: 'group_1'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -654,7 +654,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/remove',
-            stringify({data: {device: 'bulb_color', group: 'group_1'}, status: 'ok'}),
+            stringify({data: {device: 'bulb_color', endpoint: 'default', group: 'group_1'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -661,7 +661,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTT.publish).not.toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/add',
-            stringify({data: {device: 'bulb_color', group: 'group_1'}, status: 'error', error: 'Failed to add from group (timeout)'}),
+            stringify({data: {}, status: 'error', error: 'Failed to add from group (timeout)'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -695,14 +695,17 @@ describe('Extension: Groups', () => {
         expect(group.members.length).toBe(0);
         await resetExtension();
         mockMQTT.publish.mockClear();
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/add', stringify({group: 'group_1', device: 'wall_switch_double/right'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/group/members/add',
+            stringify({group: 'group_1', device: 'wall_switch_double', endpoint: 'right'}),
+        );
         await flushPromises();
         expect(group.members).toStrictEqual([endpoint]);
         expect(settings.getGroup('group_1').devices).toStrictEqual([`${device.ieeeAddr}/${endpoint.ID}`]);
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/add',
-            stringify({data: {device: 'wall_switch_double/right', group: 'group_1'}, status: 'ok'}),
+            stringify({data: {device: 'wall_switch_double', endpoint: 'right', group: 'group_1'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -715,16 +718,22 @@ describe('Extension: Groups', () => {
         expect(group.members.length).toBe(0);
         await resetExtension();
         mockMQTT.publish.mockClear();
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/add', stringify({group: 'group_1', device: 'wall_switch_double/right'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/group/members/add',
+            stringify({group: 'group_1', device: 'wall_switch_double', endpoint: 'right'}),
+        );
         await flushPromises();
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/add', stringify({group: 'group_1', device: '0x0017880104e45542/3'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/group/members/add',
+            stringify({group: 'group_1', device: '0x0017880104e45542', endpoint: '3'}),
+        );
         await flushPromises();
         expect(group.members).toStrictEqual([endpoint]);
         expect(settings.getGroup('group_1').devices).toStrictEqual([`${device.ieeeAddr}/${endpoint.ID}`]);
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/add',
-            stringify({data: {device: 'wall_switch_double/right', group: 'group_1'}, status: 'ok'}),
+            stringify({data: {device: 'wall_switch_double', endpoint: 'right', group: 'group_1'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -804,14 +813,17 @@ describe('Extension: Groups', () => {
         settings.set(['groups'], {1: {friendly_name: 'group_1', retain: false, devices: [`wall_switch_double/right`]}});
         await resetExtension();
         mockMQTT.publish.mockClear();
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/remove', stringify({group: 'group_1', device: '0x0017880104e45542/3'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/group/members/remove',
+            stringify({group: 'group_1', device: '0x0017880104e45542', endpoint: '3'}),
+        );
         await flushPromises();
         expect(group.members).toStrictEqual([]);
         expect(settings.getGroup('group_1').devices).toStrictEqual([]);
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/remove',
-            stringify({data: {device: '0x0017880104e45542/3', group: 'group_1'}, status: 'ok'}),
+            stringify({data: {device: '0x0017880104e45542', endpoint: '3', group: 'group_1'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -825,14 +837,17 @@ describe('Extension: Groups', () => {
         settings.set(['groups'], {1: {friendly_name: 'group_1', retain: false, devices: [`0x0017880104e45542/right`]}});
         await resetExtension();
         mockMQTT.publish.mockClear();
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/remove', stringify({group: 'group_1', device: 'wall_switch_double/3'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/group/members/remove',
+            stringify({group: 'group_1', device: 'wall_switch_double', endpoint: '3'}),
+        );
         await flushPromises();
         expect(group.members).toStrictEqual([]);
         expect(settings.getGroup('group_1').devices).toStrictEqual([]);
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/remove',
-            stringify({data: {device: 'wall_switch_double/3', group: 'group_1'}, status: 'ok'}),
+            stringify({data: {device: 'wall_switch_double', endpoint: '3', group: 'group_1'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -846,14 +861,17 @@ describe('Extension: Groups', () => {
         settings.set(['groups'], {1: {friendly_name: 'group_1', retain: false, devices: [`wall_switch_double/3`]}});
         await resetExtension();
         mockMQTT.publish.mockClear();
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/remove', stringify({group: 'group_1', device: '0x0017880104e45542/right'}));
+        mockMQTTEvents.message(
+            'zigbee2mqtt/bridge/request/group/members/remove',
+            stringify({group: 'group_1', device: '0x0017880104e45542', endpoint: 'right'}),
+        );
         await flushPromises();
         expect(group.members).toStrictEqual([]);
         expect(settings.getGroup('group_1').devices).toStrictEqual([]);
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/remove',
-            stringify({data: {device: '0x0017880104e45542/right', group: 'group_1'}, status: 'ok'}),
+            stringify({data: {device: '0x0017880104e45542', endpoint: 'right', group: 'group_1'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -867,14 +885,14 @@ describe('Extension: Groups', () => {
         settings.set(['groups'], {1: {friendly_name: 'group_1', retain: false, devices: [`wall_switch_double/3`]}});
         await resetExtension();
         mockMQTT.publish.mockClear();
-        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/remove_all', stringify({device: '0x0017880104e45542/right'}));
+        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/remove_all', stringify({device: '0x0017880104e45542', endpoint: 'right'}));
         await flushPromises();
         expect(group.members).toStrictEqual([]);
         expect(settings.getGroup('group_1').devices).toStrictEqual([]);
         expect(mockMQTT.publish).toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/remove_all',
-            stringify({data: {device: '0x0017880104e45542/right'}, status: 'ok'}),
+            stringify({data: {device: '0x0017880104e45542', endpoint: 'right'}, status: 'ok'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -889,11 +907,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTT.publish).not.toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/remove',
-            stringify({
-                data: {device: 'bulb_color', group: 'group_1_not_existing'},
-                status: 'error',
-                error: "Group 'group_1_not_existing' does not exist",
-            }),
+            stringify({data: {}, status: 'error', error: "Group 'group_1_not_existing' does not exist"}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -908,11 +922,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTT.publish).not.toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/add',
-            stringify({
-                data: {device: 'bulb_color_not_existing', group: 'group_1'},
-                status: 'error',
-                error: "Device 'bulb_color_not_existing' does not exist",
-            }),
+            stringify({data: {}, status: 'error', error: "Device 'bulb_color_not_existing' does not exist"}),
             {retain: false, qos: 0},
             expect.any(Function),
         );
@@ -924,17 +934,43 @@ describe('Extension: Groups', () => {
         mockMQTT.publish.mockClear();
         mockMQTTEvents.message(
             'zigbee2mqtt/bridge/request/group/members/add',
-            stringify({group: 'group_1', device: 'bulb_color/not_existing_endpoint'}),
+            stringify({group: 'group_1', device: 'bulb_color', endpoint: 'not_existing_endpoint'}),
         );
         await flushPromises();
         expect(mockMQTT.publish).not.toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
         expect(mockMQTT.publish).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/group/members/add',
-            stringify({
-                data: {device: 'bulb_color/not_existing_endpoint', group: 'group_1'},
-                status: 'error',
-                error: "Device 'bulb_color' does not have endpoint 'not_existing_endpoint'",
-            }),
+            stringify({data: {}, status: 'error', error: "Device 'bulb_color' does not have endpoint 'not_existing_endpoint'"}),
+            {retain: false, qos: 0},
+            expect.any(Function),
+        );
+    });
+
+    it('Error when invalid payload', async () => {
+        await resetExtension();
+        mockLogger.error.mockClear();
+        mockMQTT.publish.mockClear();
+        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/add', stringify({group: 'group_1', devicez: 'bulb_color'}));
+        await flushPromises();
+        expect(mockMQTT.publish).not.toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
+        expect(mockMQTT.publish).toHaveBeenCalledWith(
+            'zigbee2mqtt/bridge/response/group/members/add',
+            stringify({data: {}, status: 'error', error: 'Invalid payload'}),
+            {retain: false, qos: 0},
+            expect.any(Function),
+        );
+    });
+
+    it('Error when add/remove with invalid payload', async () => {
+        await resetExtension();
+        mockLogger.error.mockClear();
+        mockMQTT.publish.mockClear();
+        mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/add', stringify({groupz: 'group_1', device: 'bulb_color'}));
+        await flushPromises();
+        expect(mockMQTT.publish).not.toHaveBeenCalledWith('zigbee2mqtt/bridge/groups', expect.any(String), expect.any(Object), expect.any(Function));
+        expect(mockMQTT.publish).toHaveBeenCalledWith(
+            'zigbee2mqtt/bridge/response/group/members/add',
+            stringify({data: {}, status: 'error', error: 'Invalid payload'}),
             {retain: false, qos: 0},
             expect.any(Function),
         );

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -785,7 +785,6 @@ describe('Extension: Groups', () => {
     });
 
     it('Error when invalid payload', async () => {
-        await resetExtension();
         mockLogger.error.mockClear();
         mockMQTT.publish.mockClear();
         mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/add', stringify({group: 'group_1', devicez: 'bulb_color'}));
@@ -800,7 +799,6 @@ describe('Extension: Groups', () => {
     });
 
     it('Error when add/remove with invalid payload', async () => {
-        await resetExtension();
         mockLogger.error.mockClear();
         mockMQTT.publish.mockClear();
         mockMQTTEvents.message('zigbee2mqtt/bridge/request/group/members/add', stringify({groupz: 'group_1', device: 'bulb_color'}));

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -2174,7 +2174,7 @@ describe('Extension: HomeAssistant', () => {
         mockMQTT.publish.mockClear();
         mockMQTTEvents.message(
             'zigbee2mqtt/bridge/request/group/members/add',
-            stringify({group: 'ha_discovery_group', device: 'wall_switch_double/left'}),
+            stringify({group: 'ha_discovery_group', device: 'wall_switch_double', endpoint: 'left'}),
         );
         await flushPromises();
 


### PR DESCRIPTION
- No longer use `resolveEntityAndEndpoint` for payload parsing (only for topic parsing, better consistency, speed)
  - 'zigbee2mqtt/bridge/request/device/configure_reporting' (same for `response`)
    - before: `{id: 'device/endpoint'}`
    - after: `{id: 'device', endpoint: 'endpoint'}`
  - 'zigbee2mqtt/bridge/request/device/(bind|unbind)' (same for `response`)
    - before: `{from: 'sourceDevice/sourceEndpoint', to: 'target'}`
    - after: `{from: 'sourceDevice', from_endpoint: 'sourceEndpoint', to: 'target'}`
    - --
    - before: `{from: 'sourceDevice/sourceEndpoint', to: 'targetDevice/targetEndpoint'}`
    - after: `{from: 'sourceDevice', from_endpoint: 'sourceEndpoint', to: 'targetDevice', to_Endpoint: 'targetEndpoint'}`
    - --
    - `fromEndpoint: 'default'` automatically added to response if none supplied in request
  - 'zigbee2mqtt/bridge/request/group/members/(remove|add|remove_all)' (same for `response`)
    - before: `{device: 'device/endpoint', group: 'group'}`
    - after: `{device: 'device', endpoint: 'endpoint', group: 'group'}`
- Short-circuit unnecessary logic on payload failure for `Bind` and `Groups`
- Cleanup response `data` payloads for `Bind` and `Groups` on error (smaller mqtt footprint, match behavior from other topics)
- Extract payload parsing/resolving from actual logic for `Bind` (in `parseMQTTMessage`)
- Fix duplicate JSON parsing
- Improve typing

Note: the remaining `resolveEntityAndEndpoint` in `Groups` will get removed by https://github.com/Koenkk/zigbee2mqtt/pull/24338

TODO:
- [x] https://github.com/Koenkk/zigbee2mqtt.io/pull/3123
- [x] https://github.com/nurikk/zigbee2mqtt-frontend/pull/2165