### PR TITLE
fix: add cap_net_bind_service=+ep to /usr/bin/node (#25385)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ FROM linux-${TARGETARCH}-alpine AS base
 
 ENV NODE_ENV=production
 WORKDIR /app
-RUN apk add --no-cache tzdata eudev tini nodejs
+RUN apk add --no-cache tzdata eudev tini nodejs libcap
 
 # Dependencies and build
 FROM base AS deps
@@ -47,6 +47,7 @@ COPY package.json LICENSE index.js data/configuration.example.yaml ./
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN setcap 'cap_net_bind_service=+ep' /usr/bin/node
 
 RUN mkdir /app/data
 


### PR DESCRIPTION
In order for the container to bind to low ports the node binary needs to have cap_net_bind_service. This is needed besides adding the  capability when starting the container.