### PR TITLE
fix(ignore): Force rebuild of @serialport/bindings-cpp in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,9 +22,9 @@ COPY package.json pnpm-lock.yaml ./
 RUN apk add make gcc g++ python3 linux-headers npm && \
     npm install -g pnpm && \
     pnpm install --frozen-lockfile --no-optional && \
-    # Serialport requires to be re-build, otherwise starts fails
-    # See e.g. https://github.com/Koenkk/zigbee2mqtt/issues/25092
-    pnpm rebuild
+    # serialport has outdated prebuilds that appear to fail on some archs, force build on target platform
+    rm -rf `find ./node_modules/.pnpm/ -wholename "*/@serialport/bindings-cpp/prebuilds" -type d` && \
+    pnpm rebuild @serialport/bindings-cpp
 
 # Release
 FROM base AS release


### PR DESCRIPTION
Ref https://github.com/Koenkk/zigbee2mqtt/issues/25092

Bit of a workaround until hopefully a new serialport release fixes these issues.
Force containers to always rebuild @serialport/bindings-cpp which has prebuilds that seem to create issues on some archs. This way, there is no issue with selection of prebuild, or the prebuild itself.

It builds on all currently supported archs, so, shouldn't be a problem...

<details><summary>amd64 node v22</summary>

```
2024-12-14T15:39:49.2423848Z #10 7.905 .../@serialport/bindings-cpp install$ node-gyp-build
2024-12-14T15:39:49.3786665Z #10 8.042 .../@serialport/bindings-cpp install: gyp info it worked if it ends with ok
2024-12-14T15:39:49.5862892Z #10 8.045 .../@serialport/bindings-cpp install: gyp info using node-gyp@10.2.0
2024-12-14T15:39:49.5864068Z #10 8.046 .../@serialport/bindings-cpp install: gyp info using node@22.11.0 | linux | x64
2024-12-14T15:39:49.5865533Z #10 8.123 .../@serialport/bindings-cpp install: gyp info find Python using Python version 3.12.8 found at "/usr/bin/python3"
2024-12-14T15:39:49.5867318Z #10 8.250 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v22.11.0/node-v22.11.0-headers.tar.gz
2024-12-14T15:39:49.8174085Z #10 8.330 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v22.11.0/node-v22.11.0-headers.tar.gz
2024-12-14T15:39:51.1564789Z #10 9.820 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt
2024-12-14T15:39:51.3476641Z #10 9.846 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt
2024-12-14T15:39:51.3477923Z #10 9.852 .../@serialport/bindings-cpp install: gyp info spawn /usr/bin/python3
2024-12-14T15:39:51.3478842Z #10 9.854 .../@serialport/bindings-cpp install: gyp info spawn args [
2024-12-14T15:39:51.3480280Z #10 9.855 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
2024-12-14T15:39:51.3481650Z #10 9.855 .../@serialport/bindings-cpp install: gyp info spawn args 'binding.gyp',
2024-12-14T15:39:51.3482631Z #10 9.856 .../@serialport/bindings-cpp install: gyp info spawn args '-f',
2024-12-14T15:39:51.3483547Z #10 9.856 .../@serialport/bindings-cpp install: gyp info spawn args 'make',
2024-12-14T15:39:51.3484471Z #10 9.856 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:39:51.3486186Z #10 9.857 .../@serialport/bindings-cpp install: gyp info spawn args '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build/config.gypi',
2024-12-14T15:39:51.3487696Z #10 9.857 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:39:51.3489080Z #10 9.857 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
2024-12-14T15:39:51.3490345Z #10 9.857 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:39:51.3491578Z #10 9.858 .../@serialport/bindings-cpp install: gyp info spawn args '/root/.cache/node-gyp/22.11.0/include/node/common.gypi',
2024-12-14T15:39:51.3492877Z #10 9.858 .../@serialport/bindings-cpp install: gyp info spawn args '-Dlibrary=shared_library',
2024-12-14T15:39:51.3493988Z #10 9.858 .../@serialport/bindings-cpp install: gyp info spawn args '-Dvisibility=default',
2024-12-14T15:39:51.3495563Z #10 9.858 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/22.11.0',
2024-12-14T15:39:51.3497191Z #10 9.858 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_gyp_dir=/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp',
2024-12-14T15:39:51.3498895Z #10 9.859 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_lib_file=/root/.cache/node-gyp/22.11.0/<(target_arch)/node.lib',
2024-12-14T15:39:51.3500890Z #10 9.859 .../@serialport/bindings-cpp install: gyp info spawn args '-Dmodule_root_dir=/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp',
2024-12-14T15:39:51.3502863Z #10 9.859 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_engine=v8',
2024-12-14T15:39:51.3504176Z #10 9.859 .../@serialport/bindings-cpp install: gyp info spawn args '--depth=.',
2024-12-14T15:39:51.3505200Z #10 9.859 .../@serialport/bindings-cpp install: gyp info spawn args '--no-parallel',
2024-12-14T15:39:51.3506301Z #10 9.860 .../@serialport/bindings-cpp install: gyp info spawn args '--generator-output',
2024-12-14T15:39:51.3507321Z #10 9.860 .../@serialport/bindings-cpp install: gyp info spawn args 'build',
2024-12-14T15:39:51.3508303Z #10 9.861 .../@serialport/bindings-cpp install: gyp info spawn args '-Goutput_dir=.'
2024-12-14T15:39:51.3509223Z #10 9.861 .../@serialport/bindings-cpp install: gyp info spawn args ]
2024-12-14T15:39:51.3966668Z #10 10.06 .../@serialport/bindings-cpp install: gyp info spawn make
2024-12-14T15:39:51.5514854Z #10 10.06 .../@serialport/bindings-cpp install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
2024-12-14T15:39:51.5516889Z #10 10.06 .../@serialport/bindings-cpp install: make: Entering directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:39:51.5518812Z #10 10.06 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport.o
2024-12-14T15:39:53.6588811Z #10 12.32 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_unix.o
2024-12-14T15:39:55.3162462Z #10 13.98 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/poller.o
2024-12-14T15:39:57.6659145Z #10 16.33 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_linux.o
2024-12-14T15:39:57.8801129Z #10 16.39 .../@serialport/bindings-cpp install:   SOLINK_MODULE(target) Release/obj.target/bindings.node
2024-12-14T15:39:59.5558234Z #10 18.22 .../@serialport/bindings-cpp install:   COPY Release/bindings.node
2024-12-14T15:39:59.7308206Z #10 18.22 .../@serialport/bindings-cpp install: make: Leaving directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:39:59.7310000Z #10 18.22 .../@serialport/bindings-cpp install: gyp info ok 
2024-12-14T15:39:59.7310914Z #10 18.24 .../@serialport/bindings-cpp install: Done
```

</details>
<details><summary>386 node v22</summary>

```
2024-12-14T15:39:36.4328127Z #10 7.669 .../@serialport/bindings-cpp install$ node-gyp-build
2024-12-14T15:39:36.4329540Z #10 7.808 .../@serialport/bindings-cpp install: gyp info it worked if it ends with ok
2024-12-14T15:39:36.6366206Z #10 7.811 .../@serialport/bindings-cpp install: gyp info using node-gyp@10.2.0
2024-12-14T15:39:36.6367818Z #10 7.812 .../@serialport/bindings-cpp install: gyp info using node@22.11.0 | linux | ia32
2024-12-14T15:39:36.6369687Z #10 7.879 .../@serialport/bindings-cpp install: gyp info find Python using Python version 3.12.8 found at "/usr/bin/python3"
2024-12-14T15:39:36.6371647Z #10 8.011 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v22.11.0/node-v22.11.0-headers.tar.gz
2024-12-14T15:39:36.8815866Z #10 8.106 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v22.11.0/node-v22.11.0-headers.tar.gz
2024-12-14T15:39:38.3332197Z #10 9.708 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt
2024-12-14T15:39:38.5395605Z #10 9.751 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt
2024-12-14T15:39:38.5397690Z #10 9.758 .../@serialport/bindings-cpp install: gyp info spawn /usr/bin/python3
2024-12-14T15:39:38.5398867Z #10 9.759 .../@serialport/bindings-cpp install: gyp info spawn args [
2024-12-14T15:39:38.5401153Z #10 9.759 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
2024-12-14T15:39:38.5402499Z #10 9.759 .../@serialport/bindings-cpp install: gyp info spawn args 'binding.gyp',
2024-12-14T15:39:38.5403432Z #10 9.760 .../@serialport/bindings-cpp install: gyp info spawn args '-f',
2024-12-14T15:39:38.5404333Z #10 9.760 .../@serialport/bindings-cpp install: gyp info spawn args 'make',
2024-12-14T15:39:38.5405233Z #10 9.760 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:39:38.5406983Z #10 9.760 .../@serialport/bindings-cpp install: gyp info spawn args '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build/config.gypi',
2024-12-14T15:39:38.5408857Z #10 9.761 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:39:38.5410285Z #10 9.761 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
2024-12-14T15:39:38.5411574Z #10 9.761 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:39:38.5412826Z #10 9.761 .../@serialport/bindings-cpp install: gyp info spawn args '/root/.cache/node-gyp/22.11.0/include/node/common.gypi',
2024-12-14T15:39:38.5414118Z #10 9.761 .../@serialport/bindings-cpp install: gyp info spawn args '-Dlibrary=shared_library',
2024-12-14T15:39:38.5415250Z #10 9.762 .../@serialport/bindings-cpp install: gyp info spawn args '-Dvisibility=default',
2024-12-14T15:39:38.5416507Z #10 9.762 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/22.11.0',
2024-12-14T15:39:38.5418169Z #10 9.762 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_gyp_dir=/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp',
2024-12-14T15:39:38.5419930Z #10 9.762 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_lib_file=/root/.cache/node-gyp/22.11.0/<(target_arch)/node.lib',
2024-12-14T15:39:38.5421978Z #10 9.762 .../@serialport/bindings-cpp install: gyp info spawn args '-Dmodule_root_dir=/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp',
2024-12-14T15:39:38.5425748Z #10 9.763 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_engine=v8',
2024-12-14T15:39:38.5426796Z #10 9.763 .../@serialport/bindings-cpp install: gyp info spawn args '--depth=.',
2024-12-14T15:39:38.5427837Z #10 9.763 .../@serialport/bindings-cpp install: gyp info spawn args '--no-parallel',
2024-12-14T15:39:38.5428928Z #10 9.763 .../@serialport/bindings-cpp install: gyp info spawn args '--generator-output',
2024-12-14T15:39:38.5429944Z #10 9.763 .../@serialport/bindings-cpp install: gyp info spawn args 'build',
2024-12-14T15:39:38.5430952Z #10 9.764 .../@serialport/bindings-cpp install: gyp info spawn args '-Goutput_dir=.'
2024-12-14T15:39:38.5431878Z #10 9.764 .../@serialport/bindings-cpp install: gyp info spawn args ]
2024-12-14T15:39:38.5977056Z #10 9.972 .../@serialport/bindings-cpp install: gyp info spawn make
2024-12-14T15:39:38.7528794Z #10 9.974 .../@serialport/bindings-cpp install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
2024-12-14T15:39:38.7531156Z #10 9.976 .../@serialport/bindings-cpp install: make: Entering directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:39:38.7533569Z #10 9.977 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport.o
2024-12-14T15:39:41.4111590Z #10 12.79 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_unix.o
2024-12-14T15:39:43.4402031Z #10 14.81 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/poller.o
2024-12-14T15:39:45.5781198Z #10 16.95 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_linux.o
2024-12-14T15:39:45.7930553Z #10 17.02 .../@serialport/bindings-cpp install:   SOLINK_MODULE(target) Release/obj.target/bindings.node
2024-12-14T15:39:47.6357482Z #10 19.01 .../@serialport/bindings-cpp install:   COPY Release/bindings.node
2024-12-14T15:39:47.7360893Z #10 19.01 .../@serialport/bindings-cpp install: make: Leaving directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:39:47.7362603Z #10 19.02 .../@serialport/bindings-cpp install: gyp info ok 
2024-12-14T15:39:47.7363445Z #10 19.04 .../@serialport/bindings-cpp install: Done
```

</details>
<details><summary>arm64/v8 node v22</summary>

```
2024-12-14T15:40:19.0642035Z #10 46.39 .../@serialport/bindings-cpp install$ node-gyp-build
2024-12-14T15:40:22.0062899Z #10 49.33 .../@serialport/bindings-cpp install: gyp info it worked if it ends with ok
2024-12-14T15:40:22.1871334Z #10 49.36 .../@serialport/bindings-cpp install: gyp info using node-gyp@10.2.0
2024-12-14T15:40:22.1872913Z #10 49.36 .../@serialport/bindings-cpp install: gyp info using node@22.11.0 | linux | arm64
2024-12-14T15:40:22.9022477Z #10 50.23 .../@serialport/bindings-cpp install: gyp info find Python using Python version 3.12.8 found at "/usr/bin/python3"
2024-12-14T15:40:23.8185974Z #10 51.14 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v22.11.0/node-v22.11.0-headers.tar.gz
2024-12-14T15:40:24.2931390Z #10 51.62 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v22.11.0/node-v22.11.0-headers.tar.gz
2024-12-14T15:40:33.1028649Z #10 60.43 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt
2024-12-14T15:40:33.2241111Z #10 60.49 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt
2024-12-14T15:40:33.2244094Z #10 60.55 .../@serialport/bindings-cpp install: gyp info spawn /usr/bin/python3
2024-12-14T15:40:33.4548175Z #10 60.58 .../@serialport/bindings-cpp install: gyp info spawn args [
2024-12-14T15:40:33.4549992Z #10 60.58 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
2024-12-14T15:40:33.4551608Z #10 60.58 .../@serialport/bindings-cpp install: gyp info spawn args 'binding.gyp',
2024-12-14T15:40:33.4604044Z #10 60.59 .../@serialport/bindings-cpp install: gyp info spawn args '-f',
2024-12-14T15:40:33.4605007Z #10 60.59 .../@serialport/bindings-cpp install: gyp info spawn args 'make',
2024-12-14T15:40:33.4605917Z #10 60.59 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:33.4607590Z #10 60.60 .../@serialport/bindings-cpp install: gyp info spawn args '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build/config.gypi',
2024-12-14T15:40:33.4609071Z #10 60.60 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:33.4610797Z #10 60.60 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
2024-12-14T15:40:33.4612043Z #10 60.60 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:33.4613273Z #10 60.60 .../@serialport/bindings-cpp install: gyp info spawn args '/root/.cache/node-gyp/22.11.0/include/node/common.gypi',
2024-12-14T15:40:33.4614569Z #10 60.61 .../@serialport/bindings-cpp install: gyp info spawn args '-Dlibrary=shared_library',
2024-12-14T15:40:33.4615675Z #10 60.61 .../@serialport/bindings-cpp install: gyp info spawn args '-Dvisibility=default',
2024-12-14T15:40:33.4616936Z #10 60.61 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/22.11.0',
2024-12-14T15:40:33.4618831Z #10 60.61 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_gyp_dir=/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp',
2024-12-14T15:40:33.4620582Z #10 60.61 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_lib_file=/root/.cache/node-gyp/22.11.0/<(target_arch)/node.lib',
2024-12-14T15:40:33.4622576Z #10 60.62 .../@serialport/bindings-cpp install: gyp info spawn args '-Dmodule_root_dir=/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp',
2024-12-14T15:40:33.4624130Z #10 60.62 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_engine=v8',
2024-12-14T15:40:33.4625139Z #10 60.62 .../@serialport/bindings-cpp install: gyp info spawn args '--depth=.',
2024-12-14T15:40:33.4626138Z #10 60.62 .../@serialport/bindings-cpp install: gyp info spawn args '--no-parallel',
2024-12-14T15:40:33.4627185Z #10 60.62 .../@serialport/bindings-cpp install: gyp info spawn args '--generator-output',
2024-12-14T15:40:33.4628179Z #10 60.63 .../@serialport/bindings-cpp install: gyp info spawn args 'build',
2024-12-14T15:40:33.4629145Z #10 60.63 .../@serialport/bindings-cpp install: gyp info spawn args '-Goutput_dir=.'
2024-12-14T15:40:33.4630062Z #10 60.63 .../@serialport/bindings-cpp install: gyp info spawn args ]
2024-12-14T15:40:35.3390390Z #10 62.67 .../@serialport/bindings-cpp install: gyp info spawn make
2024-12-14T15:40:35.5441330Z #10 62.67 .../@serialport/bindings-cpp install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
2024-12-14T15:40:35.5443578Z #10 62.71 .../@serialport/bindings-cpp install: make: Entering directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:40:35.5445586Z #10 62.72 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport.o
2024-12-14T15:40:55.0776453Z #10 82.40 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_unix.o
2024-12-14T15:41:08.4995456Z #10 95.83 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/poller.o
2024-12-14T15:41:26.4923910Z #10 113.8 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_linux.o
2024-12-14T15:41:28.1825830Z #10 115.5 .../@serialport/bindings-cpp install:   SOLINK_MODULE(target) Release/obj.target/bindings.node
2024-12-14T15:41:46.7800084Z #10 134.1 .../@serialport/bindings-cpp install:   COPY Release/bindings.node
2024-12-14T15:41:46.9957200Z #10 134.2 .../@serialport/bindings-cpp install: make: Leaving directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:41:46.9958990Z #10 134.2 .../@serialport/bindings-cpp install: gyp info ok 
2024-12-14T15:41:46.9959854Z #10 134.3 .../@serialport/bindings-cpp install: Done
```

</details>
<details><summary>arm/v6 node v18</summary>

```
2024-12-14T15:40:25.7381098Z #10 53.36 .../@serialport/bindings-cpp install$ node-gyp-build
2024-12-14T15:40:28.7451965Z #10 56.37 .../@serialport/bindings-cpp install: gyp info it worked if it ends with ok
2024-12-14T15:40:28.9325517Z #10 56.39 .../@serialport/bindings-cpp install: gyp info using node-gyp@10.2.0
2024-12-14T15:40:28.9326892Z #10 56.41 .../@serialport/bindings-cpp install: gyp info using node@18.20.1 | linux | arm
2024-12-14T15:40:29.7747195Z #10 57.40 .../@serialport/bindings-cpp install: gyp info find Python using Python version 3.11.11 found at "/usr/bin/python3"
2024-12-14T15:40:31.0433228Z #10 58.67 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v18.20.1/node-v18.20.1-headers.tar.gz
2024-12-14T15:40:31.9327720Z #10 59.56 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v18.20.1/node-v18.20.1-headers.tar.gz
2024-12-14T15:40:42.7499154Z #10 70.38 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v18.20.1/SHASUMS256.txt
2024-12-14T15:40:42.8958567Z #10 70.52 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v18.20.1/SHASUMS256.txt
2024-12-14T15:40:43.0492956Z #10 70.62 .../@serialport/bindings-cpp install: gyp info spawn /usr/bin/python3
2024-12-14T15:40:43.0494263Z #10 70.67 .../@serialport/bindings-cpp install: gyp info spawn args [
2024-12-14T15:40:43.2795225Z #10 70.68 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
2024-12-14T15:40:43.2797840Z #10 70.69 .../@serialport/bindings-cpp install: gyp info spawn args 'binding.gyp',
2024-12-14T15:40:43.2798894Z #10 70.70 .../@serialport/bindings-cpp install: gyp info spawn args '-f',
2024-12-14T15:40:43.2800353Z #10 70.70 .../@serialport/bindings-cpp install: gyp info spawn args 'make',
2024-12-14T15:40:43.2801376Z #10 70.70 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:43.2803502Z #10 70.71 .../@serialport/bindings-cpp install: gyp info spawn args '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build/config.gypi',
2024-12-14T15:40:43.2805106Z #10 70.71 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:43.2806553Z #10 70.72 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
2024-12-14T15:40:43.2807845Z #10 70.72 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:43.2809141Z #10 70.73 .../@serialport/bindings-cpp install: gyp info spawn args '/root/.cache/node-gyp/18.20.1/include/node/common.gypi',
2024-12-14T15:40:43.2810484Z #10 70.73 .../@serialport/bindings-cpp install: gyp info spawn args '-Dlibrary=shared_library',
2024-12-14T15:40:43.2811971Z #10 70.73 .../@serialport/bindings-cpp install: gyp info spawn args '-Dvisibility=default',
2024-12-14T15:40:43.2813272Z #10 70.73 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/18.20.1',
2024-12-14T15:40:43.2814916Z #10 70.74 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_gyp_dir=/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp',
2024-12-14T15:40:43.2816651Z #10 70.74 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_lib_file=/root/.cache/node-gyp/18.20.1/<(target_arch)/node.lib',
2024-12-14T15:40:43.2818737Z #10 70.74 .../@serialport/bindings-cpp install: gyp info spawn args '-Dmodule_root_dir=/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp',
2024-12-14T15:40:43.2820369Z #10 70.75 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_engine=v8',
2024-12-14T15:40:43.2821439Z #10 70.75 .../@serialport/bindings-cpp install: gyp info spawn args '--depth=.',
2024-12-14T15:40:43.2822560Z #10 70.75 .../@serialport/bindings-cpp install: gyp info spawn args '--no-parallel',
2024-12-14T15:40:43.2823683Z #10 70.75 .../@serialport/bindings-cpp install: gyp info spawn args '--generator-output',
2024-12-14T15:40:43.2824704Z #10 70.75 .../@serialport/bindings-cpp install: gyp info spawn args 'build',
2024-12-14T15:40:43.2825704Z #10 70.75 .../@serialport/bindings-cpp install: gyp info spawn args '-Goutput_dir=.'
2024-12-14T15:40:43.2826615Z #10 70.75 .../@serialport/bindings-cpp install: gyp info spawn args ]
2024-12-14T15:40:45.0549650Z #10 72.68 .../@serialport/bindings-cpp install: gyp info spawn make
2024-12-14T15:40:45.2533841Z #10 72.69 .../@serialport/bindings-cpp install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
2024-12-14T15:40:45.2536163Z #10 72.72 .../@serialport/bindings-cpp install: make: Entering directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:40:45.2538370Z #10 72.73 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport.o
2024-12-14T15:41:00.4854880Z #10 88.11 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_unix.o
2024-12-14T15:41:12.1090040Z #10 99.73 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/poller.o
2024-12-14T15:41:25.3109527Z #10 112.9 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_linux.o
2024-12-14T15:41:26.5253362Z #10 114.2 .../@serialport/bindings-cpp install:   SOLINK_MODULE(target) Release/obj.target/bindings.node
2024-12-14T15:41:26.7867507Z #10 114.4 .../@serialport/bindings-cpp install:   COPY Release/bindings.node
2024-12-14T15:41:27.0124576Z #10 114.5 .../@serialport/bindings-cpp install: make: Leaving directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:41:27.0126741Z #10 114.5 .../@serialport/bindings-cpp install: gyp info ok 
2024-12-14T15:41:27.0179348Z #10 114.6 .../@serialport/bindings-cpp install: Done
```

</details>
<details><summary>arm/v7 node v18</summary>

```

2024-12-14T15:40:24.9276431Z #10 53.18 .../@serialport/bindings-cpp install$ node-gyp-build
2024-12-14T15:40:27.9890671Z #10 56.24 .../@serialport/bindings-cpp install: gyp info it worked if it ends with ok
2024-12-14T15:40:28.1766772Z #10 56.26 .../@serialport/bindings-cpp install: gyp info using node-gyp@10.2.0
2024-12-14T15:40:28.1767939Z #10 56.28 .../@serialport/bindings-cpp install: gyp info using node@18.20.1 | linux | arm
2024-12-14T15:40:29.0416652Z #10 57.29 .../@serialport/bindings-cpp install: gyp info find Python using Python version 3.11.10 found at "/usr/bin/python3"
2024-12-14T15:40:30.3310249Z #10 58.58 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v18.20.1/node-v18.20.1-headers.tar.gz
2024-12-14T15:40:30.8075006Z #10 59.06 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v18.20.1/node-v18.20.1-headers.tar.gz
2024-12-14T15:40:41.3897905Z #10 69.64 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v18.20.1/SHASUMS256.txt
2024-12-14T15:40:41.5511356Z #10 69.80 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v18.20.1/SHASUMS256.txt
2024-12-14T15:40:41.6554143Z #10 69.91 .../@serialport/bindings-cpp install: gyp info spawn /usr/bin/python3
2024-12-14T15:40:41.7583102Z #10 69.95 .../@serialport/bindings-cpp install: gyp info spawn args [
2024-12-14T15:40:41.7585749Z #10 69.96 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
2024-12-14T15:40:41.7587179Z #10 69.97 .../@serialport/bindings-cpp install: gyp info spawn args 'binding.gyp',
2024-12-14T15:40:41.7588159Z #10 69.98 .../@serialport/bindings-cpp install: gyp info spawn args '-f',
2024-12-14T15:40:41.7589086Z #10 69.98 .../@serialport/bindings-cpp install: gyp info spawn args 'make',
2024-12-14T15:40:41.7590042Z #10 69.99 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:41.7592242Z #10 69.99 .../@serialport/bindings-cpp install: gyp info spawn args '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build/config.gypi',
2024-12-14T15:40:41.7593830Z #10 69.99 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:41.7595247Z #10 70.00 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
2024-12-14T15:40:41.7596538Z #10 70.01 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:41.9519699Z #10 70.01 .../@serialport/bindings-cpp install: gyp info spawn args '/root/.cache/node-gyp/18.20.1/include/node/common.gypi',
2024-12-14T15:40:41.9521077Z #10 70.02 .../@serialport/bindings-cpp install: gyp info spawn args '-Dlibrary=shared_library',
2024-12-14T15:40:41.9522750Z #10 70.02 .../@serialport/bindings-cpp install: gyp info spawn args '-Dvisibility=default',
2024-12-14T15:40:41.9524029Z #10 70.02 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/18.20.1',
2024-12-14T15:40:41.9525697Z #10 70.03 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_gyp_dir=/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp',
2024-12-14T15:40:41.9527409Z #10 70.03 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_lib_file=/root/.cache/node-gyp/18.20.1/<(target_arch)/node.lib',
2024-12-14T15:40:41.9529437Z #10 70.04 .../@serialport/bindings-cpp install: gyp info spawn args '-Dmodule_root_dir=/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp',
2024-12-14T15:40:41.9531047Z #10 70.04 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_engine=v8',
2024-12-14T15:40:41.9532074Z #10 70.04 .../@serialport/bindings-cpp install: gyp info spawn args '--depth=.',
2024-12-14T15:40:41.9533120Z #10 70.04 .../@serialport/bindings-cpp install: gyp info spawn args '--no-parallel',
2024-12-14T15:40:41.9534600Z #10 70.05 .../@serialport/bindings-cpp install: gyp info spawn args '--generator-output',
2024-12-14T15:40:41.9535643Z #10 70.05 .../@serialport/bindings-cpp install: gyp info spawn args 'build',
2024-12-14T15:40:41.9536660Z #10 70.05 .../@serialport/bindings-cpp install: gyp info spawn args '-Goutput_dir=.'
2024-12-14T15:40:41.9537673Z #10 70.05 .../@serialport/bindings-cpp install: gyp info spawn args ]
2024-12-14T15:40:43.6990819Z #10 71.95 .../@serialport/bindings-cpp install: gyp info spawn make
2024-12-14T15:40:43.9028168Z #10 71.96 .../@serialport/bindings-cpp install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
2024-12-14T15:40:43.9030524Z #10 71.99 .../@serialport/bindings-cpp install: make: Entering directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:40:43.9032637Z #10 72.00 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport.o
2024-12-14T15:40:59.7679143Z #10 88.02 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_unix.o
2024-12-14T15:41:10.9745110Z #10 99.22 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/poller.o
2024-12-14T15:41:24.4785864Z #10 112.7 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_linux.o
2024-12-14T15:41:25.8022446Z #10 114.1 .../@serialport/bindings-cpp install:   SOLINK_MODULE(target) Release/obj.target/bindings.node
2024-12-14T15:41:26.0728697Z #10 114.3 .../@serialport/bindings-cpp install:   COPY Release/bindings.node
2024-12-14T15:41:26.2904930Z #10 114.4 .../@serialport/bindings-cpp install: make: Leaving directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:41:26.2906430Z #10 114.4 .../@serialport/bindings-cpp install: gyp info ok 
2024-12-14T15:41:26.2907173Z #10 114.5 .../@serialport/bindings-cpp install: Done
```

</details>
<details><summary>riscv64 node v22</summary>

```

2024-12-14T15:40:16.0423444Z #10 35.85 .../@serialport/bindings-cpp install$ node-gyp-build
2024-12-14T15:40:18.6191315Z #10 38.43 .../@serialport/bindings-cpp install: gyp info it worked if it ends with ok
2024-12-14T15:40:18.7868403Z #10 38.44 .../@serialport/bindings-cpp install: gyp info using node-gyp@10.2.0
2024-12-14T15:40:18.7871100Z #10 38.45 .../@serialport/bindings-cpp install: gyp info using node@22.11.0 | linux | riscv64
2024-12-14T15:40:19.4265533Z #10 39.24 .../@serialport/bindings-cpp install: gyp info find Python using Python version 3.12.8 found at "/usr/bin/python3"
2024-12-14T15:40:20.3097646Z #10 40.12 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v22.11.0/node-v22.11.0-headers.tar.gz
2024-12-14T15:40:20.8944792Z #10 40.71 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v22.11.0/node-v22.11.0-headers.tar.gz
2024-12-14T15:40:28.4024975Z #10 48.21 .../@serialport/bindings-cpp install: gyp http GET https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt
2024-12-14T15:40:28.5142033Z #10 48.26 .../@serialport/bindings-cpp install: gyp http 200 https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt
2024-12-14T15:40:28.5143648Z #10 48.31 .../@serialport/bindings-cpp install: gyp info spawn /usr/bin/python3
2024-12-14T15:40:28.5144857Z #10 48.32 .../@serialport/bindings-cpp install: gyp info spawn args [
2024-12-14T15:40:28.7106465Z #10 48.33 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
2024-12-14T15:40:28.7108446Z #10 48.33 .../@serialport/bindings-cpp install: gyp info spawn args 'binding.gyp',
2024-12-14T15:40:28.7109686Z #10 48.33 .../@serialport/bindings-cpp install: gyp info spawn args '-f',
2024-12-14T15:40:28.7110878Z #10 48.33 .../@serialport/bindings-cpp install: gyp info spawn args 'make',
2024-12-14T15:40:28.7162700Z #10 48.34 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:28.7164497Z #10 48.34 .../@serialport/bindings-cpp install: gyp info spawn args '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build/config.gypi',
2024-12-14T15:40:28.7166058Z #10 48.34 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:28.7167488Z #10 48.34 .../@serialport/bindings-cpp install: gyp info spawn args '/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
2024-12-14T15:40:28.7168754Z #10 48.34 .../@serialport/bindings-cpp install: gyp info spawn args '-I',
2024-12-14T15:40:28.7170021Z #10 48.35 .../@serialport/bindings-cpp install: gyp info spawn args '/root/.cache/node-gyp/22.11.0/include/node/common.gypi',
2024-12-14T15:40:28.7171345Z #10 48.35 .../@serialport/bindings-cpp install: gyp info spawn args '-Dlibrary=shared_library',
2024-12-14T15:40:28.7172504Z #10 48.35 .../@serialport/bindings-cpp install: gyp info spawn args '-Dvisibility=default',
2024-12-14T15:40:28.7173805Z #10 48.35 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/22.11.0',
2024-12-14T15:40:28.7175473Z #10 48.35 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_gyp_dir=/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp',
2024-12-14T15:40:28.7177316Z #10 48.36 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_lib_file=/root/.cache/node-gyp/22.11.0/<(target_arch)/node.lib',
2024-12-14T15:40:28.7179401Z #10 48.36 .../@serialport/bindings-cpp install: gyp info spawn args '-Dmodule_root_dir=/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp',
2024-12-14T15:40:28.7181021Z #10 48.36 .../@serialport/bindings-cpp install: gyp info spawn args '-Dnode_engine=v8',
2024-12-14T15:40:28.7182054Z #10 48.36 .../@serialport/bindings-cpp install: gyp info spawn args '--depth=.',
2024-12-14T15:40:28.7183088Z #10 48.36 .../@serialport/bindings-cpp install: gyp info spawn args '--no-parallel',
2024-12-14T15:40:28.7184165Z #10 48.36 .../@serialport/bindings-cpp install: gyp info spawn args '--generator-output',
2024-12-14T15:40:28.7185189Z #10 48.37 .../@serialport/bindings-cpp install: gyp info spawn args 'build',
2024-12-14T15:40:28.7186183Z #10 48.37 .../@serialport/bindings-cpp install: gyp info spawn args '-Goutput_dir=.'
2024-12-14T15:40:28.7187127Z #10 48.37 .../@serialport/bindings-cpp install: gyp info spawn args ]
2024-12-14T15:40:30.5088094Z #10 50.32 .../@serialport/bindings-cpp install: gyp info spawn make
2024-12-14T15:40:30.7028323Z #10 50.32 .../@serialport/bindings-cpp install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
2024-12-14T15:40:30.7030254Z #10 50.35 .../@serialport/bindings-cpp install: make: Entering directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:40:30.7031977Z #10 50.36 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport.o
2024-12-14T15:40:49.4060769Z #10 69.22 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_unix.o
2024-12-14T15:41:02.7760651Z #10 82.59 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/poller.o
2024-12-14T15:41:21.1145403Z #10 100.9 .../@serialport/bindings-cpp install:   CXX(target) Release/obj.target/bindings/src/serialport_linux.o
2024-12-14T15:41:22.5395532Z #10 102.4 .../@serialport/bindings-cpp install:   SOLINK_MODULE(target) Release/obj.target/bindings.node
2024-12-14T15:41:39.0770838Z #10 118.9 .../@serialport/bindings-cpp install:   COPY Release/bindings.node
2024-12-14T15:41:39.2581146Z #10 119.0 .../@serialport/bindings-cpp install: make: Leaving directory '/app/node_modules/.pnpm/@serialport+bindings-cpp@12.0.1/node_modules/@serialport/bindings-cpp/build'
2024-12-14T15:41:39.2583207Z #10 119.0 .../@serialport/bindings-cpp install: gyp info ok 
2024-12-14T15:41:39.2630910Z #10 119.1 .../@serialport/bindings-cpp install: Done
```

</details>