### PR TITLE
fix: Remove extraneous whitespace in template for binary attributes

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1010,7 +1010,7 @@ export default class HomeAssistant extends Extension {
                             name: endpoint ? `${firstExpose.label} ${endpoint}` : firstExpose.label,
                             value_template:
                                 typeof firstExpose.value_on === 'boolean'
-                                    ? `{% if value_json.${firstExpose.property} %} true {% else %} false {% endif %}`
+                                    ? `{% if value_json.${firstExpose.property} %}true{% else %}false{% endif %}`
                                     : `{{ value_json.${firstExpose.property} }}`,
                             payload_on: firstExpose.value_on.toString(),
                             payload_off: firstExpose.value_off.toString(),


### PR DESCRIPTION
I assume Home Assistant strips the whitespace at some point before comparing it to payload_on/payload_off, but I haven't quite found where yet. I have confirmed Python preserves the whitespace when simply evaluating the Jinja.

For openHAB, it does not strip the whitespace, causing errors because it doesn't match the payload_on or payload_off values. At some point I'd like to bring openHAB inline with Home Assistant, but I need to do so carefully without breaking something unexpectedly (especially with non- Home Assistant MQTT integrations). In the meantime, this should fix the issue in openHAB, without causing issues for Home Assistant or any other software that follows Home Assistant's MQTT discovery process.