### PR TITLE
fix: Temporarily disable serving compressed index file.

### DIFF
--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -74,7 +74,10 @@ export default class Frontend extends Extension {
         /* istanbul ignore next */
         const options = {
             enableBrotli: true,
+            // TODO: https://github.com/Koenkk/zigbee2mqtt/issues/24654 - enable compressed index serving when express-static-gzip is fixed.
+            index: false,
             serveStatic: {
+                index: 'index.html',
                 setHeaders: (res: ServerResponse, path: string): void => {
                     if (path.endsWith('index.html')) {
                         res.setHeader('Cache-Control', 'no-store');


### PR DESCRIPTION
express-static-gzip does not handle redirects with custom base URLs properly. As index.html file is only 5KB, compression is not critical for it.

This is a temporary workaround for #24654, while I am working on a proper fix.