### PR TITLE
feat(frontend): Frontend notification blocklist

### DIFF
--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -162,6 +162,7 @@ declare global {
             url?: string;
             ssl_cert?: string;
             ssl_key?: string;
+            notification_filter?: string[];
         };
         devices: {[s: string]: DeviceOptions};
         groups: {[s: string]: Omit<GroupOptions, 'ID'>};

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -410,6 +410,14 @@
                     "description": "Base URL for the frontend. If hosted under a subpath, e.g. 'http://localhost:8080/z2m', set this to '/z2m'",
                     "default": "/",
                     "requiresRestart": true
+                },
+                "notification_filter": {
+                    "title": "Notification Filter",
+                    "description": "Hide frontend notifications matching specified regex strings. Example: 'z2m: Failed to ping.*'",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "required": []


### PR DESCRIPTION
This PR updates the settings schema to add a `notification_filter` node to frontend config that accepts an array of regex strings and hides matching toast notifications.

In large Zigbee networks with devices that are not always online, but not offline long enough to warrant using the `disabled` device setting and lose availability, it is very useful to be able to silence 'Failed to ping' toast notifications in the frontend UI. These are even more intrusive when using the frontend from a small screen device.

Instead of limiting the feature to only failed pings, this PR broadens the scope to allow the user to specify which messages don't result in a toast notification.

Frontend: https://github.com/nurikk/zigbee2mqtt-frontend/pull/2439
Documentation: https://github.com/Koenkk/zigbee2mqtt.io/pull/3617