### PR TITLE
Fixed calculation of group state when including non-default endpoints

### DIFF
--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -158,7 +158,7 @@ export default class Groups extends Extension {
     }
 
     private shouldPublishPayloadForGroup(group: Group, payload: KeyValue, endpointName: string | undefined): boolean {
-        const stateKey = endpointName ? `state_${endpointName}` : 'state'
+        const stateKey = endpointName ? `state_${endpointName}` : 'state';
         return (
             group.options.off_state === 'last_member_state' ||
             !payload ||
@@ -173,8 +173,8 @@ export default class Groups extends Extension {
 
             if (this.state.exists(device)) {
                 const state = this.state.get(device);
-                const endpointNames = device.isDevice() && device.getEndpointNames()
-                const stateKey = (endpointNames && endpointNames.length >= member.ID) ? `state_${endpointNames[member.ID - 1]}` : 'state'
+                const endpointNames = device.isDevice() && device.getEndpointNames();
+                const stateKey = endpointNames && endpointNames.length >= member.ID ? `state_${endpointNames[member.ID - 1]}` : 'state';
 
                 if (state[stateKey] === 'ON' || state[stateKey] === 'OPEN') {
                     return false;

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -100,7 +100,7 @@ export default class Groups extends Extension {
                         if (
                             group.zh.hasMember(endpoint) &&
                             !equals(this.lastOptimisticState[group.ID], payload) &&
-                            this.shouldPublishPayloadForGroup(group, payload)
+                            this.shouldPublishPayloadForGroup(group, payload, endpointName)
                         ) {
                             this.lastOptimisticState[group.ID] = payload;
 
@@ -142,7 +142,7 @@ export default class Groups extends Extension {
                     await this.publishEntityState(device, memberPayload, reason);
 
                     for (const zigbeeGroup of groups) {
-                        if (zigbeeGroup.zh.hasMember(member) && this.shouldPublishPayloadForGroup(zigbeeGroup, payload)) {
+                        if (zigbeeGroup.zh.hasMember(member) && this.shouldPublishPayloadForGroup(zigbeeGroup, memberPayload, endpointName)) {
                             groupsToPublish.add(zigbeeGroup);
                         }
                     }
@@ -157,11 +157,12 @@ export default class Groups extends Extension {
         }
     }
 
-    private shouldPublishPayloadForGroup(group: Group, payload: KeyValue): boolean {
+    private shouldPublishPayloadForGroup(group: Group, payload: KeyValue, endpointName: string | undefined): boolean {
+        const stateKey = endpointName ? `state_${endpointName}` : 'state'
         return (
             group.options.off_state === 'last_member_state' ||
             !payload ||
-            (payload.state !== 'OFF' && payload.state !== 'CLOSE') ||
+            (payload[stateKey] !== 'OFF' && payload[stateKey] !== 'CLOSE') ||
             this.areAllMembersOffOrClosed(group)
         );
     }
@@ -172,8 +173,10 @@ export default class Groups extends Extension {
 
             if (this.state.exists(device)) {
                 const state = this.state.get(device);
+                const endpointNames = device.isDevice() && device.getEndpointNames()
+                const stateKey = (endpointNames && endpointNames.length >= member.ID) ? `state_${endpointNames[member.ID - 1]}` : 'state'
 
-                if (state.state === 'ON' || state.state === 'OPEN') {
+                if (state[stateKey] === 'ON' || state[stateKey] === 'OPEN') {
                     return false;
                 }
             }

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -266,6 +266,50 @@ describe('Extension: Groups', () => {
         expect(mockMQTT.publishAsync).toHaveBeenNthCalledWith(2, 'zigbee2mqtt/bulb_color', stringify({state: 'OFF'}), {retain: false, qos: 0});
     });
 
+    it('Should not publish state change off if any lights within are still on when changed via device with non default-ep', async () => {
+        const device_1 = devices.bulb_color;
+        const device_2 = devices.QBKG03LM;
+        const endpoint_1 = device_1.getEndpoint(1)!;
+        const endpoint_2 = device_2.getEndpoint(3)!;
+        const group = groups.group_1;
+        group.members.push(endpoint_1);
+        group.members.push(endpoint_2);
+
+        await mockMQTTEvents.message('zigbee2mqtt/group_1/set', stringify({state: 'ON'}));
+        await flushPromises();
+        mockMQTT.publishAsync.mockClear();
+
+        await mockMQTTEvents.message('zigbee2mqtt/bulb_color/set', stringify({state: 'OFF'}));
+        await flushPromises();
+        expect(mockMQTT.publishAsync).toHaveBeenCalledTimes(1);
+        expect(mockMQTT.publishAsync).toHaveBeenCalledWith('zigbee2mqtt/bulb_color', stringify({state: 'OFF'}), {retain: false, qos: 0});
+    });
+
+    it('Should publish state change off if all lights within turn off with non default-ep', async () => {
+        const device_1 = devices.bulb_color;
+        const device_2 = devices.QBKG03LM;
+        const endpoint_1 = device_1.getEndpoint(1)!;
+        const endpoint_2 = device_2.getEndpoint(2)!;
+        const group = groups.group_1;
+        group.members.push(endpoint_1);
+        group.members.push(endpoint_2);
+        settings.set(['groups'], {
+            1: {friendly_name: 'group_1', retain: false},
+        });
+
+        await mockMQTTEvents.message('zigbee2mqtt/group_1/set', stringify({state: 'ON'}));
+        await flushPromises();
+        mockMQTT.publishAsync.mockClear();
+
+        await mockMQTTEvents.message('zigbee2mqtt/bulb_color/set', stringify({state: 'OFF'}));
+        await mockMQTTEvents.message('zigbee2mqtt/wall_switch_double/set', stringify({state_left: 'OFF'}));
+        await flushPromises();
+        expect(mockMQTT.publishAsync).toHaveBeenCalledTimes(3);
+        expect(mockMQTT.publishAsync).toHaveBeenCalledWith('zigbee2mqtt/bulb_color', stringify({state: 'OFF'}), {retain: false, qos: 0});
+        expect(mockMQTT.publishAsync).toHaveBeenCalledWith('zigbee2mqtt/wall_switch_double', stringify({state_left: 'OFF'}), {retain: false, qos: 0});
+        expect(mockMQTT.publishAsync).toHaveBeenCalledWith('zigbee2mqtt/group_1', stringify({state: 'OFF'}), {retain: false, qos: 0});
+    });
+
     it('Should not publish state change off if any lights within are still on when changed via shared group', async () => {
         const device_1 = devices.bulb_color;
         const device_2 = devices.bulb;


### PR DESCRIPTION
Groups could contain endpoints with state stored in non default keys like state_l2. In this pull request I changed functions shouldPublishPayloadForGroup and areAllMembersOffOrClosed to consider actual state of every endpoint in group base on their names.
Fixes #18932