### PR TITLE
fix(gnore): Onboarding fixes

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -9,9 +9,4 @@ fi
 
 echo "Using '$DATA' as data directory"
 
-if [ ! -f "$DATA/configuration.yaml" ]; then
-    echo "Creating configuration file..."
-    cp /app/configuration.example.yaml "$DATA/configuration.yaml"
-fi
-
 exec "$@"

--- a/lib/util/onboarding.ts
+++ b/lib/util/onboarding.ts
@@ -371,7 +371,7 @@ function generateHtmlError(errors: string): string {
 }
 
 function getServerUrl(): URL {
-    return new URL(process.env.Z2M_ONBOARD_URL ?? 'http://localhost:8080');
+    return new URL(process.env.Z2M_ONBOARD_URL ?? 'http://0.0.0.0:8080');
 }
 
 async function startOnboardingServer(): Promise<boolean> {

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -288,7 +288,7 @@ describe('Onboarding', () => {
             expect(resEnd).toHaveBeenCalledTimes(2);
         }
 
-        const serverUrl = new URL(process.env.Z2M_ONBOARD_URL ?? 'http://localhost:8080');
+        const serverUrl = new URL(process.env.Z2M_ONBOARD_URL ?? 'http://0.0.0.0:8080');
         expect(mockHttpListen).toHaveBeenCalledWith(parseInt(serverUrl.port), serverUrl.hostname, expect.any(Function));
 
         return [resEnd.mock.calls[0][0], resEnd.mock.calls[1][0]];
@@ -346,7 +346,7 @@ describe('Onboarding', () => {
 
         expect(resEnd).toHaveBeenCalledTimes(2);
 
-        const serverUrl = new URL(process.env.Z2M_ONBOARD_URL ?? 'http://localhost:8080');
+        const serverUrl = new URL(process.env.Z2M_ONBOARD_URL ?? 'http://0.0.0.0:8080');
         expect(mockHttpListen).toHaveBeenCalledWith(parseInt(serverUrl.port), serverUrl.hostname, expect.any(Function));
 
         return resEnd.mock.calls[0][0];


### PR DESCRIPTION
- Fix leftover auto-creation of yaml in Docker
- Listen on `0.0.0.0` by default