### PR TITLE
feat: Use dynamic import for optional extensions

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -172,11 +172,14 @@ export class Controller {
                         throw new Error('Tried to enable Frontend extension disabled in settings');
                     }
 
+                    // this is not actually used, not tested either
+                    /* v8 ignore start */
                     const {Frontend} = await import('./extension/frontend.js');
 
                     await this.addExtension(new Frontend(...this.extensionArgs));
 
                     break;
+                    /* v8 ignore stop */
                 }
                 case 'HomeAssistant': {
                     if (!settings.get().homeassistant.enabled) {

--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -193,7 +193,9 @@ export class Controller {
                     break;
                 }
                 default: {
-                    throw new Error(`Extension ${name} does not exist or is not built-in (should be added with 'addExtension')`);
+                    throw new Error(
+                        `Extension ${name} does not exist (should be added with 'addExtension') or is built-in that cannot be enabled at runtime`,
+                    );
                 }
             }
         } else {

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -1,4 +1,4 @@
-import type {Zigbee2MQTTAPI} from 'lib/types/api';
+import type {Zigbee2MQTTAPI} from '../types/api';
 
 import assert from 'node:assert';
 

--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -1,4 +1,4 @@
-import type {Zigbee2MQTTAPI, Zigbee2MQTTResponseEndpoints} from 'lib/types/api';
+import type {Zigbee2MQTTAPI, Zigbee2MQTTResponseEndpoints} from '../types/api';
 
 import assert from 'node:assert';
 

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -1,4 +1,4 @@
-import type {Zigbee2MQTTAPI, Zigbee2MQTTDevice, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints} from 'lib/types/api';
+import type {Zigbee2MQTTAPI, Zigbee2MQTTDevice, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints} from '../types/api';
 
 import fs from 'node:fs';
 

--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -1,4 +1,4 @@
-import type {Zigbee2MQTTAPI} from 'lib/types/api';
+import type {Zigbee2MQTTAPI} from '../types/api';
 
 import bind from 'bind-decorator';
 import stringify from 'json-stable-stringify-without-jsonify';

--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -1,4 +1,4 @@
-import type {Zigbee2MQTTAPI, Zigbee2MQTTResponse} from 'lib/types/api';
+import type {Zigbee2MQTTAPI, Zigbee2MQTTResponse} from '../types/api';
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -27,7 +27,7 @@ import Extension from './extension';
 /**
  * This extension servers the frontend
  */
-export default class Frontend extends Extension {
+export class Frontend extends Extension {
     private mqttBaseTopic: string;
     private host: string | undefined;
     private port: number;
@@ -225,3 +225,5 @@ export default class Frontend extends Extension {
         }
     }
 }
+
+export default Frontend;

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -1,4 +1,4 @@
-import type {Zigbee2MQTTAPI, Zigbee2MQTTResponseEndpoints} from 'lib/types/api';
+import type {Zigbee2MQTTAPI, Zigbee2MQTTResponseEndpoints} from '../types/api';
 
 import assert from 'node:assert';
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -383,7 +383,7 @@ class Bridge {
 /**
  * This extensions handles integration with HomeAssistant
  */
-export default class HomeAssistant extends Extension {
+export class HomeAssistant extends Extension {
     private discovered: {[s: string]: Discovered} = {};
     private discoveryTopic: string;
     private discoveryRegex: RegExp;
@@ -2150,3 +2150,5 @@ export default class HomeAssistant extends Extension {
         return value_template;
     }
 }
+
+export default HomeAssistant;

--- a/lib/extension/networkMap.ts
+++ b/lib/extension/networkMap.ts
@@ -1,4 +1,4 @@
-import type {Zigbee2MQTTAPI, Zigbee2MQTTNetworkMap} from 'lib/types/api';
+import type {Zigbee2MQTTAPI, Zigbee2MQTTNetworkMap} from '../types/api';
 
 import bind from 'bind-decorator';
 import stringify from 'json-stable-stringify-without-jsonify';

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -1,5 +1,6 @@
-import type {Zigbee2MQTTAPI} from 'lib/types/api';
 import type {Ota} from 'zigbee-herdsman-converters';
+
+import type {Zigbee2MQTTAPI} from '../types/api';
 
 import assert from 'node:assert';
 import path from 'node:path';

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -1,14 +1,15 @@
-import type TypeEventBus from 'lib/eventBus';
-import type TypeExtension from 'lib/extension/extension';
-import type TypeDevice from 'lib/model/device';
-import type TypeGroup from 'lib/model/group';
-import type TypeMQTT from 'lib/mqtt';
-import type TypeState from 'lib/state';
-import type TypeZigbee from 'lib/zigbee';
 import type {AdapterTypes as ZHAdapterTypes, Events as ZHEvents, Models as ZHModels} from 'zigbee-herdsman';
 import type {Cluster as ZHCluster, FrameControl as ZHFrameControl} from 'zigbee-herdsman/dist/zspec/zcl/definition/tstype';
 
-import {LogLevel} from 'lib/util/settings';
+import type TypeEventBus from '../eventBus';
+import type TypeExtension from '../extension/extension';
+import type TypeDevice from '../model/device';
+import type TypeGroup from '../model/group';
+import type TypeMQTT from '../mqtt';
+import type TypeState from '../state';
+import type TypeZigbee from '../zigbee';
+
+import {LogLevel} from '../util/settings';
 
 type OptionalProps<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -1,5 +1,6 @@
-import type {Zigbee2MQTTAPI, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints, Zigbee2MQTTScene} from 'lib/types/api';
 import type * as zhc from 'zigbee-herdsman-converters';
+
+import type {Zigbee2MQTTAPI, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints, Zigbee2MQTTScene} from '../types/api';
 
 import {exec} from 'child_process';
 import assert from 'node:assert';
@@ -50,7 +51,7 @@ function capitalize(s: string): string {
     return s[0].toUpperCase() + s.slice(1);
 }
 
-async function getZigbee2MQTTVersion(includeCommitHash = true): Promise<{commitHash?: string; version: string}> {
+export async function getZigbee2MQTTVersion(includeCommitHash = true): Promise<{commitHash?: string; version: string}> {
     const packageJSON = (await import('../../package.json', {with: {type: 'json'}})).default;
     const version = packageJSON.version;
     let commitHash: string | undefined;

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1112,8 +1112,8 @@ describe('Controller', () => {
         await controller.start();
 
         await expect(async () => {
-            await controller.enableDisableExtension(true, 'DoesNotExist');
-        }).rejects.toThrow("Extension DoesNotExist does not exist or is not built-in (should be added with 'addExtension')");
+            await controller.enableDisableExtension(true, 'Fake');
+        }).rejects.toThrow("Extension Fake does not exist (should be added with 'addExtension') or is built-in that cannot be enabled at runtime");
 
         await expect(async () => {
             await controller.enableDisableExtension(false, 'Availability');

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1107,4 +1107,16 @@ describe('Controller', () => {
         expect(callback).toHaveBeenCalledTimes(1);
         expect(mockLogger.error).toHaveBeenCalledWith(`EventBus error 'Test/stateChange': Whoops!`);
     });
+
+    it('prevents interacting with invalid extensions', async () => {
+        await controller.start();
+
+        await expect(async () => {
+            await controller.enableDisableExtension(true, 'DoesNotExist');
+        }).rejects.toThrow("Extension DoesNotExist does not exist or is not built-in (should be added with 'addExtension')");
+
+        await expect(async () => {
+            await controller.enableDisableExtension(false, 'Availability');
+        }).rejects.toThrow('Built-in extension Availability cannot be disabled at runtime');
+    });
 });

--- a/test/extensions/availability.test.ts
+++ b/test/extensions/availability.test.ts
@@ -32,8 +32,8 @@ describe('Extension: Availability', () => {
     let controller: Controller;
 
     const resetExtension = async (): Promise<void> => {
-        await controller.enableDisableExtension(false, 'Availability');
-        await controller.enableDisableExtension(true, 'Availability');
+        await controller.removeExtension(controller.getExtension('Availability')!);
+        await controller.addExtension(new Availability(...controller.extensionArgs));
     };
 
     const setTimeAndAdvanceTimers = async (value: number): Promise<void> => {
@@ -362,8 +362,7 @@ describe('Extension: Availability', () => {
     });
 
     it('Should clear the ping queue on stop', async () => {
-        // @ts-expect-error private
-        const availability = controller.extensions.find((extension) => extension instanceof Availability)!;
+        const availability = controller.getExtension('Availability')! as Availability;
         // @ts-expect-error private
         const publishAvailabilitySpy = vi.spyOn(availability, 'publishAvailability');
 
@@ -384,8 +383,7 @@ describe('Extension: Availability', () => {
     });
 
     it('Should prevent instance restart', async () => {
-        // @ts-expect-error private
-        const availability = controller.extensions.find((extension) => extension instanceof Availability)!;
+        const availability = controller.getExtension('Availability')! as Availability;
 
         await availability.stop();
 

--- a/test/extensions/bind.test.ts
+++ b/test/extensions/bind.test.ts
@@ -8,6 +8,7 @@ import {Device, devices, groups, events as mockZHEvents} from '../mocks/zigbeeHe
 import stringify from 'json-stable-stringify-without-jsonify';
 
 import {Controller} from '../../lib/controller';
+import Bind from '../../lib/extension/bind';
 import * as settings from '../../lib/util/settings';
 
 const mocksClear = [
@@ -22,8 +23,8 @@ describe('Extension: Bind', () => {
     let controller: Controller;
 
     const resetExtension = async (): Promise<void> => {
-        await controller.enableDisableExtension(false, 'Bind');
-        await controller.enableDisableExtension(true, 'Bind');
+        await controller.removeExtension(controller.getExtension('Bind')!);
+        await controller.addExtension(new Bind(...controller.extensionArgs));
     };
 
     const mockClear = (device: Device): void => {

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -3758,10 +3758,7 @@ describe('Extension: Bridge', () => {
     it('Change options and apply - homeassistant', async () => {
         expect(controller.getExtension('HomeAssistant')).toBeUndefined();
         await mockMQTTEvents.message('zigbee2mqtt/bridge/request/options', stringify({options: {homeassistant: {enabled: true}}}));
-        // TODO: there appears to be a race condition somewhere in here, calls in `bridgeOptions` are not properly ordered when logged
-        await vi.advanceTimersByTimeAsync(10000);
-        await flushPromises();
-        expect(controller.getExtension('HomeAssistant')).toBeDefined();
+        await expect(vi.waitUntil(() => controller.getExtension('HomeAssistant'))).resolves.toBeDefined();
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith('zigbee2mqtt/bridge/info', expect.any(String), {retain: true, qos: 0});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             'zigbee2mqtt/bridge/response/options',
@@ -3770,8 +3767,7 @@ describe('Extension: Bridge', () => {
         );
         // revert
         await mockMQTTEvents.message('zigbee2mqtt/bridge/request/options', stringify({options: {homeassistant: {enabled: false}}}));
-        await flushPromises();
-        expect(controller.getExtension('HomeAssistant')).toBeUndefined();
+        await vi.waitUntil(() => controller.getExtension('HomeAssistant') === undefined);
     });
 
     it('Change options and apply - log_level', async () => {

--- a/test/extensions/configure.test.ts
+++ b/test/extensions/configure.test.ts
@@ -7,6 +7,7 @@ import {Device, devices, Endpoint, events as mockZHEvents} from '../mocks/zigbee
 import stringify from 'json-stable-stringify-without-jsonify';
 
 import {Controller} from '../../lib/controller';
+import Configure from '../../lib/extension/configure';
 import * as settings from '../../lib/util/settings';
 
 const mocksClear = [mockMQTTPublishAsync, mockLogger.warning, mockLogger.debug];
@@ -16,8 +17,8 @@ describe('Extension: Configure', () => {
     let coordinatorEndpoint: Endpoint;
 
     const resetExtension = async (): Promise<void> => {
-        await controller.enableDisableExtension(false, 'Configure');
-        await controller.enableDisableExtension(true, 'Configure');
+        await controller.removeExtension(controller.getExtension('Configure')!);
+        await controller.addExtension(new Configure(...controller.extensionArgs));
     };
 
     const mockClear = (device: Device): void => {
@@ -227,7 +228,7 @@ describe('Extension: Configure', () => {
 
     it('Should configure max 3 times when fails', async () => {
         // @ts-expect-error private
-        controller.extensions.find((e) => e.constructor.name === 'Configure').attempts = {};
+        (controller.getExtension('Configure')! as Configure).attempts = {};
         const device = devices.remote;
         delete device.meta.configured;
         const endpoint = device.getEndpoint(1)!;

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -14,6 +14,7 @@ import stringify from 'json-stable-stringify-without-jsonify';
 import * as zhc from 'zigbee-herdsman-converters';
 
 import {Controller} from '../../lib/controller';
+import ExternalConverters from '../../lib/extension/externalConverters';
 import * as settings from '../../lib/util/settings';
 
 const BASE_DIR = 'external_converters';
@@ -61,8 +62,8 @@ describe('Extension: ExternalConverters', () => {
     };
 
     const resetExtension = async (): Promise<void> => {
-        await controller.enableDisableExtension(false, 'ExternalConverters');
-        await controller.enableDisableExtension(true, 'ExternalConverters');
+        await controller.removeExtension(controller.getExtension('ExternalConverters')!);
+        await controller.addExtension(new ExternalConverters(...controller.extensionArgs));
     };
 
     beforeAll(async () => {

--- a/test/extensions/externalExtensions.test.ts
+++ b/test/extensions/externalExtensions.test.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import stringify from 'json-stable-stringify-without-jsonify';
 
 import {Controller} from '../../lib/controller';
+import ExternalExtensions from '../../lib/extension/externalExtensions';
 import * as settings from '../../lib/util/settings';
 
 const BASE_DIR = 'external_extensions';
@@ -47,8 +48,8 @@ describe('Extension: ExternalExtensions', () => {
     };
 
     const resetExtension = async (): Promise<void> => {
-        await controller.enableDisableExtension(false, 'ExternalExtensions');
-        await controller.enableDisableExtension(true, 'ExternalExtensions');
+        await controller.removeExtension(controller.getExtension('ExternalExtensions')!);
+        await controller.addExtension(new ExternalExtensions(...controller.extensionArgs));
     };
 
     beforeAll(async () => {

--- a/test/extensions/frontend.test.ts
+++ b/test/extensions/frontend.test.ts
@@ -434,4 +434,32 @@ describe('Extension: Frontend', () => {
         expect(mockNodeStatic[frontendPath]).not.toHaveBeenCalled();
         expect(mockFinalHandler).toHaveBeenCalled();
     });
+
+    it('prevents mismatching setting/extension state', async () => {
+        settings.set(['frontend', 'enabled'], false);
+
+        controller = new Controller(vi.fn(), vi.fn());
+        await controller.start();
+
+        await expect(async () => {
+            await controller.enableDisableExtension(true, 'Frontend');
+        }).rejects.toThrow('Tried to enable Frontend extension disabled in settings');
+
+        settings.set(['frontend', 'enabled'], true);
+
+        await expect(async () => {
+            await controller.enableDisableExtension(false, 'Frontend');
+        }).rejects.toThrow('Tried to disable Frontend extension enabled in settings');
+
+        await controller.enableDisableExtension(true, 'Frontend');
+
+        await expect(async () => {
+            await controller.enableDisableExtension(true, 'Frontend');
+        }).rejects.toThrow('Extension with name Frontend already present');
+
+        settings.set(['frontend', 'enabled'], false);
+        await controller.enableDisableExtension(false, 'Frontend');
+
+        await vi.waitFor(() => controller.getExtension('Frontend') === undefined);
+    });
 });

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -2692,4 +2692,28 @@ describe('Extension: HomeAssistant', () => {
         expect(mockMQTTPublishAsync.mock.calls[2][0]).toStrictEqual('homeassistant/device_automation/0x0017880104e45520/action_single/config');
         expect(mockMQTTPublishAsync.mock.calls[3][0]).toStrictEqual('zigbee2mqtt/button/action');
     });
+
+    it('prevents mismatching setting/extension state', async () => {
+        settings.set(['homeassistant', 'enabled'], true);
+        await resetExtension();
+
+        await expect(async () => {
+            await controller.enableDisableExtension(false, 'HomeAssistant');
+        }).rejects.toThrow('Tried to disable HomeAssistant extension enabled in settings');
+
+        await expect(async () => {
+            await controller.enableDisableExtension(true, 'HomeAssistant');
+        }).rejects.toThrow('Extension with name HomeAssistant already present');
+
+        settings.set(['homeassistant', 'enabled'], false);
+
+        await expect(async () => {
+            await controller.enableDisableExtension(true, 'HomeAssistant');
+        }).rejects.toThrow('Tried to enable HomeAssistant extension disabled in settings');
+
+        settings.set(['homeassistant', 'enabled'], false);
+        await controller.enableDisableExtension(false, 'HomeAssistant');
+
+        await vi.waitFor(() => controller.getExtension('HomeAssistant') === undefined);
+    });
 });

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -8,11 +8,11 @@ import {devices, events as mockZHEvents} from '../mocks/zigbeeHerdsman';
 import path from 'node:path';
 
 import stringify from 'json-stable-stringify-without-jsonify';
-import OTAUpdate from 'lib/extension/otaUpdate';
 
 import * as zhc from 'zigbee-herdsman-converters';
 
 import {Controller} from '../../lib/controller';
+import OTAUpdate from '../../lib/extension/otaUpdate';
 import * as settings from '../../lib/util/settings';
 
 const mocksClear = [mockMQTTPublishAsync, devices.bulb.save, mockLogger.info];
@@ -29,8 +29,8 @@ describe('Extension: OTAUpdate', () => {
     const isUpdateAvailableSpy = vi.spyOn(zhc.ota, 'isUpdateAvailable');
 
     const resetExtension = async (): Promise<void> => {
-        await controller.enableDisableExtension(false, 'OTAUpdate');
-        await controller.enableDisableExtension(true, 'OTAUpdate');
+        await controller.removeExtension(controller.getExtension('OTAUpdate')!);
+        await controller.addExtension(new OTAUpdate(...controller.extensionArgs));
     };
 
     beforeAll(async () => {
@@ -51,8 +51,7 @@ describe('Extension: OTAUpdate', () => {
 
     beforeEach(async () => {
         zhc.ota.setConfiguration(DEFAULT_CONFIG);
-        // @ts-expect-error private
-        const extension: OTAUpdate = controller.extensions.find((e) => e.constructor.name === 'OTAUpdate');
+        const extension = controller.getExtension('OTAUpdate')! as OTAUpdate;
         // @ts-expect-error private
         extension.lastChecked = {};
         // @ts-expect-error private

--- a/test/mocks/logger.ts
+++ b/test/mocks/logger.ts
@@ -1,5 +1,6 @@
-import type {LogLevel} from 'lib/util/settings';
 import type Transport from 'winston-transport';
+
+import type {LogLevel} from '../../lib/util/settings';
 
 let level: LogLevel = 'info';
 let debugNamespaceIgnore: string = '';

--- a/test/mocks/mqtt.ts
+++ b/test/mocks/mqtt.ts
@@ -20,9 +20,9 @@ export const mockMQTTConnectAsync = vi.fn(() => ({
     endAsync: mockMQTTEndAsync,
     subscribeAsync: mockMQTTSubscribeAsync,
     unsubscribeAsync: mockMQTTUnsubscribeAsync,
-    on: vi.fn((type, handler) => {
+    on: vi.fn(async (type, handler) => {
         if (type === 'connect') {
-            handler();
+            await handler();
         }
 
         events[type] = handler;


### PR DESCRIPTION
- don't import frontend/homeassistant at all if disabled
  - dynamically imported as needed
- use Set instead of array for cached loaded extensions
- add guards against improper extension calls (mostly for unknown behavior of external extensions, to prevent corrupted Z2M states)
- cleanup typing
- fix some imports
- add tests to cover new logic