### PR TITLE
fix: Improve device icon serving

### DIFF
--- a/data/configuration.example.yaml
+++ b/data/configuration.example.yaml
@@ -1,5 +1,5 @@
 # Indicates the configuration version (used by configuration migrations)
-version: 2
+version: 4
 
 # Home Assistant integration (MQTT discovery)
 homeassistant:

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -434,7 +434,7 @@ export default class Bridge extends Extension {
         const oldOptions = objectAssignDeep({}, cleanup(entity.options));
 
         if (message.options.icon) {
-            const base64Match = utils.isBase64File(message.options.icon);
+            const base64Match = utils.matchBase64File(message.options.icon);
             if (base64Match) {
                 const fileSettings = utils.saveBase64DeviceIcon(base64Match);
                 message.options.icon = fileSettings;

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -1,8 +1,6 @@
 import type {Zigbee2MQTTAPI, Zigbee2MQTTDevice, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints} from 'lib/types/api';
 
-import crypto from 'node:crypto';
 import fs from 'node:fs';
-import path from 'node:path';
 
 import bind from 'bind-decorator';
 import stringify from 'json-stable-stringify-without-jsonify';
@@ -438,11 +436,7 @@ export default class Bridge extends Extension {
         if (message.options.icon) {
             const base64Match = utils.isBase64File(message.options.icon);
             if (base64Match) {
-                const md5Hash = crypto.createHash('md5').update(base64Match.data).digest('hex');
-                const fileSettings = `device_icons/${md5Hash}.${base64Match.extension}`;
-                const file = path.join(data.getPath(), fileSettings);
-                fs.mkdirSync(path.dirname(file), {recursive: true});
-                fs.writeFileSync(file, base64Match.data, {encoding: 'base64'});
+                const fileSettings = utils.saveBase64DeviceIcon(base64Match);
                 message.options.icon = fileSettings;
                 logger.debug(`Saved base64 image as file to '${fileSettings}'`);
             }

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -439,7 +439,7 @@ export default class Bridge extends Extension {
             const base64Match = utils.isBase64File(message.options.icon);
             if (base64Match) {
                 const md5Hash = crypto.createHash('md5').update(base64Match.data).digest('hex');
-                const fileSettings = path.join('device_icons', `${md5Hash}.${base64Match.extension}`);
+                const fileSettings = `device_icons/${md5Hash}.${base64Match.extension}`;
                 const file = path.join(data.getPath(), fileSettings);
                 fs.mkdirSync(path.dirname(file), {recursive: true});
                 fs.writeFileSync(file, base64Match.data, {encoding: 'base64'});

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -804,7 +804,7 @@
                 "icon": {
                     "type": "string",
                     "title": "Icon",
-                    "description": "The user-defined device icon for the frontend. It can be a full URL link to an image (e.g. https://SOME.SITE/MODEL123.jpg) (you cannot use a path to a local file) or base64 encoded data URL (e.g. image/svg+xml;base64,PHN2ZyB3aW....R0aD)"
+                    "description": "The user-defined device icon for the frontend. It can be a full URL link to an image (e.g. https://SOME.SITE/MODEL123.jpg) or a path to a local file inside the `device_icons` directory."
                 },
                 "homeassistant": {
                     "type": ["object", "null"],

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -246,6 +246,9 @@ export function validate(): string[] {
         if (names.includes(e.friendly_name)) errors.push(`Duplicate friendly_name '${e.friendly_name}' found`);
         errors.push(...utils.validateFriendlyName(e.friendly_name));
         names.push(e.friendly_name);
+        if ('icon' in e && e.icon && !utils.isBase64File(e.icon) && !e.icon.startsWith('device_icons/')) {
+            errors.push(`Device icon of '${e.friendly_name}' should start with 'device_icons/', got '${e.icon}'`);
+        }
         if (e.qos != null && ![0, 1, 2].includes(e.qos)) {
             errors.push(`QOS for '${e.friendly_name}' not valid, should be 0, 1 or 2 got ${e.qos}`);
         }

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -246,7 +246,7 @@ export function validate(): string[] {
         if (names.includes(e.friendly_name)) errors.push(`Duplicate friendly_name '${e.friendly_name}' found`);
         errors.push(...utils.validateFriendlyName(e.friendly_name));
         names.push(e.friendly_name);
-        if ('icon' in e && e.icon && !utils.matchBase64File(e.icon) && !e.icon.startsWith('device_icons/')) {
+        if ('icon' in e && e.icon && !e.icon.startsWith('device_icons/')) {
             errors.push(`Device icon of '${e.friendly_name}' should start with 'device_icons/', got '${e.icon}'`);
         }
         if (e.qos != null && ![0, 1, 2].includes(e.qos)) {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -246,7 +246,7 @@ export function validate(): string[] {
         if (names.includes(e.friendly_name)) errors.push(`Duplicate friendly_name '${e.friendly_name}' found`);
         errors.push(...utils.validateFriendlyName(e.friendly_name));
         names.push(e.friendly_name);
-        if ('icon' in e && e.icon && !utils.isBase64File(e.icon) && !e.icon.startsWith('device_icons/')) {
+        if ('icon' in e && e.icon && !utils.matchBase64File(e.icon) && !e.icon.startsWith('device_icons/')) {
             errors.push(`Device icon of '${e.friendly_name}' should start with 'device_icons/', got '${e.icon}'`);
         }
         if (e.qos != null && ![0, 1, 2].includes(e.qos)) {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -9,7 +9,7 @@ import utils from './utils';
 import yaml, {YAMLFileException} from './yaml';
 
 export {schemaJson};
-export const CURRENT_VERSION = 3;
+export const CURRENT_VERSION = 4;
 /** NOTE: by order of priority, lower index is lower level (more important) */
 export const LOG_LEVELS: readonly string[] = ['error', 'warning', 'info', 'debug'] as const;
 export type LogLevel = 'error' | 'warning' | 'info' | 'debug';

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -9,6 +9,9 @@ import utils from './utils';
 import yaml, {YAMLFileException} from './yaml';
 
 export {schemaJson};
+// When updating also update:
+// - https://github.com/Koenkk/zigbee2mqtt/blob/dev/data/configuration.example.yaml#L2
+// - https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/blob/master/common/rootfs/docker-entrypoint.sh#L54
 export const CURRENT_VERSION = 4;
 /** NOTE: by order of priority, lower index is lower level (more important) */
 export const LOG_LEVELS: readonly string[] = ['error', 'warning', 'info', 'debug'] as const;
@@ -246,7 +249,7 @@ export function validate(): string[] {
         if (names.includes(e.friendly_name)) errors.push(`Duplicate friendly_name '${e.friendly_name}' found`);
         errors.push(...utils.validateFriendlyName(e.friendly_name));
         names.push(e.friendly_name);
-        if ('icon' in e && e.icon && !e.icon.startsWith('device_icons/')) {
+        if ('icon' in e && e.icon && !e.icon.startsWith('http://') && !e.icon.startsWith('https://') && !e.icon.startsWith('device_icons/')) {
             errors.push(`Device icon of '${e.friendly_name}' should start with 'device_icons/', got '${e.icon}'`);
         }
         if (e.qos != null && ![0, 1, 2].includes(e.qos)) {

--- a/lib/util/settingsMigration.ts
+++ b/lib/util/settingsMigration.ts
@@ -460,7 +460,7 @@ function migrateToFour(
         const [validPath, previousValue] = getValue(currentSettings, ['devices']);
 
         for (const deviceKey in currentSettings.devices) {
-            const base64Match = utils.isBase64File(currentSettings.devices[deviceKey].icon ?? '');
+            const base64Match = utils.matchBase64File(currentSettings.devices[deviceKey].icon ?? '');
             if (base64Match) {
                 currentSettings.devices[deviceKey].icon = utils.saveBase64DeviceIcon(base64Match);
             }

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -375,7 +375,7 @@ function deviceNotCoordinator(device: zh.Device): boolean {
     return device.type !== 'Coordinator';
 }
 
-function isBase64File(value: string): {extension: string; data: string} | false {
+function matchBase64File(value: string): {extension: string; data: string} | false {
     const match = value.match(BASE64_IMAGE_REGEX);
     if (match) {
         assert(match.groups?.extension && match.groups?.data);
@@ -397,7 +397,7 @@ function saveBase64DeviceIcon(base64Match: {extension: string; data: string}): s
 const noop = (): void => {};
 
 export default {
-    isBase64File,
+    matchBase64File,
     saveBase64DeviceIcon,
     capitalize,
     getZigbee2MQTTVersion,

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -8,6 +8,8 @@ import path from 'node:path';
 import equals from 'fast-deep-equal/es6';
 import humanizeDuration from 'humanize-duration';
 
+const BASE64_IMAGE_REGEX = new RegExp(`data:image/(?<extension>.+);base64,(?<data>.+)`);
+
 function pad(num: number): string {
     const norm = Math.floor(Math.abs(num));
     return (norm < 10 ? '0' : '') + norm;
@@ -370,10 +372,21 @@ function deviceNotCoordinator(device: zh.Device): boolean {
     return device.type !== 'Coordinator';
 }
 
+function isBase64File(value: string): {extension: string; data: string} | false {
+    const match = value.match(BASE64_IMAGE_REGEX);
+    console.log('match', match);
+    if (match) {
+        assert(match.groups?.extension && match.groups?.data);
+        return {extension: match.groups.extension, data: match.groups.data};
+    }
+    return false;
+}
+
 /* v8 ignore next */
 const noop = (): void => {};
 
 export default {
+    isBase64File,
     capitalize,
     getZigbee2MQTTVersion,
     getDependencyVersion,

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -374,7 +374,6 @@ function deviceNotCoordinator(device: zh.Device): boolean {
 
 function isBase64File(value: string): {extension: string; data: string} | false {
     const match = value.match(BASE64_IMAGE_REGEX);
-    console.log('match', match);
     if (match) {
         assert(match.groups?.extension && match.groups?.data);
         return {extension: match.groups.extension, data: match.groups.data};

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -2,11 +2,14 @@ import type {Zigbee2MQTTAPI, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints, 
 import type * as zhc from 'zigbee-herdsman-converters';
 
 import assert from 'node:assert';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
 import equals from 'fast-deep-equal/es6';
 import humanizeDuration from 'humanize-duration';
+
+import data from './data';
 
 const BASE64_IMAGE_REGEX = new RegExp(`data:image/(?<extension>.+);base64,(?<data>.+)`);
 
@@ -381,11 +384,21 @@ function isBase64File(value: string): {extension: string; data: string} | false 
     return false;
 }
 
+function saveBase64DeviceIcon(base64Match: {extension: string; data: string}): string {
+    const md5Hash = crypto.createHash('md5').update(base64Match.data).digest('hex');
+    const fileSettings = `device_icons/${md5Hash}.${base64Match.extension}`;
+    const file = path.join(data.getPath(), fileSettings);
+    fs.mkdirSync(path.dirname(file), {recursive: true});
+    fs.writeFileSync(file, base64Match.data, {encoding: 'base64'});
+    return fileSettings;
+}
+
 /* v8 ignore next */
 const noop = (): void => {};
 
 export default {
     isBase64File,
+    saveBase64DeviceIcon,
     capitalize,
     getZigbee2MQTTVersion,
     getDependencyVersion,

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -40,6 +40,8 @@ const mocksClear = [
     devices.bulb.removeFromNetwork,
 ];
 
+const deviceIconsDir = path.join(data.mockDir, 'device_icons');
+
 describe('Extension: Bridge', () => {
     let controller: Controller;
     let mockRestart: Mock;
@@ -80,6 +82,7 @@ describe('Extension: Bridge', () => {
         extension.restartRequired = false;
         // @ts-expect-error private
         controller.state.state = {[devices.bulb.ieeeAddr]: {brightness: 50}};
+        fs.rmSync(deviceIconsDir, {force: true, recursive: true});
     });
 
     afterAll(async () => {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -756,7 +756,6 @@ describe('Settings', () => {
     it.each([
         ['bla.png', `Device icon of 'myname' should start with 'device_icons/', got 'bla.png'`],
         ['device_icons/bla.png', undefined],
-        ['data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ', undefined],
     ])('Device icons should be in `device_icons` directory', (icon, error) => {
         write(configurationFile, {
             ...minimalConfig,

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -753,6 +753,25 @@ describe('Settings', () => {
         expect(settings.validate()).toEqual(expect.arrayContaining([error]));
     });
 
+    it.each([
+        ['bla.png', `Device icon of 'myname' should start with 'device_icons/', got 'bla.png'`],
+        ['device_icons/bla.png', undefined],
+        ['data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ', undefined],
+    ])('Device icons should be in `device_icons` directory', (icon, error) => {
+        write(configurationFile, {
+            ...minimalConfig,
+            devices: {'0x0017880104e45519': {friendly_name: 'myname', icon}},
+        });
+
+        settings.reRead();
+
+        if (error) {
+            expect(settings.validate()).toEqual(expect.arrayContaining([error]));
+        } else {
+            expect(settings.validate()).toEqual([]);
+        }
+    });
+
     it('Configuration friendly name cannot be empty', async () => {
         write(configurationFile, {
             ...minimalConfig,

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -756,7 +756,9 @@ describe('Settings', () => {
     it.each([
         ['bla.png', `Device icon of 'myname' should start with 'device_icons/', got 'bla.png'`],
         ['device_icons/bla.png', undefined],
-    ])('Device icons should be in `device_icons` directory', (icon, error) => {
+        ['https://www.example.org/my-device.png', undefined],
+        ['http://www.example.org/my-device.png', undefined],
+    ])('onlythis Device icons should be in `device_icons` directory or a url', (icon, error) => {
         write(configurationFile, {
             ...minimalConfig,
             devices: {'0x0017880104e45519': {friendly_name: 'myname', icon}},

--- a/test/settingsMigration.test.ts
+++ b/test/settingsMigration.test.ts
@@ -823,7 +823,7 @@ describe('Settings Migration', () => {
             settings.reRead();
         });
 
-        it('onlythis Update', () => {
+        it('Update', () => {
             // @ts-expect-error workaround
             const beforeSettings = objectAssignDeep.noMutate({}, settings.getPersistedSettings());
             // @ts-expect-error workaround
@@ -836,11 +836,10 @@ describe('Settings Migration', () => {
                 },
                 '0x223127fffe8d96bc': {
                     friendly_name: '0x223127fffe8d96bc',
-                    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
+                    icon: 'device_icons/effcad234beeb56ea7c457cf2d36d10b.png',
                 },
                 '0x323127fffe8d96bc': {
                     friendly_name: '0x323127fffe8d96bc',
-                    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
                 },
             };
 
@@ -855,7 +854,6 @@ describe('Settings Migration', () => {
                 },
                 '0x323127fffe8d96bc': {
                     friendly_name: '0x323127fffe8d96bc',
-                    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
                 },
             });
 
@@ -873,7 +871,6 @@ describe('Settings Migration', () => {
                         },
                         '0x323127fffe8d96bc': {
                             friendly_name: '0x323127fffe8d96bc',
-                            icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
                         },
                     },
                 }),
@@ -884,12 +881,10 @@ describe('Settings Migration', () => {
             const migratedSettings = settings.getPersistedSettings();
 
             expect(migratedSettings).toStrictEqual(afterSettings);
-            // const migrationNotes = mockedData.joinPath('migration-2-to-3.log');
-            // expect(existsSync(migrationNotes)).toStrictEqual(true);
-            // const migrationNotesContent = readFileSync(migrationNotes, 'utf8');
-            // expect(migrationNotesContent).toContain(`[SPECIAL] Property 'homeassistant' is now always an object.`);
-            // expect(migrationNotesContent).toContain(`[SPECIAL] Property 'frontend' is now always an object.`);
-            // expect(migrationNotesContent).toContain(`[SPECIAL] Property 'availability' is now always an object.`);
+            const migrationNotes = mockedData.joinPath('migration-3-to-4.log');
+            expect(existsSync(migrationNotes)).toStrictEqual(true);
+            const migrationNotesContent = readFileSync(migrationNotes, 'utf8');
+            expect(migrationNotesContent).toContain(`[SPECIAL] Device icons are now saved as images.`);
         });
     });
 });

--- a/test/settingsMigration.test.ts
+++ b/test/settingsMigration.test.ts
@@ -808,4 +808,88 @@ describe('Settings Migration', () => {
             expect(migrationNotesContent).toContain(`[SPECIAL] Property 'availability' is now always an object.`);
         });
     });
+
+    describe('Migrates v3 to v4', () => {
+        const BASE_CONFIG = {
+            version: 3,
+            mqtt: {
+                server: 'mqtt://localhost',
+            },
+        };
+
+        beforeEach(() => {
+            settings.testing.CURRENT_VERSION = 4; // stop update after this version
+            data.writeDefaultConfiguration(BASE_CONFIG);
+            settings.reRead();
+        });
+
+        it('onlythis Update', () => {
+            // @ts-expect-error workaround
+            const beforeSettings = objectAssignDeep.noMutate({}, settings.getPersistedSettings());
+            // @ts-expect-error workaround
+            const afterSettings = objectAssignDeep.noMutate({}, settings.getPersistedSettings());
+            afterSettings.version = 4;
+            afterSettings.devices = {
+                '0x123127fffe8d96bc': {
+                    friendly_name: '0x847127fffe8d96bc',
+                    icon: 'device_icons/08a9016bbc0657cf5f581ae9c19c31a5.png',
+                },
+                '0x223127fffe8d96bc': {
+                    friendly_name: '0x223127fffe8d96bc',
+                    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
+                },
+                '0x323127fffe8d96bc': {
+                    friendly_name: '0x323127fffe8d96bc',
+                    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
+                },
+            };
+
+            settings.set(['devices'], {
+                '0x123127fffe8d96bc': {
+                    friendly_name: '0x847127fffe8d96bc',
+                    icon: 'device_icons/08a9016bbc0657cf5f581ae9c19c31a5.png',
+                },
+                '0x223127fffe8d96bc': {
+                    friendly_name: '0x223127fffe8d96bc',
+                    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
+                },
+                '0x323127fffe8d96bc': {
+                    friendly_name: '0x323127fffe8d96bc',
+                    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
+                },
+            });
+
+            expect(settings.getPersistedSettings()).toStrictEqual(
+                // @ts-expect-error workaround
+                objectAssignDeep.noMutate(beforeSettings, {
+                    devices: {
+                        '0x123127fffe8d96bc': {
+                            friendly_name: '0x847127fffe8d96bc',
+                            icon: 'device_icons/08a9016bbc0657cf5f581ae9c19c31a5.png',
+                        },
+                        '0x223127fffe8d96bc': {
+                            friendly_name: '0x223127fffe8d96bc',
+                            icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
+                        },
+                        '0x323127fffe8d96bc': {
+                            friendly_name: '0x323127fffe8d96bc',
+                            icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJ',
+                        },
+                    },
+                }),
+            );
+
+            settingsMigration.migrateIfNecessary();
+
+            const migratedSettings = settings.getPersistedSettings();
+
+            expect(migratedSettings).toStrictEqual(afterSettings);
+            // const migrationNotes = mockedData.joinPath('migration-2-to-3.log');
+            // expect(existsSync(migrationNotes)).toStrictEqual(true);
+            // const migrationNotesContent = readFileSync(migrationNotes, 'utf8');
+            // expect(migrationNotesContent).toContain(`[SPECIAL] Property 'homeassistant' is now always an object.`);
+            // expect(migrationNotesContent).toContain(`[SPECIAL] Property 'frontend' is now always an object.`);
+            // expect(migrationNotesContent).toContain(`[SPECIAL] Property 'availability' is now always an object.`);
+        });
+    });
 });


### PR DESCRIPTION
Currently device icons are stores as base64 string inside the device options. This significantly increases the size of the `configuration.yaml`, especially when done for all devices (which is what the localise device images on the frontend does). This can even lead to Zigbee2MQTT failing to start (e.g. https://github.com/Koenkk/zigbee2mqtt/issues/25259). With this PR device icons are now saved in the `device_icons` directory, the `configuration.yaml` only contains the reference to the image, e.g.:

```yaml
devices:
    '0x847127fffe8d96bc':
        friendly_name: '0x847127fffe8d96bc'
        icon: device_icons/08a9016bbc0657cf5f581ae9c19c31a5.png
```

Note that images must be in the `device_icons` directory!

Fixes: https://github.com/Koenkk/zigbee2mqtt/issues/25259, https://github.com/nurikk/zigbee2mqtt-frontend/issues/2100, https://github.com/nurikk/zigbee2mqtt-frontend/issues/1477

TODO:
- [x] Test with base url change
- [x] Add check to settings
- [x] Update docs: https://github.com/Koenkk/zigbee2mqtt.io/pull/3352