### PR TITLE
fix: Fix `Cannot read properties of null (reading 'toString')` when Home Assistant event entities are enabled

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1069,7 +1069,7 @@ export default class HomeAssistant extends Extension {
                         discoveryEntries.push({
                             type: 'event',
                             object_id: firstExpose.property,
-                            mockProperties: [{property: firstExpose.property, value: null}],
+                            mockProperties: [],
                             discovery_payload: {
                                 name: endpoint ? /* istanbul ignore next */ `${firstExpose.label} ${endpoint}` : firstExpose.label,
                                 state_topic: true,


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/25133