### PR TITLE
Add semver tags to docker releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,19 @@ jobs:
                       VERSION=dev
                       DATE=${{ github.event.repository.updated_at }}
 
+            - name: release - Docker meta
+              if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
+              uses: docker/metadata-action@v5
+              id: meta
+              with:
+                  images: |
+                      koenkk/zigbee2mqtt
+                      ghcr.io/koenkk/zigbee2mqtt
+                  tags: |
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      type=semver,pattern={{major}}
+
             - name: release - Docker build and push
               if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
               uses: docker/build-push-action@v6
@@ -93,7 +106,7 @@ jobs:
                   file: docker/Dockerfile
                   provenance: false
                   platforms: linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7,linux/riscv64,linux/386
-                  tags: koenkk/zigbee2mqtt:latest,ghcr.io/koenkk/zigbee2mqtt:latest,koenkk/zigbee2mqtt:${{ github.ref_name }},ghcr.io/koenkk/zigbee2mqtt:${{ github.ref_name }}
+                  tags: ${{ steps.meta.outputs.tags }}
                   push: true
                   build-args: |
                       COMMIT=${{ github.sha }}


### PR DESCRIPTION
Change to GH Workflow that publishes Docker images.
This PR will add additional tags to each release ([Rationale](https://medium.com/@mccode/using-semantic-versioning-for-docker-image-tags-dfde8be06699)).
Implements #25524

For a proof of concept, I've created a test tag ([`3.1.4`](https://github.com/RoboMagus/zigbee2mqtt/releases/tag/3.1.4)) which results in [This](https://github.com/RoboMagus/zigbee2mqtt/actions/runs/12614085068/job/35152638409) CI Actions run.
The `release - Docker meta` will result in the following tags being created:
```
  koenkk/zigbee2mqtt:3.1.4
  koenkk/zigbee2mqtt:3.1
  koenkk/zigbee2mqtt:3
  koenkk/zigbee2mqtt:latest
  ghcr.io/koenkk/zigbee2mqtt:3.1.4
  ghcr.io/koenkk/zigbee2mqtt:3.1
  ghcr.io/koenkk/zigbee2mqtt:3
  ghcr.io/koenkk/zigbee2mqtt:latest
```