### PR TITLE
Add a settings option to log to console in json format.

### DIFF
--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -168,6 +168,7 @@ declare global {
         device_options: KeyValue;
         advanced: {
             log_rotation: boolean;
+            log_console_json: boolean;
             log_symlink_current: boolean;
             log_output: ('console' | 'file' | 'syslog')[];
             log_directory: string;

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -53,20 +53,20 @@ class Logger {
         let logging = `Logging to console${consoleSilenced ? ' (silenced)' : ''}`;
 
         // Setup default console logger
-	// winston.config.syslog.levels sets 'warning' as 'red'
-	let console_format = winston.format.combine(
-                    winston.format.colorize({colors: {debug: 'blue', info: 'green', warning: 'yellow', error: 'red'}}),
-                    winston.format.printf((info) => {
-                        return `[${info.timestamp}] ${info.level}: \t${info.message}`;
-                    }),
-                )
-	if (settings.get().advanced.log_console_json) {
-		console_format = winston.format.json()
-	}
+        // winston.config.syslog.levels sets 'warning' as 'red'
+        let console_format = winston.format.combine(
+            winston.format.colorize({colors: {debug: 'blue', info: 'green', warning: 'yellow', error: 'red'}}),
+            winston.format.printf((info) => {
+                return `[${info.timestamp}] ${info.level}: \t${info.message}`;
+            }),
+        );
+        if (settings.get().advanced.log_console_json) {
+            console_format = winston.format.json();
+        }
         this.logger.add(
             new winston.transports.Console({
                 silent: consoleSilenced,
-                format: console_format
+                format: console_format,
             }),
         );
 

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -53,20 +53,18 @@ class Logger {
         let logging = `Logging to console${consoleSilenced ? ' (silenced)' : ''}`;
 
         // Setup default console logger
-        // winston.config.syslog.levels sets 'warning' as 'red'
-        let console_format = winston.format.combine(
-            winston.format.colorize({colors: {debug: 'blue', info: 'green', warning: 'yellow', error: 'red'}}),
-            winston.format.printf((info) => {
-                return `[${info.timestamp}] ${info.level}: \t${info.message}`;
-            }),
-        );
-        if (settings.get().advanced.log_console_json) {
-            console_format = winston.format.json();
-        }
         this.logger.add(
             new winston.transports.Console({
                 silent: consoleSilenced,
-                format: console_format,
+                format: settings.get().advanced.log_console_json
+                    ? winston.format.json()
+                    : winston.format.combine(
+                          // winston.config.syslog.levels sets 'warning' as 'red'
+                          winston.format.colorize({colors: {debug: 'blue', info: 'green', warning: 'yellow', error: 'red'}}),
+                          winston.format.printf((info) => {
+                              return `[${info.timestamp}] ${info.level}: \t${info.message}`;
+                          }),
+                      ),
             }),
         );
 

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -53,16 +53,20 @@ class Logger {
         let logging = `Logging to console${consoleSilenced ? ' (silenced)' : ''}`;
 
         // Setup default console logger
-        this.logger.add(
-            new winston.transports.Console({
-                silent: consoleSilenced,
-                // winston.config.syslog.levels sets 'warning' as 'red'
-                format: winston.format.combine(
+	// winston.config.syslog.levels sets 'warning' as 'red'
+	let console_format = winston.format.combine(
                     winston.format.colorize({colors: {debug: 'blue', info: 'green', warning: 'yellow', error: 'red'}}),
                     winston.format.printf((info) => {
                         return `[${info.timestamp}] ${info.level}: \t${info.message}`;
                     }),
-                ),
+                )
+	if (settings.get().advanced.log_console_json) {
+		console_format = winston.format.json()
+	}
+        this.logger.add(
+            new winston.transports.Console({
+                silent: consoleSilenced,
+                format: console_format
             }),
         );
 

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -452,6 +452,13 @@
                     "description": "Log rotation",
                     "default": true
                 },
+                "log_console_json": {
+                    "type": "boolean",
+                    "title": "Console json log",
+                    "requiresRestart": true,
+                    "description": "Console json log",
+                    "default": false
+                },
                 "log_symlink_current": {
                     "type": "boolean",
                     "title": "Log symlink current",

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -86,6 +86,7 @@ export const defaults: RecursivePartial<Settings> = {
     device_options: {},
     advanced: {
         log_rotation: true,
+        log_console_json: false,
         log_symlink_current: false,
         log_output: ['console', 'file'],
         log_directory: path.join(data.getPath(), 'log', '%TIMESTAMP%'),

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -118,6 +118,7 @@ describe('Extension: Bridge', () => {
                         log_level: 'info',
                         log_namespaced_levels: {},
                         log_output: ['console', 'file'],
+                        log_console_json: false,
                         log_rotation: true,
                         log_symlink_current: false,
                         log_syslog: {},

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -397,4 +397,27 @@ describe('Logger', () => {
         expect(logSpy).toHaveBeenLastCalledWith('debug', `z2m:test: ${splatChars}`);
         expect(consoleWriteSpy.mock.calls[1][0]).toMatch(new RegExp(`^.*\tz2m:test: ${splatChars}`));
     });
+
+    it('Logs to console in JSON when configured', () => {
+        settings.set(['advanced', 'log_console_json'], true);
+        logger.init();
+
+        consoleWriteSpy.mockClear();
+        logger.info(`Test JSON message`, 'z2m');
+
+        const outputJSON = JSON.parse(consoleWriteSpy.mock.calls[0][0]);
+        expect(outputJSON).toStrictEqual({
+            level: 'info',
+            message: 'z2m: Test JSON message',
+            timestamp: expect.any(String),
+        });
+
+        settings.set(['advanced', 'log_console_json'], false);
+        logger.init();
+
+        consoleWriteSpy.mockClear();
+        logger.info(`Test JSON message`, 'z2m');
+
+        expect(consoleWriteSpy.mock.calls[0][0].endsWith('[32minfo[39m: 	z2m: Test JSON message\r\n')).toStrictEqual(true);
+    });
 });

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -418,6 +418,7 @@ describe('Logger', () => {
         consoleWriteSpy.mockClear();
         logger.info(`Test JSON message`, 'z2m');
 
-        expect(consoleWriteSpy.mock.calls[0][0].endsWith('[32minfo[39m: 	z2m: Test JSON message\r\n')).toStrictEqual(true);
+        const outputStr: string = consoleWriteSpy.mock.calls[0][0];
+        expect(outputStr.trim().endsWith('\u001b[32minfo\u001b[39m: \tz2m: Test JSON message')).toStrictEqual(true);
     });
 });


### PR DESCRIPTION
For deployments in docker containers it is very useful to just log to console in a structured json format without any color escapes. This adds the advanced option log_console_json (default false) to enable this.