### PR TITLE
Fix OTA attribute "is_updating" for home assistant discovery/integration

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1411,7 +1411,7 @@ export default class HomeAssistant extends Extension {
                     entity_category: 'config',
                     command_topic: `${settings.get().mqtt.base_topic}/bridge/request/device/ota_update/update`,
                     payload_install: `{"id": "${entity.ieeeAddr}"}`,
-                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }}}`,
+                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }},"is_updating":{{ value_json['update']['state'] == 'updating' }}}`,
                 },
             };
             configs.push(updateSensor);

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1681,7 +1681,7 @@ describe('Extension: HomeAssistant', () => {
             state_topic: 'zigbee2mqtt/bulb',
             unique_id: '0x000b57fffec6a5b2_update_zigbee2mqtt',
             value_template:
-                "{\"latest_version\":\"{{ value_json['update']['latest_version'] }}\",\"installed_version\":\"{{ value_json['update']['installed_version'] }}\",\"update_percentage\":{{ value_json['update'].get('progress', 'null') }}}",
+                "{\"latest_version\":\"{{ value_json['update']['latest_version'] }}\",\"installed_version\":\"{{ value_json['update']['installed_version'] }}\",\"update_percentage\":{{ value_json['update'].get('progress', 'null') }},\"is_updating\":{{ value_json['update']['state'] == 'updating' }}}",
         };
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('homeassistant/update/0x000b57fffec6a5b2/update/config', stringify(payload), {


### PR DESCRIPTION
The OTA updates discovery payload was not including the "is_updating" field that allows Home Assistant UI to detect and show to user when updates are ongoing.

This PR fixes that.
