### PR TITLE
feat: Availability improvements

### DIFF
--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -134,9 +134,7 @@ export default class Publish extends Extension {
         const entityState = this.state.get(re);
         const membersState =
             re instanceof Group
-                ? Object.fromEntries(
-                      re.zh.members.map((e) => [e.getDevice().ieeeAddr, this.state.get(this.zigbee.resolveEntity(e.getDevice().ieeeAddr)!)]),
-                  )
+                ? Object.fromEntries(re.zh.members.map((e) => [e.deviceIeeeAddress, this.state.get(this.zigbee.resolveEntity(e.deviceIeeeAddress)!)]))
                 : undefined;
         const converters = this.getDefinitionConverters(definition);
 

--- a/lib/model/group.ts
+++ b/lib/model/group.ts
@@ -26,8 +26,10 @@ export default class Group {
         return !!device.zh.endpoints.find((e) => this.zh.members.includes(e));
     }
 
-    membersDevices(): Device[] {
-        return this.zh.members.map((d) => this.resolveDevice(d.getDevice().ieeeAddr)!);
+    *membersDevices(): Generator<Device> {
+        for (const member of this.zh.members) {
+            yield this.resolveDevice(member.deviceIeeeAddress)!;
+        }
     }
 
     membersDefinitions(): zhc.Definition[] {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -48,7 +48,7 @@ declare global {
 
     namespace eventdata {
         type EntityRenamed = {entity: Device | Group; homeAssisantRename: boolean; from: string; to: string};
-        type EntityRemoved = {id: number | string; name: string; type: 'device' | 'group'};
+        type EntityRemoved = {id: string; name: string; type: 'device'} | {id: number; name: string; type: 'group'};
         type MQTTMessage = {topic: string; message: string};
         type MQTTMessagePublished = {topic: string; payload: string; options: {retain: boolean; qos: number}};
         type StateChange = {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -98,7 +98,12 @@ declare global {
         };
         availability: {
             enabled: boolean;
-            active: {timeout: number; max_jitter: number};
+            active: {
+                timeout: number;
+                max_jitter: number;
+                backoff: boolean;
+                pause_on_backoff_gt: number;
+            };
             passive: {timeout: number};
         };
         mqtt: {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -98,7 +98,7 @@ declare global {
         };
         availability: {
             enabled: boolean;
-            active: {timeout: number};
+            active: {timeout: number; max_jitter: number};
             passive: {timeout: number};
         };
         mqtt: {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -205,7 +205,14 @@ declare global {
     interface DeviceOptions {
         disabled?: boolean;
         retention?: number;
-        availability?: boolean | {timeout: number};
+        availability?:
+            | boolean
+            | {
+                  timeout: number;
+                  max_jitter?: number;
+                  backoff?: boolean;
+                  pause_on_backoff_gt?: number;
+              };
         optimistic?: boolean;
         debounce?: number;
         debounce_ignore?: string[];

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -90,7 +90,7 @@
                             "description": "Pause availability pings when backoff reaches over this limit (until device updates its 'last seen'). A value of zero disables pausing."
                         }
                     },
-                    "required": ["timeout", "max_jitter", "pause_on_backoff_gt"]
+                    "required": ["timeout"]
                 },
                 "passive": {
                     "type": "object",

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -87,7 +87,7 @@
                             "title": "Pause on backoff greater than",
                             "default": 0,
                             "minimum": 0,
-                            "description": "Pause availability pings when backoff reaches over this limit (until device updates its 'last seen'). A value of zero disables pausing."
+                            "description": "Pause availability pings when backoff reaches over this limit until a new Zigbee message is received from the device. A value of zero disables pausing."
                         }
                     },
                     "required": ["timeout"]

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -71,13 +71,26 @@
                         },
                         "max_jitter": {
                             "type": "number",
-                            "title": "Max Jitter",
+                            "title": "Max jitter",
                             "default": 30000,
                             "minimum": 1000,
                             "description": "Maximum jitter (in msec) allowed on timeout to avoid availability pings trying to trigger around the same time"
+                        },
+                        "backoff": {
+                            "type": "boolean",
+                            "title": "Enabled",
+                            "description": "Enable timeout backoff on failed availability pings (x1.5, x3, x6, x12...)",
+                            "default": true
+                        },
+                        "pause_on_backoff_gt": {
+                            "type": "number",
+                            "title": "Pause on backoff greater than",
+                            "default": 0,
+                            "minimum": 0,
+                            "description": "Pause availability pings when backoff reaches over this limit (until device updates its 'last seen'). A value of zero disables pausing."
                         }
                     },
-                    "required": ["timeout", "max_jitter"]
+                    "required": ["timeout", "max_jitter", "pause_on_backoff_gt"]
                 },
                 "passive": {
                     "type": "object",

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -68,9 +68,16 @@
                             "requiresRestart": true,
                             "default": 10,
                             "description": "Time after which an active device will be marked as offline in minutes"
+                        },
+                        "max_jitter": {
+                            "type": "number",
+                            "title": "Max Jitter",
+                            "default": 30000,
+                            "minimum": 1000,
+                            "description": "Maximum jitter (in msec) allowed on timeout to avoid availability pings trying to trigger around the same time"
                         }
                     },
-                    "required": ["timeout"]
+                    "required": ["timeout", "max_jitter"]
                 },
                 "passive": {
                     "type": "object",

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -38,7 +38,7 @@ export const defaults: RecursivePartial<Settings> = {
     },
     availability: {
         enabled: false,
-        active: {timeout: 10},
+        active: {timeout: 10, max_jitter: 30000},
         passive: {timeout: 1500},
     },
     frontend: {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -38,7 +38,7 @@ export const defaults: RecursivePartial<Settings> = {
     },
     availability: {
         enabled: false,
-        active: {timeout: 10, max_jitter: 30000},
+        active: {timeout: 10, max_jitter: 30000, backoff: true, pause_on_backoff_gt: 0},
         passive: {timeout: 1500},
     },
     frontend: {

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -247,7 +247,13 @@ function isAvailabilityEnabledForEntity(entity: Device | Group, settings: Settin
     }
 
     if (entity.isGroup()) {
-        return !entity.membersDevices().some((d) => !isAvailabilityEnabledForEntity(d, settings));
+        for (const memberDevice of entity.membersDevices()) {
+            if (!isAvailabilityEnabledForEntity(memberDevice, settings)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     if (entity.options.availability != null) {

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -260,11 +260,7 @@ function isAvailabilityEnabledForEntity(entity: Device | Group, settings: Settin
         return !!entity.options.availability;
     }
 
-    if (!settings.availability.enabled) {
-        return false;
-    }
-
-    return true;
+    return settings.availability.enabled;
 }
 
 function isZHEndpoint(obj: unknown): obj is zh.Endpoint {

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -258,7 +258,12 @@ describe('Extension: Bridge', () => {
                     },
                     availability: {
                         enabled: false,
-                        active: {timeout: 10, max_jitter: 30000},
+                        active: {
+                            timeout: 10,
+                            max_jitter: 30000,
+                            backoff: true,
+                            pause_on_backoff_gt: 0,
+                        },
                         passive: {timeout: 1500},
                     },
                     frontend: {

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -258,7 +258,7 @@ describe('Extension: Bridge', () => {
                     },
                     availability: {
                         enabled: false,
-                        active: {timeout: 10},
+                        active: {timeout: 10, max_jitter: 30000},
                         passive: {timeout: 1500},
                     },
                     frontend: {

--- a/test/mocks/zigbeeHerdsman.ts
+++ b/test/mocks/zigbeeHerdsman.ts
@@ -1141,7 +1141,7 @@ export const devices = {
         '0x00124b00cfcf3298',
         18129,
         0xfff1,
-        [new Endpoint(8, [0, 3, 4, 5, 6, 8], []), new Endpoint(242, [], [33])],
+        [new Endpoint(8, [0, 3, 4, 5, 6, 8], [], '0x00124b00cfcf3298'), new Endpoint(242, [], [33], '0x00124b00cfcf3298')],
         true,
         'DC Source',
         'FanBee1',
@@ -1169,7 +1169,8 @@ export const mockController = {
         (): Promise<AdapterTypes.CoordinatorVersion> => Promise.resolve({type: 'z-Stack', meta: {version: 1, revision: 20190425}}),
     ),
     getNetworkParameters: vi.fn(
-        (): Promise<AdapterTypes.NetworkParameters> => Promise.resolve({panID: 0x162a, extendedPanID: '0x64c5fd698daf0c00', channel: 15}),
+        (): Promise<AdapterTypes.NetworkParameters> =>
+            Promise.resolve({panID: 0x162a, extendedPanID: '0x64c5fd698daf0c00', channel: 15, nwkUpdateID: 0}),
     ),
     getDevices: vi.fn((): Device[] => []),
     getDevicesIterator: vi.fn(function* (predicate?: (value: Device) => boolean): Generator<Device> {

--- a/test/mocks/zigbeeHerdsman.ts
+++ b/test/mocks/zigbeeHerdsman.ts
@@ -236,7 +236,7 @@ export class Device {
     interview: Mock;
     interviewing: boolean;
     meta: Record<string, unknown>;
-    ping: Mock;
+    ping: Mock<(disableRecovery?: boolean) => Promise<void>>;
     removeFromNetwork: Mock;
     removeFromDatabase: Mock;
     customClusters: Record<string, unknown>;


### PR DESCRIPTION
> [!IMPORTANT]
> A router failing to ping likely means a route in the network is lost, which can seriously affect the stability of the network if it happens on a regular basis (delays, missing state updates, other devices temporary unavailable, etc.).

## Changes

- Add jitter to timeout to spread pinging a bit
  -  Should prevent storming networks with successive pings
- Add backoff to timeout to prevent pinging devices as often when they previously failed
  - Backoff calc: *1.5 if device was previously available, *2 otherwise
    - resulting in: *1.5, *3, *6, *12... (with default timeout of 10min: 10, 15, 30, 60, 120)
  - Add ability to pause pinging after backoff reaches a certain value (resumed on next "last seen" update) - _this is disabled by default (0) to not change the default Availability behavior too much_
- Widen the definition of "active" to [all power sources not unknown/battery](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/zspec/zcl/definition/consts.ts#L2) to support devices possibly using 3-phase, DC & other more specific sources
- Cleanup various getters, use Map/Set instead of objects, and some more little fixes

## Changes in Availability behavior

- Three new settings:
  - `availability.active.max_jitter` (default: 30000)
  - `availability.active.backoff` (default: true)
  - `availability.active.pause_on_backoff_gt` (default: 0)
- Pinging is now randomly offset from `timeout` by up to `max_jitter`
- Backoff is now enabled by default, successive failed pings will increase interval between tries automatically

Should alleviate some of the issues described in https://github.com/Koenkk/zigbee2mqtt/issues/23910 (and others)

TODO: 
- [x] https://github.com/Koenkk/zigbee2mqtt.io/pull/3679
- [x] confirm default settings