### PR TITLE
fix!: Change default `homeassistant.status_topic` to `homeassistant/status`

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -46,7 +46,6 @@ const ACTION_PATTERNS: string[] = [
 const ACCESS_STATE = 0b001;
 const ACCESS_SET = 0b010;
 const GROUP_SUPPORTED_TYPES: ReadonlyArray<string> = ['light', 'switch', 'lock', 'cover'];
-const DEFAULT_STATUS_TOPIC = 'homeassistant/status';
 const COVER_OPENING_LOOKUP: ReadonlyArray<string> = ['opening', 'open', 'forward', 'up', 'rising'];
 const COVER_CLOSING_LOOKUP: ReadonlyArray<string> = ['closing', 'close', 'backward', 'back', 'reverse', 'down', 'declining'];
 const COVER_STOPPED_LOOKUP: ReadonlyArray<string> = ['stopped', 'stop', 'pause', 'paused'];
@@ -449,7 +448,6 @@ export default class HomeAssistant extends Extension {
         this.eventBus.onExposesChanged(this, async (data) => await this.discover(data.device));
 
         await this.mqtt.subscribe(this.statusTopic);
-        await this.mqtt.subscribe(DEFAULT_STATUS_TOPIC);
 
         /**
          * Prevent unnecessary re-discovery of entities by waiting 5 seconds for retained discovery messages to come in.
@@ -1748,7 +1746,7 @@ export default class HomeAssistant extends Extension {
             } else if (entity) {
                 this.getDiscovered(entity).messages[topic] = {payload: stringify(message), published: true};
             }
-        } else if ((data.topic === this.statusTopic || data.topic === DEFAULT_STATUS_TOPIC) && data.message.toLowerCase() === 'online') {
+        } else if (data.topic === this.statusTopic && data.message.toLowerCase() === 'online') {
             const timer = setTimeout(async () => {
                 // Publish all device states.
                 for (const entity of this.zigbee.devicesAndGroupsIterator(utils.deviceNotCoordinator)) {

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -25,7 +25,7 @@
                     "type": "string",
                     "title": "Home Assistant status topic",
                     "description": "Home Assistant status topic",
-                    "default": "hass/status",
+                    "default": "homeassistant/status",
                     "requiresRestart": true,
                     "examples": ["homeassistant/status"]
                 },

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -28,7 +28,7 @@ export const defaults: RecursivePartial<Settings> = {
     homeassistant: {
         enabled: false,
         discovery_topic: 'homeassistant',
-        status_topic: 'hass/status',
+        status_topic: 'homeassistant/status',
         legacy_action_sensor: false,
         experimental_event_entities: false,
     },

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -240,7 +240,7 @@ describe('Extension: Bridge', () => {
                     homeassistant: {
                         enabled: false,
                         discovery_topic: 'homeassistant',
-                        status_topic: 'hass/status',
+                        status_topic: 'homeassistant/status',
                         legacy_action_sensor: false,
                         experimental_event_entities: false,
                     },

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1348,9 +1348,9 @@ describe('Extension: HomeAssistant', () => {
         // @ts-expect-error private
         extension.state.load();
         await resetExtension();
-        expect(mockMQTT.subscribeAsync).toHaveBeenCalledWith('hass/status');
+        expect(mockMQTT.subscribeAsync).toHaveBeenCalledWith('homeassistant/status');
         mockMQTT.publishAsync.mockClear();
-        await mockMQTTEvents.message('hass/status', 'online');
+        await mockMQTTEvents.message('homeassistant/status', 'online');
         await flushPromises();
         await jest.runOnlyPendingTimersAsync();
         await flushPromises();
@@ -1389,7 +1389,7 @@ describe('Extension: HomeAssistant', () => {
         await resetExtension();
         await flushPromises();
         mockMQTT.publishAsync.mockClear();
-        await mockMQTTEvents.message('hass/status', 'offline');
+        await mockMQTTEvents.message('homeassistant/status', 'offline');
         await flushPromises();
         await jest.runOnlyPendingTimersAsync();
         await flushPromises();
@@ -1402,7 +1402,7 @@ describe('Extension: HomeAssistant', () => {
         extension.state.load();
         await resetExtension();
         mockMQTT.publishAsync.mockClear();
-        await mockMQTTEvents.message('hass/status_different', 'offline');
+        await mockMQTTEvents.message('homeassistant/status_different', 'offline');
         await flushPromises();
         await jest.runOnlyPendingTimersAsync();
         await flushPromises();


### PR DESCRIPTION
For https://github.com/Koenkk/zigbee2mqtt/discussions/24198

> - By default, Zigbee2MQTT does not listen to the `hass/status` Home Assistant status topic anymore, `homeassistant/status` is used instead (if `homeassistant.status_topic` is not set in your Z2M `configuration.yaml`). Double check that Home Assistant is using this status topic by going to: HA -> Settings -> Devices & services -> MQTT -> Configure -> Re-configure MQTT -> Next; the *Birth message topic* should be `homeassistant/status`.