### PR TITLE
fix: Fix `Error: write after end` error

### DIFF
--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -244,7 +244,9 @@ class Logger {
     // https://github.com/Koenkk/zigbee2mqtt/pull/10905
     /* v8 ignore start */
     public async end(): Promise<void> {
-        // Flush the file transport
+        // Only flush the file transport, don't end logger itself as log() might still be called
+        // causing a UnhandledPromiseRejection (`Error: write after end`). Flushing the file transport
+        // ensures the log files are written before stopping.
         if (this.fileTransport) {
             await new Promise<void>((resolve) => {
                 // @ts-expect-error workaround

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -244,12 +244,9 @@ class Logger {
     // https://github.com/Koenkk/zigbee2mqtt/pull/10905
     /* v8 ignore start */
     public async end(): Promise<void> {
-        this.logger.end();
-
-        await new Promise<void>((resolve) => {
-            if (!this.fileTransport) {
-                process.nextTick(resolve);
-            } else {
+        // Flush the file transport
+        if (this.fileTransport) {
+            await new Promise<void>((resolve) => {
                 // @ts-expect-error workaround
                 if (this.fileTransport._dest) {
                     // @ts-expect-error workaround
@@ -258,8 +255,9 @@ class Logger {
                     // @ts-expect-error workaround
                     this.fileTransport.on('open', () => this.fileTransport._dest.on('finish', resolve));
                 }
-            }
-        });
+                this.fileTransport.end();
+            });
+        }
     }
     /* v8 ignore stop */
 }


### PR DESCRIPTION
Verified by modifying `controller.ts` `exit()` like this:

```js
async exit(code: number, restart = false): Promise<void> {
    console.log('Call logger.end()');
    await logger.end();
    console.log('Before log after end');
    logger.info('LOG AFTER END');
    console.log('After log after end');
    return await this.exitCallback(code, restart);
}
```

Before it threw a `Error: write after end`, after this fix:

```log
[2025-01-10 21:55:30] info: 	z2m: Stopped zigbee-herdsman
[2025-01-10 21:55:30] info: 	z2m: Stopped Zigbee2MQTT
Call logger.end()
Before log after end
[2025-01-10 21:55:30] info: 	z2m: LOG AFTER END
After log after end
```