### PR TITLE
fix: Long startup time when `OnEvent` 'start' times out (repeatedly)

### DIFF
--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -9,7 +9,7 @@ import Extension from './extension';
 export default class OnEvent extends Extension {
     override async start(): Promise<void> {
         for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
-            void this.callOnEvent(device, 'start', {});
+            this.callOnEvent(device, 'start', {}).catch(utils.noop);
         }
 
         this.eventBus.onDeviceMessage(this, (data) => this.callOnEvent(data.device, 'message', this.convertData(data)));

--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -9,7 +9,7 @@ import Extension from './extension';
 export default class OnEvent extends Extension {
     override async start(): Promise<void> {
         for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
-            await this.callOnEvent(device, 'start', {});
+            void this.callOnEvent(device, 'start', {});
         }
 
         this.eventBus.onDeviceMessage(this, (data) => this.callOnEvent(data.device, 'message', this.convertData(data)));


### PR DESCRIPTION
@Koenkk I don't believe there is a scenario where `onEvent` should take precedence over the startup of the rest of Z2M? So this should be fine. Should actually help with spammy networks.

Fix #25681
This particular issue (probably more with the same cause though) was tracked down to this change: 
https://github.com/Koenkk/zigbee-herdsman-converters/pull/8479
These devices are apparently rather picky, and can be offline for a while after the coordinator comes back online, which means, if you have a lot of these, and they all time out, you end up with (10s timeout * number of devices) right in the middle of startup.
Same applies for other devices with similar scenario (_hence the change at the top logic instead of in every converter_).

@antst thanks for the very detailed testing for this, and the (long) time taken! 😉