### PR TITLE
(feat): save the last source route path to each device state

### DIFF
--- a/lib/eventBus.ts
+++ b/lib/eventBus.ts
@@ -27,6 +27,7 @@ interface EventBusMap {
     scenesChanged: [data: eventdata.ScenesChanged];
     reconfigure: [data: eventdata.Reconfigure];
     stateChange: [data: eventdata.StateChange];
+    sourceRoute: [data: eventdata.SourceRouteChanged];
 }
 type EventBusListener<K> = K extends keyof EventBusMap
     ? EventBusMap[K] extends unknown[]
@@ -192,6 +193,13 @@ export default class EventBus {
     public emitExposesAndDevicesChanged(device: Device): void {
         this.emitDevicesChanged();
         this.emitExposesChanged({device});
+    }
+
+    public emitSourceRoute(data: eventdata.SourceRouteChanged): void {
+        this.emitter.emit('sourceRoute', data);
+    }
+    public onSourceRoute(key: ListenerKey, callback: (data: eventdata.SourceRouteChanged) => void): void {
+        this.on('sourceRoute', callback, key);
     }
 
     private on<K extends keyof EventBusMap>(event: K, callback: EventBusListener<K>, key: ListenerKey): void {

--- a/lib/extension/receive.ts
+++ b/lib/extension/receive.ts
@@ -22,6 +22,7 @@ export default class Receive extends Extension {
     async start(): Promise<void> {
         this.eventBus.onPublishEntityState(this, this.onPublishEntityState);
         this.eventBus.onDeviceMessage(this, this.onDeviceMessage);
+        this.eventBus.onSourceRoute(this, this.onSourceRouteChanged);
     }
 
     @bind async onPublishEntityState(data: eventdata.PublishEntityState): Promise<void> {
@@ -182,5 +183,15 @@ export default class Receive extends Extension {
         } else {
             await utils.publishLastSeen({device: data.device, reason: 'messageEmitted'}, settings.get(), true, this.publishEntityState);
         }
+    }
+
+    @bind async onSourceRouteChanged(data: eventdata.SourceRouteChanged): Promise<void> {
+        const device = this.zigbee.resolveEntity(data.device.ieeeAddr);
+        if (!device) {
+            logger.warning(`Source route indication received for unknown device '${data.device.ieeeAddr}'`);
+            return;
+        }
+        logger.debug(`Source route indication received for '${device.name}'`);
+        this.state.set(device, {source_route: data.relaylist});
     }
 }

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -91,6 +91,12 @@ declare global {
             meta: {zclTransactionSequenceNumber?: number; manufacturerCode?: number; frameControl?: ZHFrameControl};
         };
         type ScenesChanged = {entity: Device | Group};
+        type SourceRouteChanged = {
+            device: zh.Device;
+            dstaddr: number;
+            relaycount: number;
+            relaylist: number[];
+        };
     }
 
     // Settings

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -123,6 +123,15 @@ export default class Zigbee {
             if (device.zh.type === 'Coordinator') return;
             this.eventBus.emitDeviceMessage({...data, device});
         });
+        this.herdsman.on('sourceRoute', (data: ZHEvents.SrcRouteIndPayload) => {
+            logger.debug(`Source route indication received: ${stringify(data)}`);
+            const device = this.herdsman.getDeviceByNetworkAddress(data.dstaddr);
+            if (!device) {
+                logger.warning(`Source route indication received for unknown device '${data.dstaddr}'`);
+                return;
+            }
+            this.eventBus.emitSourceRoute({device: device, ...data});
+        });
 
         logger.info(`zigbee-herdsman started (${startResult})`);
         logger.info(`Coordinator firmware version: '${stringify(await this.getCoordinatorVersion())}'`);


### PR DESCRIPTION
This depends on https://github.com/Koenkk/zigbee-herdsman/pull/1264 and works towards solving https://github.com/Koenkk/zigbee2mqtt/issues/21859.

With this PR, an additional `source_route` property is added to devices. This allows the frontend to show the last known path of device messages, which can help when devices are not responding (and then can't be refreshed in the map).