### PR TITLE
fix(ignore): Fix external converter loading

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -97,6 +97,7 @@ export class Controller {
         ];
 
         this.extensions = [
+            new ExtensionExternalConverters(...this.extensionArgs),
             new ExtensionOnEvent(...this.extensionArgs),
             new ExtensionBridge(...this.extensionArgs),
             new ExtensionPublish(...this.extensionArgs),
@@ -107,7 +108,6 @@ export class Controller {
             new ExtensionBind(...this.extensionArgs),
             new ExtensionOTAUpdate(...this.extensionArgs),
             new ExtensionExternalExtensions(...this.extensionArgs),
-            new ExtensionExternalConverters(...this.extensionArgs),
             new ExtensionAvailability(...this.extensionArgs),
         ];
 

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -95,7 +95,7 @@ describe('Extension: ExternalConverters', () => {
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith('zigbee2mqtt/bridge/converters', stringify([]), {retain: true, qos: 0});
     });
 
-    it('loads from folder', async () => {
+    it('onlythisloads from folder', async () => {
         useAssets();
 
         await controller.start();
@@ -149,9 +149,9 @@ describe('Extension: ExternalConverters', () => {
             }),
         );
 
-        const bridgeDevices = mockMQTT.publishAsync.mock.calls.find((c) => c[0] === 'zigbee2mqtt/bridge/devices');
-        assert(bridgeDevices);
-        expect(JSON.parse(bridgeDevices[1])).toEqual(
+        const bridgeDevices = mockMQTT.publishAsync.mock.calls.filter((c) => c[0] === 'zigbee2mqtt/bridge/devices');
+        expect(bridgeDevices.length).toBe(1);
+        expect(JSON.parse(bridgeDevices[0][1])).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
                     model_id: 'external_converter_device',

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -6,6 +6,7 @@ import {devices, mockController as mockZHController, returnDevices} from '../moc
 
 import type Device from '../../lib/model/device';
 
+import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 
@@ -74,7 +75,7 @@ describe('Extension: ExternalConverters', () => {
         data.writeDefaultConfiguration();
         data.writeDefaultState();
         settings.reRead();
-        returnDevices.push(devices.external_converter_device.ieeeAddr);
+        returnDevices.push(devices.external_converter_device.ieeeAddr, devices.coordinator.ieeeAddr);
 
         controller = new Controller(jest.fn(), jest.fn());
     });
@@ -146,6 +147,21 @@ describe('Extension: ExternalConverters', () => {
                 model: 'external_converter_device',
                 description: 'external',
             }),
+        );
+
+        const bridgeDevices = mockMQTT.publishAsync.mock.calls.find((c) => c[0] === 'zigbee2mqtt/bridge/devices');
+        assert(bridgeDevices);
+        expect(JSON.parse(bridgeDevices[1])).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    model_id: 'external_converter_device',
+                    supported: true,
+                    definition: expect.objectContaining({
+                        description: 'external',
+                        model: 'external_converter_device',
+                    }),
+                }),
+            ]),
         );
     });
 

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -6,7 +6,6 @@ import {devices, mockController as mockZHController, returnDevices} from '../moc
 
 import type Device from '../../lib/model/device';
 
-import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 
@@ -95,7 +94,7 @@ describe('Extension: ExternalConverters', () => {
         expect(mockMQTT.publishAsync).toHaveBeenCalledWith('zigbee2mqtt/bridge/converters', stringify([]), {retain: true, qos: 0});
     });
 
-    it('onlythisloads from folder', async () => {
+    it('loads from folder', async () => {
         useAssets();
 
         await controller.start();


### PR DESCRIPTION
Currently the external converters are loaded after the HA discovery + `bridge/devices` publish, because of this the HA discovery doesn't include the external converter and the frontend shows the device as unsupported. This PR fixes that by loading the external converter extension first.