### PR TITLE
Removed initialization which defined current and voltage entities as diagnostic

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -205,8 +205,6 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     cube_side: {icon: 'mdi:cube'},
     current: {
         device_class: 'current',
-        enabled_by_default: false,
-        entity_category: 'diagnostic',
         state_class: 'measurement',
     },
     current_phase_b: {
@@ -304,8 +302,6 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     vibration_timeout: {entity_category: 'config', icon: 'mdi:timer'},
     voltage: {
         device_class: 'voltage',
-        enabled_by_default: false,
-        entity_category: 'diagnostic',
         state_class: 'measurement',
     },
     voltage_phase_b: {


### PR DESCRIPTION
This is for issue number #25319 I am not sure how I to link issue to PR's in github.  This is only my second contribution.  Let me know how I should do things in the future.

This is an optional change since it will likely have backward changing effects and for my purposes, the PR in the zigbee-herdsman-converters repo solves my immediate issue.