### PR TITLE
Rename `internal_temperature` to `internalTemperature` to correct typo

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -181,7 +181,7 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     humidity_min: {entity_category: 'config', icon: 'mdi:water-percent'},
     illuminance_calibration: {entity_category: 'config', icon: 'mdi:wrench-clock'},
     illuminance: {device_class: 'illuminance', state_class: 'measurement'},
-    internal_temperature: {
+    internalTemperature: {
         device_class: 'temperature',
         entity_category: 'diagnostic',
         state_class: 'measurement',


### PR DESCRIPTION
In #25289, I exposed the internal_temperature sensor from Inovelli devices with the correct device class, however, the actual sensor is called `internalTemperature` and not `internal_temperature`. Correcting that mistake here.