### PR TITLE
fix: Fix duplicate `action` publish when `advanced.output` has `attribute`

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1294,7 +1294,7 @@ export default class HomeAssistant extends Extension {
          * Whenever a device publish an {action: *} we discover an MQTT device trigger sensor
          * and republish it to zigbee2mqtt/my_device/action
          */
-        if (entity.isDevice() && entity.definition && data.message.action) {
+        if (settings.get().advanced.output === 'json' && entity.isDevice() && entity.definition && data.message.action) {
             const value = data.message['action'].toString();
             await this.publishDeviceTriggerDiscover(entity, 'action', value);
             await this.mqtt.publish(`${data.entity.name}/action`, value, {});

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1724,8 +1724,6 @@ describe('Extension: HomeAssistant', () => {
             {retain: true, qos: 1},
         );
 
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/button/action', 'single', {retain: false, qos: 0});
-
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/button',
             stringify({
@@ -1748,8 +1746,6 @@ describe('Extension: HomeAssistant', () => {
             stringify(discoverPayloadAction),
             {retain: true, qos: 1},
         );
-
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/button/action', 'single', {retain: false, qos: 0});
 
         // Shouldn't rediscover when already discovered in previous session
         clearDiscoveredTrigger('0x0017880104e45520');
@@ -1787,6 +1783,19 @@ describe('Extension: HomeAssistant', () => {
             expect.any(String),
             expect.any(Object),
         );
+    });
+
+    test.each(['attribute_and_json', 'json', 'attribute'])('Should publish /action for MQTT device trigger', async (output) => {
+        settings.set(['advanced', 'output'], output);
+        mockMQTTPublishAsync.mockClear();
+
+        const device = devices.WXKG11LM;
+        const payload1 = {data: {onOff: 1}, cluster: 'genOnOff', device, endpoint: device.getEndpoint(1), type: 'attributeReport', linkquality: 10};
+        await mockZHEvents.message(payload1);
+        await flushPromises();
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/button/action', 'single', {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync.mock.calls.filter((c) => c[1] === 'single')).toHaveLength(1);
     });
 
     it('Should not discover device_automation when disabled', async () => {


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/25877