### PR TITLE
fix(ignore): Fix 2 to 3 migration enabling frontend/availabilty/homeassistant when not set

### DIFF
--- a/lib/util/settingsMigration.ts
+++ b/lib/util/settingsMigration.ts
@@ -85,16 +85,21 @@ function setValue(currentSettings: any, path: string[], value: unknown, createPa
 function getValue(currentSettings: any, path: string[]): [validPath: boolean, value: unknown] {
     for (let i = 0; i < path.length; i++) {
         const key = path[i];
+        const value = currentSettings[key];
 
-        if (i === path.length - 1 && currentSettings[key] !== undefined) {
-            return [true, currentSettings[key]];
+        if (i === path.length - 1) {
+            if (value == undefined) {
+                return [false, undefined];
+            } else {
+                return [true, value];
+            }
         } else {
-            if (!currentSettings[key]) {
+            if (!value) {
                 // invalid path
                 break;
             }
 
-            currentSettings = currentSettings[key];
+            currentSettings = value;
         }
     }
 

--- a/lib/util/settingsMigration.ts
+++ b/lib/util/settingsMigration.ts
@@ -86,7 +86,7 @@ function getValue(currentSettings: any, path: string[]): [validPath: boolean, va
     for (let i = 0; i < path.length; i++) {
         const key = path[i];
 
-        if (i === path.length - 1) {
+        if (i === path.length - 1 && currentSettings[key] !== undefined) {
             return [true, currentSettings[key]];
         } else {
             if (!currentSettings[key]) {

--- a/lib/util/settingsMigration.ts
+++ b/lib/util/settingsMigration.ts
@@ -408,7 +408,7 @@ function migrateToThree(
     const changeToObject = (currentSettings: Partial<Settings>, path: string[]): ReturnType<SettingsCustomHandler['execute']> => {
         const [validPath, previousValue] = getValue(currentSettings, path);
 
-        if (validPath) {
+        if (validPath && previousValue !== undefined) {
             if (typeof previousValue === 'boolean') {
                 setValue(currentSettings, path, {enabled: previousValue});
             } else {

--- a/lib/util/settingsMigration.ts
+++ b/lib/util/settingsMigration.ts
@@ -88,11 +88,7 @@ function getValue(currentSettings: any, path: string[]): [validPath: boolean, va
         const value = currentSettings[key];
 
         if (i === path.length - 1) {
-            if (value == undefined) {
-                return [false, undefined];
-            } else {
-                return [true, value];
-            }
+            return [value !== undefined, value];
         } else {
             if (!value) {
                 // invalid path

--- a/lib/util/settingsMigration.ts
+++ b/lib/util/settingsMigration.ts
@@ -408,7 +408,7 @@ function migrateToThree(
     const changeToObject = (currentSettings: Partial<Settings>, path: string[]): ReturnType<SettingsCustomHandler['execute']> => {
         const [validPath, previousValue] = getValue(currentSettings, path);
 
-        if (validPath && previousValue !== undefined) {
+        if (validPath) {
             if (typeof previousValue === 'boolean') {
                 setValue(currentSettings, path, {enabled: previousValue});
             } else {

--- a/test/settingsMigration.test.ts
+++ b/test/settingsMigration.test.ts
@@ -807,5 +807,35 @@ describe('Settings Migration', () => {
             expect(migrationNotesContent).toContain(`[SPECIAL] Property 'frontend' is now always an object.`);
             expect(migrationNotesContent).toContain(`[SPECIAL] Property 'availability' is now always an object.`);
         });
+
+        it('Update when not set, tests that frontend/availability is not added when not set', () => {
+            // @ts-expect-error workaround
+            const beforeSettings = objectAssignDeep.noMutate({}, settings.getPersistedSettings());
+            // @ts-expect-error workaround
+            const afterSettings = objectAssignDeep.noMutate({}, settings.getPersistedSettings());
+            afterSettings.version = 3;
+            afterSettings.homeassistant = {enabled: false};
+
+            settings.set(['homeassistant'], false);
+
+            expect(settings.getPersistedSettings()).toStrictEqual(
+                // @ts-expect-error workaround
+                objectAssignDeep.noMutate(beforeSettings, {
+                    homeassistant: false,
+                }),
+            );
+
+            settingsMigration.migrateIfNecessary();
+
+            const migratedSettings = settings.getPersistedSettings();
+
+            expect(migratedSettings).toStrictEqual(afterSettings);
+            const migrationNotes = mockedData.joinPath('migration-2-to-3.log');
+            expect(existsSync(migrationNotes)).toStrictEqual(true);
+            const migrationNotesContent = readFileSync(migrationNotes, 'utf8');
+            expect(migrationNotesContent).toContain(`[SPECIAL] Property 'homeassistant' is now always an object.`);
+            expect(migrationNotesContent).toContain(`[SPECIAL] Property 'frontend' is now always an object.`);
+            expect(migrationNotesContent).toContain(`[SPECIAL] Property 'availability' is now always an object.`);
+        });
     });
 });

--- a/test/settingsMigration.test.ts
+++ b/test/settingsMigration.test.ts
@@ -834,8 +834,8 @@ describe('Settings Migration', () => {
             expect(existsSync(migrationNotes)).toStrictEqual(true);
             const migrationNotesContent = readFileSync(migrationNotes, 'utf8');
             expect(migrationNotesContent).toContain(`[SPECIAL] Property 'homeassistant' is now always an object.`);
-            expect(migrationNotesContent).toContain(`[SPECIAL] Property 'frontend' is now always an object.`);
-            expect(migrationNotesContent).toContain(`[SPECIAL] Property 'availability' is now always an object.`);
+            expect(migrationNotesContent).not.toContain(`[SPECIAL] Property 'frontend' is now always an object.`);
+            expect(migrationNotesContent).not.toContain(`[SPECIAL] Property 'availability' is now always an object.`);
         });
     });
 });


### PR DESCRIPTION
Fix issue with the 2 to 3 migration enabling features when not set, e.g. before this PR:

```yaml
homeassistant: false
```

would result in

```yaml
homeassistant:
  enabled: false
frontend:
  enabled: true
availability:
  enabled: true
```

This PR fixes that