### PR TITLE
fix: write `ZIGBEE2MQTT_CONFIG_*` envs to yaml as overrides

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ async function start() {
         // Validate settings
         const settings = require('./dist/util/settings');
 
+        settings.write(); // trigger initial writing of `ZIGBEE2MQTT_CONFIG_*` ENVs
         settings.reRead();
 
         const settingsMigration = require('./dist/util/settingsMigration');

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -146,9 +146,11 @@ function parseValueRef(text: string): {filename: string; key: string} | null {
     }
 }
 
-function write(): void {
+export function write(): void {
     const settings = getPersistedSettings();
     const toWrite: KeyValue = objectAssignDeep({}, settings);
+
+    applyEnvironmentVariables(toWrite);
 
     // Read settings to check if we have to split devices/groups into separate file.
     const actual = yaml.read(CONFIG_FILE_PATH);
@@ -277,7 +279,6 @@ export function validate(): string[] {
 
 function read(): Partial<Settings> {
     const s = yaml.read(CONFIG_FILE_PATH) as Partial<Settings>;
-    applyEnvironmentVariables(s);
 
     // Read !secret MQTT username and password if set
     const interpretValue = <T>(value: T): T => {


### PR DESCRIPTION
Instead of applying ENVs on top of runtime settings, overwrite the corresponding yaml settings.

_Should prevent confusion around scenario like HA add-on config page, where ENVs implicitly overrode the yaml._