### PR TITLE
Add device name to no converter available error message

### DIFF
--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -212,7 +212,7 @@ export default class Publish extends Extension {
             }
 
             if (!converter) {
-                logger.error(`No converter available for '${key}' (${stringify(message[key])})`);
+                logger.error(`No converter available for '${key}' on '${re.name}': (${stringify(message[key])})`);
                 continue;
             }
 

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -628,7 +628,7 @@ describe('Extension: Publish', () => {
         mockLogger.error.mockClear();
         await mockMQTTEvents.message('zigbee2mqtt/0x0017880104e45542/get', stringify({state_center: '', state_right: ''}));
         await flushPromises();
-        expect(mockLogger.error).toHaveBeenCalledWith(`No converter available for 'state_center' ("")`);
+        expect(mockLogger.error).toHaveBeenCalledWith(`No converter available for 'state_center' on 'wall_switch_double': ("")`);
         expect(endpoint2.read).toHaveBeenCalledTimes(0);
         expect(endpoint3.read).toHaveBeenCalledTimes(1);
         expect(endpoint3.read).toHaveBeenCalledWith('genOnOff', ['onOff']);


### PR DESCRIPTION
This might help with tracing what is causing this error https://github.com/Koenkk/zigbee2mqtt/issues/24595

I'm reasonably sure this comes from a device sending an MQTT set message with an empty state, i.e. '{"state":""}'. This should at least help identify which device its coming from.

To manually trigger this error message send an MQTT message such as:
`zigbee2mqtt-test/Cube/set {"state":""}`