### PR TITLE
Sanity checks on serial port

### DIFF
--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -58,6 +58,13 @@ export default class Zigbee {
             acceptJoiningDeviceHandler: this.acceptJoiningDeviceHandler,
         };
 
+        try {
+            utils.checkSerial(`${herdsmanSettings.serialPort.path}`);
+        } catch (error) {
+            logger.error(`Error while checking serial port`);
+            throw error;
+        }
+
         logger.debug(
             () =>
                 `Using zigbee-herdsman with settings: '${stringify(JSON.stringify(herdsmanSettings).replaceAll(JSON.stringify(herdsmanSettings.network.networkKey), '"HIDDEN"'))}'`,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "fast-deep-equal": "^3.1.3",
         "finalhandler": "^1.3.1",
         "git-last-commit": "^1.0.1",
+        "glob": "^11.0.0",
         "humanize-duration": "^3.32.1",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       git-last-commit:
         specifier: ^1.0.1
         version: 1.0.1
+      glob:
+        specifier: ^11.0.0
+        version: 11.0.0
       humanize-duration:
         specifier: ^3.32.1
         version: 3.32.1


### PR DESCRIPTION
@Koenkk @Nerivec, related to feature request #25340, I have made an in-principle implementation of the code for checking the serial device when /proc filesystem is available.
This is an example code that I don't think is ready for merge but I wanted your comments on the idea.
These are the deltas I see:

1. Not sure to what extent it is useful with the new code for autodetecting the serial (I still think that gracefully detect if a port is already opened by a different process is useful)
2. Not sure if the helper function is in the place where it should be
3. Not sure if the place where I called the helper function is the best place to do it
4. Not sure if the error handling that I have implemented is the way you like it
5. The helper function returns a bool but the way I have called it, the return is not used so this can be removed
6. This works if /proc filesystem is available (Linux systems), for the moment it is not working on Windows or MacOS but there are detection methods:
    a. In Windows, you can not open a single port simultaneously by multiple applications. 
    b. In MacOS I would have to research sysctl(3) system call that should return the required data

I have added the npm:glob module because I needed to expand the gob pattern for creating the list of open files.

Depending on your comments we can decide to go on with this (and how) or stop it here.
Anyway was a good exercise to learn a bit of Node.js programming as I've always heard about it but never really dug into it.