### PR TITLE
Make update check less verbose

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,8 @@
 cd "$(dirname "$0")"
 
 if [ "$1" != "force" ]; then
-    git fetch
+    echo "Checking for updates..."
+    git fetch -q
     NEW_COMMITS="$(git rev-list HEAD...origin/"$(git branch --show-current)" --count)"
     if [ "$NEW_COMMITS" -gt "0" ]; then
         echo "Update available!"

--- a/update.sh
+++ b/update.sh
@@ -4,8 +4,8 @@ cd "$(dirname "$0")"
 if [ "$1" != "force" ]; then
     echo "Checking for updates..."
     git fetch -q
-    NEW_COMMITS="$(git rev-list HEAD...origin/"$(git branch --show-current)" --count)"
-    if [ "$NEW_COMMITS" -gt "0" ]; then
+    NEW_COMMITS="$(git rev-list HEAD...@{upstream} --count)"
+    if [ "$NEW_COMMITS" -gt 0 ]; then
         echo "Update available!"
     else
         echo "No update available. Use '$0 force' to skip the check."


### PR DESCRIPTION
… to avoid confusing users with redundant information (because most lines produced are later printed during `git pull` again).