### PR TITLE
fix!: Ensure `data` in response is always empty on `error`

### DIFF
--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -121,7 +121,8 @@ function getObjectProperty<T>(object: KeyValue, key: string, defaultValue: NoInf
 }
 
 function getResponse(request: KeyValue | string, data: KeyValue, error?: string): MQTTResponse {
-    const response: MQTTResponse = {data, status: error ? 'error' : 'ok'};
+    // On `error`, always return an empty `data` payload.
+    const response: MQTTResponse = {data: error ? {} : data, status: error ? 'error' : 'ok'};
 
     if (error) {
         response.error = error;

--- a/test/extensions/configure.test.ts
+++ b/test/extensions/configure.test.ts
@@ -162,7 +162,7 @@ describe('Extension: Configure', () => {
         await flushPromises();
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/configure',
-            stringify({data: {id: 'not_existing_device'}, status: 'error', error: "Device 'not_existing_device' does not exist"}),
+            stringify({data: {}, status: 'error', error: "Device 'not_existing_device' does not exist"}),
             {retain: false, qos: 0},
         );
     });
@@ -175,7 +175,7 @@ describe('Extension: Configure', () => {
         await flushPromises();
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/configure',
-            stringify({data: {id: 'remote'}, status: 'error', error: 'Failed to configure (Bind timeout after 10s)'}),
+            stringify({data: {}, status: 'error', error: 'Failed to configure (Bind timeout after 10s)'}),
             {retain: false, qos: 0},
         );
     });
@@ -185,7 +185,7 @@ describe('Extension: Configure', () => {
         await flushPromises();
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/configure',
-            stringify({data: {id: '0x0017882104a44559'}, status: 'error', error: "Device 'TS0601_thermostat' cannot be configured", transaction: 20}),
+            stringify({data: {}, status: 'error', error: "Device 'TS0601_thermostat' cannot be configured", transaction: 20}),
             {retain: false, qos: 0},
         );
     });

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -149,7 +149,7 @@ describe('Extension: OTAUpdate', () => {
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith('zigbee2mqtt/bulb', stringify({update: {state: 'available'}}), {retain: true, qos: 0});
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/ota_update/update',
-            stringify({data: {id: 'bulb'}, status: 'error', error: "Update of 'bulb' failed (Update failed)"}),
+            stringify({data: {}, status: 'error', error: "Update of 'bulb' failed (Update failed)"}),
             {retain: false, qos: 0},
         );
     });
@@ -222,7 +222,7 @@ describe('Extension: OTAUpdate', () => {
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/ota_update/check',
             stringify({
-                data: {id: 'bulb'},
+                data: {},
                 status: 'error',
                 error: `Failed to check if update available for 'bulb' (RF signals disturbed because of dogs barking)`,
             }),
@@ -235,7 +235,7 @@ describe('Extension: OTAUpdate', () => {
         await flushPromises();
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/ota_update/check',
-            stringify({data: {id: 'not_existing_deviceooo'}, status: 'error', error: `Device 'not_existing_deviceooo' does not exist`}),
+            stringify({data: {}, status: 'error', error: `Device 'not_existing_deviceooo' does not exist`}),
             {retain: false, qos: 0},
         );
     });
@@ -245,7 +245,7 @@ describe('Extension: OTAUpdate', () => {
         await flushPromises();
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/ota_update/check',
-            stringify({data: {id: 'dimmer_wall_switch'}, status: 'error', error: `Device 'dimmer_wall_switch' does not support OTA updates`}),
+            stringify({data: {}, status: 'error', error: `Device 'dimmer_wall_switch' does not support OTA updates`}),
             {retain: false, qos: 0},
         );
     });
@@ -268,7 +268,7 @@ describe('Extension: OTAUpdate', () => {
         await flushPromises();
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/device/ota_update/check',
-            stringify({data: {id: 'bulb'}, status: 'error', error: `Update or check for update already in progress for 'bulb'`}),
+            stringify({data: {}, status: 'error', error: `Update or check for update already in progress for 'bulb'`}),
             {retain: false, qos: 0},
         );
     });


### PR DESCRIPTION
For https://github.com/Koenkk/zigbee2mqtt/discussions/24198

> The `data` payload in the response is now always empty when there is an `error`, this affects `zigbee2mqtt/bridge/response/device/configure`and `zigbee2mqtt/bridge/response/device/ota_update/*`