### PR TITLE
Add Home Assistant device class for flow rates (e.g., Sonoff SWV)

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -172,6 +172,7 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     energy: {device_class: 'energy', state_class: 'total_increasing'},
     external_temperature_input: {icon: 'mdi:thermometer'},
     formaldehyd: {state_class: 'measurement'},
+    flow: {device_class: 'volume_flow_rate', state_class: 'measurement'},
     gas_density: {icon: 'mdi:google-circles-communities', state_class: 'measurement'},
     hcho: {icon: 'mdi:air-filter', state_class: 'measurement'},
     humidity: {device_class: 'humidity', state_class: 'measurement'},


### PR DESCRIPTION
Supports devices like the SONOFF SWV (Smart Water Valve), which has [an entity called `Flow`, with units of `m³/h`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/sonoff.ts#L1330).

Adding the device class makes it easier to natively convert this value to other units, like `L/min`.

This change is aligned with [lib/modernExtend.flow](https://github.com/Koenkk/zigbee-herdsman-converters/blob/db7595cf52b55ff47c2132d0952d7444cc0f1b91/src/lib/modernExtend.ts#L714-L726), which has a unit of `m³/h`.

It won't cover the Neo NAS-WV03B device, as it [exposes an entity called `water_current` instead](https://github.com/Koenkk/zigbee-herdsman-converters/blob/db7595cf52b55ff47c2132d0952d7444cc0f1b91/src/devices/neo.ts#L173-L179). I don't know how best to handle this scenario -- renaming it to `flow` would impact users of that device, but it also doesn't look like a go-forward name so it doesn't seem sensible to add `water_current` to the HA mappings. (And "water current" is funny wording in the first place.)

I couldn't find any other devices exposing a water flow rate.

