### PR TITLE
fix: Only use endpoint-specific states if the device definition uses them

### DIFF
--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -170,9 +170,7 @@ export default class Groups extends Extension {
                 const stateKey =
                     endpointNames &&
                     endpointNames.length >= member.ID &&
-                    device.definition &&
-                    device.definition.meta &&
-                    device.definition.meta.multiEndpoint &&
+                    device.definition?.meta?.multiEndpoint &&
                     (!device.definition.meta.multiEndpointSkip || !device.definition.meta.multiEndpointSkip.includes('state'))
                         ? `state_${endpointNames[member.ID - 1]}`
                         : 'state';

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -168,7 +168,7 @@ export default class Groups extends Extension {
                 const state = this.state.get(device);
                 const endpointNames = device.isDevice() && device.getEndpointNames();
                 const stateKey = endpointNames && endpointNames.length >= member.ID &&
-                    device.definition.meta &&
+                    device.definition && device.definition.meta &&
                     device.definition.meta.multiEndpoint &&
                     (!device.definition.meta.multiEndpointSkip || !device.definition.meta.multiEndpointSkip.includes('state')) ?
                     `state_${endpointNames[member.ID - 1]}` : 'state';

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -167,11 +167,15 @@ export default class Groups extends Extension {
             if (this.state.exists(device)) {
                 const state = this.state.get(device);
                 const endpointNames = device.isDevice() && device.getEndpointNames();
-                const stateKey = endpointNames && endpointNames.length >= member.ID &&
-                    device.definition && device.definition.meta &&
+                const stateKey =
+                    endpointNames &&
+                    endpointNames.length >= member.ID &&
+                    device.definition &&
+                    device.definition.meta &&
                     device.definition.meta.multiEndpoint &&
-                    (!device.definition.meta.multiEndpointSkip || !device.definition.meta.multiEndpointSkip.includes('state')) ?
-                    `state_${endpointNames[member.ID - 1]}` : 'state';
+                    (!device.definition.meta.multiEndpointSkip || !device.definition.meta.multiEndpointSkip.includes('state'))
+                        ? `state_${endpointNames[member.ID - 1]}`
+                        : 'state';
 
                 if (state[stateKey] === 'ON' || state[stateKey] === 'OPEN') {
                     return false;

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -167,10 +167,11 @@ export default class Groups extends Extension {
             if (this.state.exists(device)) {
                 const state = this.state.get(device);
                 const endpointNames = device.isDevice() && device.getEndpointNames();
-                const stateKey = device.definition.meta &&
+                const stateKey = endpointNames && endpointNames.length >= member.ID &&
+                    device.definition.meta &&
                     device.definition.meta.multiEndpoint &&
-                    (!device.definition.meta.multiEndpointSkip || !device.definition.meta.multiEndpointSkip.includes('state')) &&
-                    endpointNames && endpointNames.length >= member.ID ? `state_${endpointNames[member.ID - 1]}` : 'state';
+                    (!device.definition.meta.multiEndpointSkip || !device.definition.meta.multiEndpointSkip.includes('state')) ?
+                    `state_${endpointNames[member.ID - 1]}` : 'state';
 
                 if (state[stateKey] === 'ON' || state[stateKey] === 'OPEN') {
                     return false;

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -167,7 +167,10 @@ export default class Groups extends Extension {
             if (this.state.exists(device)) {
                 const state = this.state.get(device);
                 const endpointNames = device.isDevice() && device.getEndpointNames();
-                const stateKey = endpointNames && endpointNames.length >= member.ID ? `state_${endpointNames[member.ID - 1]}` : 'state';
+                const stateKey = device.definition.meta &&
+                    device.definition.meta.multiEndpoint &&
+                    (!device.definition.meta.multiEndpointSkip || !device.definition.meta.multiEndpointSkip.includes('state')) &&
+                    endpointNames && endpointNames.length >= member.ID ? `state_${endpointNames[member.ID - 1]}` : 'state';
 
                 if (state[stateKey] === 'ON' || state[stateKey] === 'OPEN') {
                     return false;

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -347,11 +347,11 @@ describe('Extension: Groups', () => {
         settings.set(['groups'], {
             1: {friendly_name: 'group_1', retain: false},
         });
-        
+
         await mockMQTTEvents.message('zigbee2mqtt/group_1/set', stringify({state: 'ON'}));
         await flushPromises();
         mockMQTTPublishAsync.mockClear();
-        
+
         await mockMQTTEvents.message('zigbee2mqtt/bulb_color/set', stringify({state: 'OFF'}));
         await mockMQTTEvents.message('zigbee2mqtt/wall_switch_double/set', stringify({state_left: 'OFF'}));
         await flushPromises();

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -336,7 +336,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/group_1', stringify({state: 'OFF'}), {retain: false, qos: 0});
     });
 
-        it('Should publish state change off if all lights within turn off with non default-ep, but device state does not use them', async () => {
+    it('Should publish state change off if all lights within turn off with non default-ep, but device state does not use them', async () => {
         const device_1 = devices.bulb_color;
         const device_2 = devices.InovelliVZM31SN;
         const endpoint_1 = device_1.getEndpoint(1)!;

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -360,7 +360,7 @@ describe('Extension: Groups', () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/wall_switch_double', stringify({state_left: 'OFF'}), {retain: false, qos: 0});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/group_1', stringify({state: 'OFF'}), {retain: false, qos: 0});
     });
-    
+
     it('Should not publish state change off if any lights within are still on when changed via shared group', async () => {
         const device_1 = devices.bulb_color;
         const device_2 = devices.bulb;

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -19,6 +19,7 @@ returnDevices.push(
     devices.bulb_color_2.ieeeAddr,
     devices.bulb_2.ieeeAddr,
     devices.GLEDOPTO_2ID.ieeeAddr,
+    devices.InovelliVZM31SN.ieeeAddr,
 );
 
 describe('Extension: Groups', () => {
@@ -335,6 +336,31 @@ describe('Extension: Groups', () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/group_1', stringify({state: 'OFF'}), {retain: false, qos: 0});
     });
 
+        it('Should publish state change off if all lights within turn off with non default-ep, but device state does not use them', async () => {
+        const device_1 = devices.bulb_color;
+        const device_2 = devices.InovelliVZM31SN;
+        const endpoint_1 = device_1.getEndpoint(1)!;
+        const endpoint_2 = device_2.getEndpoint(2)!;
+        const group = groups.group_1;
+        group.members.push(endpoint_1);
+        group.members.push(endpoint_2);
+        settings.set(['groups'], {
+            1: {friendly_name: 'group_1', retain: false},
+        });
+        
+        await mockMQTTEvents.message('zigbee2mqtt/group_1/set', stringify({state: 'ON'}));
+        await flushPromises();
+        mockMQTTPublishAsync.mockClear();
+        
+        await mockMQTTEvents.message('zigbee2mqtt/bulb_color/set', stringify({state: 'OFF'}));
+        await mockMQTTEvents.message('zigbee2mqtt/wall_switch_double/set', stringify({state_left: 'OFF'}));
+        await flushPromises();
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/bulb_color', stringify({state: 'OFF'}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/wall_switch_double', stringify({state_left: 'OFF'}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/group_1', stringify({state: 'OFF'}), {retain: false, qos: 0});
+    });
+    
     it('Should not publish state change off if any lights within are still on when changed via shared group', async () => {
         const device_1 = devices.bulb_color;
         const device_2 = devices.bulb;

--- a/test/mocks/zigbeeHerdsman.ts
+++ b/test/mocks/zigbeeHerdsman.ts
@@ -1123,9 +1123,9 @@ export const devices = {
         59545,
         4655,
         [
-            new Endpoint(1, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {"multiEndpointSkip": ['state', 'power', 'energy', 'brightness']}),
-            new Endpoint(2, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {"multiEndpointSkip": ['state', 'power', 'energy', 'brightness']}),
-            new Endpoint(3, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {"multiEndpointSkip": ['state', 'power', 'energy', 'brightness']}),
+            new Endpoint(1, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {multiEndpointSkip: ['state', 'power', 'energy', 'brightness']}),
+            new Endpoint(2, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {multiEndpointSkip: ['state', 'power', 'energy', 'brightness']}),
+            new Endpoint(3, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {multiEndpointSkip: ['state', 'power', 'energy', 'brightness']}),
         ],
         true,
         'Mains (single phase)',

--- a/test/mocks/zigbeeHerdsman.ts
+++ b/test/mocks/zigbeeHerdsman.ts
@@ -1117,7 +1117,7 @@ export const devices = {
         undefined,
         CUSTOM_CLUSTERS,
     ),
-    'InovelliVZM31SN': new Device(
+    InovelliVZM31SN: new Device(
         'Router',
         '0xb43a31fffe2f1f6a',
         59545,

--- a/test/mocks/zigbeeHerdsman.ts
+++ b/test/mocks/zigbeeHerdsman.ts
@@ -1117,6 +1117,25 @@ export const devices = {
         undefined,
         CUSTOM_CLUSTERS,
     ),
+    'InovelliVZM31SN': new Device(
+        'Router',
+        '0xb43a31fffe2f1f6a',
+        59545,
+        4655,
+        [
+            new Endpoint(1, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {"multiEndpointSkip": ['state', 'power', 'energy', 'brightness']}),
+            new Endpoint(2, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {"multiEndpointSkip": ['state', 'power', 'energy', 'brightness']}),
+            new Endpoint(3, [], [], '0xb43a31fffe2f1f6a', [], {}, [], 1, 1, {"multiEndpointSkip": ['state', 'power', 'energy', 'brightness']}),
+        ],
+        true,
+        'Mains (single phase)',
+        'VZM31-SN',
+        false,
+        undefined,
+        undefined,
+        undefined,
+        CUSTOM_CLUSTERS,
+    ),
 };
 
 export const mockController = {


### PR DESCRIPTION
Some devices don't use separate endpoint-specific states even if they support multiple endpoints (such as Inovelli Blue 2-in-1 switches).

Fixes https://github.com/Koenkk/zigbee2mqtt/pull/26019