### PR TITLE
Revert "fix: add cap_net_bind_service=+ep to /usr/bin/node (#25385)"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ FROM linux-${TARGETARCH}-alpine AS base
 
 ENV NODE_ENV=production
 WORKDIR /app
-RUN apk add --no-cache tzdata eudev tini nodejs setcap
+RUN apk add --no-cache tzdata eudev tini nodejs
 
 # Dependencies and build
 FROM base AS deps
@@ -47,7 +47,6 @@ COPY package.json LICENSE index.js data/configuration.example.yaml ./
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
-RUN setcap 'cap_net_bind_service=+ep' /usr/bin/node
 
 RUN mkdir /app/data
 


### PR DESCRIPTION
Reverts Koenkk/zigbee2mqtt#25387 because there is not `setcap` package (https://pkgs.alpinelinux.org/packages?name=setcap&branch=v3.21&repo=&arch=x86_64&origin=&flagged=&maintainer=)

CC: @rklaren 