### PR TITLE
fix: Remove invalid `warn` `log_level` https://github.com/nurikk/zigbee2mqtt-frontend/issues/2369

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -486,7 +486,7 @@
                 },
                 "log_level": {
                     "type": "string",
-                    "enum": ["error", "warning", "info", "debug", "warn"],
+                    "enum": ["error", "warning", "info", "debug"],
                     "title": "Log level",
                     "description": "Logging level",
                     "default": "info"


### PR DESCRIPTION
Fixes https://github.com/nurikk/zigbee2mqtt-frontend/issues/2369