### PR TITLE
Allow Home Assistant OTA Update entity to show progress while updating

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1405,13 +1405,12 @@ export default class HomeAssistant extends Extension {
                 discovery_payload: {
                     name: null,
                     entity_picture: 'https://github.com/Koenkk/zigbee2mqtt/raw/master/images/logo.png',
-                    latest_version_topic: false,
                     state_topic: true,
                     device_class: 'firmware',
                     entity_category: 'config',
                     command_topic: `${settings.get().mqtt.base_topic}/bridge/request/device/ota_update/update`,
                     payload_install: `{"id": "${entity.ieeeAddr}"}`,
-                    value_template: `{"latest_version": "{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}", "update_percentage": {{ value_json['update'].get('progress', 'null') }} }`,
+                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }}}`,
                 },
             };
             configs.push(updateSensor);

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1603,10 +1603,6 @@ export default class HomeAssistant extends Extension {
                 payload.fan_mode_state_topic = stateTopic;
             }
 
-            if (payload.latest_version_topic) {
-                payload.latest_version_topic = stateTopic;
-            }
-
             if (payload.fan_mode_command_topic) {
                 payload.fan_mode_command_topic = `${baseTopic}/${commandTopicPrefix}set/fan_mode`;
             }

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1405,16 +1405,13 @@ export default class HomeAssistant extends Extension {
                 discovery_payload: {
                     name: null,
                     entity_picture: 'https://github.com/Koenkk/zigbee2mqtt/raw/master/images/logo.png',
-                    latest_version_topic: true,
+                    latest_version_topic: false,
                     state_topic: true,
                     device_class: 'firmware',
                     entity_category: 'config',
                     command_topic: `${settings.get().mqtt.base_topic}/bridge/request/device/ota_update/update`,
                     payload_install: `{"id": "${entity.ieeeAddr}"}`,
-                    value_template: `{{ value_json['update']['installed_version'] }}`,
-                    latest_version_template: `{{ value_json['update']['latest_version'] }}`,
-                    json_attributes_topic: `${settings.get().mqtt.base_topic}/${entity.name}`, // state topic
-                    json_attributes_template: `{"in_progress": {{ iif(value_json['update']['state'] == 'updating', 'true', 'false') }} }`,
+                    value_template: `{"latest_version": "{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}", "update_percentage": {{ value_json['update'].get('progress', 'null') }} }`,
                 },
             };
             configs.push(updateSensor);

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1674,17 +1674,13 @@ describe('Extension: HomeAssistant', () => {
             device_class: 'firmware',
             entity_category: 'config',
             entity_picture: 'https://github.com/Koenkk/zigbee2mqtt/raw/master/images/logo.png',
-            json_attributes_template: `{"in_progress": {{ iif(value_json['update']['state'] == 'updating', 'true', 'false') }} }`,
-            json_attributes_topic: 'zigbee2mqtt/bulb',
-            latest_version_template: "{{ value_json['update']['latest_version'] }}",
-            latest_version_topic: 'zigbee2mqtt/bulb',
             name: null,
             object_id: 'bulb',
             origin,
             payload_install: `{"id": "0x000b57fffec6a5b2"}`,
             state_topic: 'zigbee2mqtt/bulb',
             unique_id: '0x000b57fffec6a5b2_update_zigbee2mqtt',
-            value_template: "{{ value_json['update']['installed_version'] }}",
+            value_template: "{\"latest_version\": \"{{ value_json['update']['latest_version'] }}\", \"installed_version\": \"{{ value_json['update']['installed_version'] }}\", \"update_percentage\": {{ value_json['update'].get('progress', 'null') }} }",
         };
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('homeassistant/update/0x000b57fffec6a5b2/update/config', stringify(payload), {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1681,7 +1681,7 @@ describe('Extension: HomeAssistant', () => {
             state_topic: 'zigbee2mqtt/bulb',
             unique_id: '0x000b57fffec6a5b2_update_zigbee2mqtt',
             value_template:
-                "{\"latest_version\": \"{{ value_json['update']['latest_version'] }}\", \"installed_version\": \"{{ value_json['update']['installed_version'] }}\", \"update_percentage\": {{ value_json['update'].get('progress', 'null') }} }",
+                "{\"latest_version\":\"{{ value_json['update']['latest_version'] }}\",\"installed_version\":\"{{ value_json['update']['installed_version'] }}\",\"update_percentage\":{{ value_json['update'].get('progress', 'null') }}}",
         };
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('homeassistant/update/0x000b57fffec6a5b2/update/config', stringify(payload), {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1680,7 +1680,8 @@ describe('Extension: HomeAssistant', () => {
             payload_install: `{"id": "0x000b57fffec6a5b2"}`,
             state_topic: 'zigbee2mqtt/bulb',
             unique_id: '0x000b57fffec6a5b2_update_zigbee2mqtt',
-            value_template: "{\"latest_version\": \"{{ value_json['update']['latest_version'] }}\", \"installed_version\": \"{{ value_json['update']['installed_version'] }}\", \"update_percentage\": {{ value_json['update'].get('progress', 'null') }} }",
+            value_template:
+                "{\"latest_version\": \"{{ value_json['update']['latest_version'] }}\", \"installed_version\": \"{{ value_json['update']['installed_version'] }}\", \"update_percentage\": {{ value_json['update'].get('progress', 'null') }} }",
         };
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('homeassistant/update/0x000b57fffec6a5b2/update/config', stringify(payload), {


### PR DESCRIPTION
# Background

When and OTA update is in progress, no progress percentage is shown in Home Assistant.
The current MQTT OTA config update set `json_attributes` which should not be used.

# Proposed change
This PR will use the `value_template` to extract `latest_version`, `installed_version` and `update_percentage` from `state_topic` instead. This will allow to use the progress attribute to indicate the progress percentage in Home Assistant.
There is no need to used `latest_version_topic` and `latest_version_template`.

A sample config payload would look like:

```json
{
  "availability": [
    {
      "topic": "zigbee2mqtt/bridge/state",
      "value_template": "{{ value_json.state }}"
    }
  ],
  "command_topic": "zigbee2mqtt/bridge/request/device/ota_update/update",
  "device": {
    "hw_version": 1,
    "identifiers": [
      "zigbee2mqtt_0x943469fffec8bf65"
    ],
    "manufacturer": "IKEA",
    "model": "STYRBAR remote control",
    "model_id": "E2001/E2002",
    "name": "Slaapkamer wandbediening",
    "sw_version": "2.4.5",
    "via_device": "zigbee2mqtt_bridge_0xe0798dfffe1a1fc9"
  },
  "device_class": "firmware",
  "entity_category": "config",
  "entity_picture": "https://github.com/Koenkk/zigbee2mqtt/raw/master/images/logo.png",
  "name": null,
  "object_id": "slaapkamer_steven_wandbediening",
  "origin": {
    "name": "Zigbee2MQTT",
    "sw": "2.0.0",
    "url": "https://www.zigbee2mqtt.io"
  },
  "payload_install": "{\"id\": \"0x943469fffec8bf65\"}",
  "state_topic": "zigbee2mqtt/Slaapkamer wandbediening",
  "unique_id": "0x943469fffec8bf65_update_zigbee2mqtt",
  "value_template": "{\"latest_version\": \"{{ value_json['update']['latest_version'] }}\", \"installed_version\": \"{{ value_json['update']['installed_version'] }}\", \"update_percentage\": {{ value_json['update'].get('progress', 'null') }} }"
}
```

