### PR TITLE
Add a settings option to log to console in json format.

### DIFF
--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -168,6 +168,7 @@ declare global {
         device_options: KeyValue;
         advanced: {
             log_rotation: boolean;
+            log_console_json: boolean;
             log_symlink_current: boolean;
             log_output: ('console' | 'file' | 'syslog')[];
             log_directory: string;

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -53,16 +53,20 @@ class Logger {
         let logging = `Logging to console${consoleSilenced ? ' (silenced)' : ''}`;
 
         // Setup default console logger
-        this.logger.add(
-            new winston.transports.Console({
-                silent: consoleSilenced,
-                // winston.config.syslog.levels sets 'warning' as 'red'
-                format: winston.format.combine(
+	// winston.config.syslog.levels sets 'warning' as 'red'
+	let console_format = winston.format.combine(
                     winston.format.colorize({colors: {debug: 'blue', info: 'green', warning: 'yellow', error: 'red'}}),
                     winston.format.printf((info) => {
                         return `[${info.timestamp}] ${info.level}: \t${info.message}`;
                     }),
-                ),
+                )
+	if (settings.get().advanced.log_console_json) {
+		console_format = winston.format.json()
+	}
+        this.logger.add(
+            new winston.transports.Console({
+                silent: consoleSilenced,
+                format: console_format
             }),
         );
 

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -452,6 +452,13 @@
                     "description": "Log rotation",
                     "default": true
                 },
+                "log_console_json": {
+                    "type": "boolean",
+                    "title": "Console json log",
+                    "requiresRestart": true,
+                    "description": "Console json log",
+                    "default": false
+                },
                 "log_symlink_current": {
                     "type": "boolean",
                     "title": "Log symlink current",

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -86,6 +86,7 @@ export const defaults: RecursivePartial<Settings> = {
     device_options: {},
     advanced: {
         log_rotation: true,
+        log_console_json: false,
         log_symlink_current: false,
         log_output: ['console', 'file'],
         log_directory: path.join(data.getPath(), 'log', '%TIMESTAMP%'),


### PR DESCRIPTION
For deployments in docker containers it is very useful to just log to console in a structured json format without any color escapes. This adds the advanced option log_console_json (default false) to enable this.