### PR TITLE
feat: speed-controlled fans 

### DIFF
--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -141,6 +141,7 @@ describe('Extension: Bridge', () => {
                             retain: false,
                         },
                         '0x000b57fffec6a5b7': {friendly_name: 'bulb_2', retain: false},
+                        '0x00124b00cfcf3298': {friendly_name: 'fanbee', retain: true},
                         '0x0017880104a44559': {friendly_name: 'J1_cover'},
                         '0x0017880104e43559': {friendly_name: 'U202DST600ZB'},
                         '0x0017880104e44559': {friendly_name: '3157100_thermostat'},

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -873,6 +873,42 @@ describe('Extension: HomeAssistant', () => {
         });
     });
 
+    it('Should discover devices with speed-controlled fan', async () => {
+        const payload = {
+            state_topic: 'zigbee2mqtt/fanbee',
+            state_value_template: '{{ value_json.state }}',
+            command_topic: 'zigbee2mqtt/fanbee/set/state',
+            percentage_state_topic: 'zigbee2mqtt/fanbee',
+            percentage_command_topic: 'zigbee2mqtt/fanbee/set/speed',
+            percentage_value_template: "{{ value_json.speed | default('None') }}",
+            percentage_command_template: "{{ value | default('') }}",
+            speed_range_min: 1,
+            speed_range_max: 254,
+            name: null,
+            object_id: 'fanbee',
+            unique_id: '0x00124b00cfcf3298_fan_zigbee2mqtt',
+            origin: origin,
+            device: {
+                identifiers: ['zigbee2mqtt_0x00124b00cfcf3298'],
+                name: 'fanbee',
+                model: 'Fan with valve',
+                model_id: 'FanBee',
+                manufacturer: 'Lorenz Brun',
+                via_device: 'zigbee2mqtt_bridge_0x00124b00120144ae',
+            },
+            availability: [
+                {
+                    topic: 'zigbee2mqtt/bridge/state',
+                    value_template: '{{ value_json.state }}',
+                },
+            ],
+        };
+
+        const idx = mockMQTTPublishAsync.mock.calls.findIndex((c) => c[0] === 'homeassistant/fan/0x00124b00cfcf3298/fan/config');
+        expect(idx).not.toBe(-1);
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[idx][1])).toStrictEqual(payload);
+    });
+
     it('Should discover thermostat devices', async () => {
         const payload = {
             action_template:

--- a/test/mocks/data.ts
+++ b/test/mocks/data.ts
@@ -205,6 +205,10 @@ export const DEFAULT_CONFIGURATION = {
         '0x000b57cdfec6a5b3': {
             friendly_name: 'hue_twilight',
         },
+        '0x00124b00cfcf3298': {
+            friendly_name: 'fanbee',
+            retain: true,
+        },
     },
     groups: {
         1: {

--- a/test/mocks/zigbeeHerdsman.ts
+++ b/test/mocks/zigbeeHerdsman.ts
@@ -1136,6 +1136,16 @@ export const devices = {
         undefined,
         CUSTOM_CLUSTERS,
     ),
+    fanbee: new Device(
+        'Router',
+        '0x00124b00cfcf3298',
+        18129,
+        0xfff1,
+        [new Endpoint(8, [0, 3, 4, 5, 6, 8], []), new Endpoint(242, [], [33])],
+        true,
+        'DC Source',
+        'FanBee1',
+    ),
 };
 
 export const mockController = {


### PR DESCRIPTION
This implements the discovery side for speed-controlled fans. Here we no
longer need to emulate speed changes by changing modes and there is a
readily-usable onOff cluster for state. Fans now need to be either mode-
or speed-controlled, otherwise an assert is hit. No such fans currently
exist in the Z2M codebase and they cannot be reasonably controlled
anyways.

Co-dependent with https://github.com/Koenkk/zigbee-herdsman-converters/pull/8188