### PR TITLE
Feat allow publish from convertSet

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -243,6 +243,7 @@ export default class Availability extends Extension {
                         options,
                         state,
                         device: device.zh,
+                        publish: (payload: KeyValue) => this.publishEntityState(devicez payload),
                     };
 
                     try {

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -243,6 +243,7 @@ export default class Availability extends Extension {
                         options,
                         state,
                         device: device.zh,
+                        /* v8 ignore next */
                         publish: (payload: KeyValue) => this.publishEntityState(device, payload),
                     };
 

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -243,7 +243,7 @@ export default class Availability extends Extension {
                         options,
                         state,
                         device: device.zh,
-                        publish: (payload: KeyValue) => this.publishEntityState(devicez payload),
+                        publish: (payload: KeyValue) => this.publishEntityState(device, payload),
                     };
 
                     try {

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -231,6 +231,7 @@ export default class Publish extends Extension {
                 state: entityState,
                 membersState,
                 mapped: definition,
+                publish: (payload: KeyValue) => this.publishEntityState(re, payload),
             };
 
             // Strip endpoint name from meta.message properties.

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -231,6 +231,7 @@ export default class Publish extends Extension {
                 state: entityState,
                 membersState,
                 mapped: definition,
+				/* v8 ignore next */
                 publish: (payload: KeyValue) => this.publishEntityState(re, payload),
             };
 


### PR DESCRIPTION
In order to be able to publish from the context of toZigbee convertSet,
adds publish to convert meta parameter
Requires zhc type update https://github.com/Koenkk/zigbee-herdsman-converters/pull/8875

Required to implement a virtual siren state in https://github.com/Koenkk/zigbee-herdsman-converters/pull/8834
