### PR TITLE
Fix HA MQTT dict entry indicating that an update is progress

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1411,7 +1411,7 @@ export default class HomeAssistant extends Extension {
                     entity_category: 'config',
                     command_topic: `${settings.get().mqtt.base_topic}/bridge/request/device/ota_update/update`,
                     payload_install: `{"id": "${entity.ieeeAddr}"}`,
-                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }},"is_updating":{{ value_json['update']['state'] == 'updating' }}}`,
+                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }},"in_progress":{{ (value_json['update']['state'] == 'updating')|lower }}`,
                 },
             };
             configs.push(updateSensor);

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1411,7 +1411,7 @@ export default class HomeAssistant extends Extension {
                     entity_category: 'config',
                     command_topic: `${settings.get().mqtt.base_topic}/bridge/request/device/ota_update/update`,
                     payload_install: `{"id": "${entity.ieeeAddr}"}`,
-                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }},"in_progress":{{ (value_json['update']['state'] == 'updating')|lower }}`,
+                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }},"in_progress":{{ (value_json['update']['state'] == 'updating')|lower }}}`,
                 },
             };
             configs.push(updateSensor);

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1681,7 +1681,7 @@ describe('Extension: HomeAssistant', () => {
             state_topic: 'zigbee2mqtt/bulb',
             unique_id: '0x000b57fffec6a5b2_update_zigbee2mqtt',
             value_template:
-                "{\"latest_version\":\"{{ value_json['update']['latest_version'] }}\",\"installed_version\":\"{{ value_json['update']['installed_version'] }}\",\"update_percentage\":{{ value_json['update'].get('progress', 'null') }},\"is_updating\":{{ value_json['update']['state'] == 'updating' }}}",
+                "{\"latest_version\":\"{{ value_json['update']['latest_version'] }}\",\"installed_version\":\"{{ value_json['update']['installed_version'] }}\",\"update_percentage\":{{ value_json['update'].get('progress', 'null') }},\"in_progress\":{{ (value_json['update']['state'] == 'updating')|lower }}}",
         };
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('homeassistant/update/0x000b57fffec6a5b2/update/config', stringify(payload), {


### PR DESCRIPTION
I think there are a couple of issues with [this PR](https://github.com/Koenkk/zigbee2mqtt/pull/26231) that result in all of my devices now reporting that there's an update when there isn't.  First, the new field introduced by https://github.com/home-assistant/core/pull/129468 is called `in_progress` and not `is_updating` and the Jinja test is outputting `True` or `False`, while the JSON parser is expecting `true` or `false`.  If I make this change, update detection in HA works again:

```
diff --git a/lib/extension/homeassistant.ts b/lib/extension/homeassistant.ts
index eed232d4..cebf730d 100644
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1411,7 +1411,7 @@ export default class HomeAssistant extends Extension {
                     entity_category: 'config',
                     command_topic: `${settings.get().mqtt.base_topic}/bridge/request/device/ota_update/update`,
                     payload_install: `{"id": "${entity.ieeeAddr}"}`,
-                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }},"is_updating":{{ value_json['update']['state'] == 'updating' }}}`,
+                    value_template: `{"latest_version":"{{ value_json['update']['latest_version'] }}","installed_version":"{{ value_json['update']['installed_version'] }}","update_percentage":{{ value_json['update'].get('progress', 'null') }},"in_progress":{{ (value_json['update']['state'] == 'updating')|lower }}}`,
                 },
             };
             configs.push(updateSensor);
```

If I only change the key to "in_progress" and leave the boolean as-is, I get the following errors about the JSON being invalid:

```
2025-02-08 16:07:17.271 DEBUG (MainThread) [homeassistant.components.mqtt.update] No valid (JSON) payload detected after processing payload '{"latest_version":"268513372","installed_version":"268513372","update_percentage":null,"in_progress":False}' on topic 'zigbee2mqttp/Family Room Couch' for entity 'update.family_room_couch'
```