### PR TITLE
fix: Fix URL in startup failed bailout message

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -143,7 +143,7 @@ export class Controller {
             this.eventBus.onAdapterDisconnected(this, this.onZigbeeAdapterDisconnected);
         } catch (error) {
             logger.error('Failed to start zigbee-herdsman');
-            logger.error('Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start.html for possible solutions');
+            logger.error('Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.html for possible solutions');
             logger.error('Exiting...');
             logger.error((error as Error).stack!);
 

--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -143,7 +143,9 @@ export class Controller {
             this.eventBus.onAdapterDisconnected(this, this.onZigbeeAdapterDisconnected);
         } catch (error) {
             logger.error('Failed to start zigbee-herdsman');
-            logger.error('Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.html for possible solutions');
+            logger.error(
+                'Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.html for possible solutions',
+            );
             logger.error('Exiting...');
             logger.error((error as Error).stack!);
 


### PR DESCRIPTION
Fix the URL in the bailout message when Zigbee2MQTT fails to start.
This is related to https://github.com/Koenkk/zigbee2mqtt.io/pull/3353.