### PR TITLE
fix: OnEvent fixes

### DIFF
--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -575,12 +575,14 @@ export default class Bind extends Extension {
                 }
             }
 
-            // If message is published to a group, add members of the group
-            const group = data.groupID && data.groupID !== 0 && this.zigbee.groupByID(data.groupID);
+            if (data.groupID && data.groupID !== 0) {
+                // If message is published to a group, add members of the group
+                const group = this.zigbee.groupByID(data.groupID);
 
-            if (group) {
-                for (const member of group.zh.members) {
-                    toPoll.add(member);
+                if (group) {
+                    for (const member of group.zh.members) {
+                        toPoll.add(member);
+                    }
                 }
             }
 

--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -1,4 +1,4 @@
-import * as zhc from 'zigbee-herdsman-converters';
+import {onEvent} from 'zigbee-herdsman-converters';
 
 import utils from '../util/utils';
 import Extension from './extension';
@@ -9,25 +9,42 @@ import Extension from './extension';
 export default class OnEvent extends Extension {
     override async start(): Promise<void> {
         for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
+            // don't await, in case of repeated failures this would hold startup
             this.callOnEvent(device, 'start', {}).catch(utils.noop);
         }
 
-        this.eventBus.onDeviceMessage(this, (data) => this.callOnEvent(data.device, 'message', this.convertData(data)));
-        this.eventBus.onDeviceJoined(this, (data) => this.callOnEvent(data.device, 'deviceJoined', this.convertData(data)));
-        this.eventBus.onDeviceInterview(this, (data) => this.callOnEvent(data.device, 'deviceInterview', this.convertData(data)));
-        this.eventBus.onDeviceAnnounce(this, (data) => this.callOnEvent(data.device, 'deviceAnnounce', this.convertData(data)));
-        this.eventBus.onDeviceNetworkAddressChanged(this, (data) =>
-            this.callOnEvent(data.device, 'deviceNetworkAddressChanged', this.convertData(data)),
-        );
-        this.eventBus.onEntityOptionsChanged(this, async (data) => {
-            if (data.entity.isDevice()) {
-                await this.callOnEvent(data.entity, 'deviceOptionsChanged', data).then(() => this.eventBus.emitDevicesChanged());
+        this.eventBus.onDeviceMessage(this, async (data) => {
+            await this.callOnEvent(data.device, 'message', {
+                endpoint: data.endpoint,
+                meta: data.meta,
+                cluster: typeof data.cluster === 'string' ? data.cluster : /* v8 ignore next */ undefined, // XXX: ZH typing is wrong?
+                type: data.type,
+                data: data.data, // XXX: typing is a bit convoluted: ZHC has `KeyValueAny` here while Z2M has `KeyValue | Array<string | number>`
+            });
+        });
+        this.eventBus.onDeviceJoined(this, async (data) => {
+            await this.callOnEvent(data.device, 'deviceJoined', {});
+        });
+        this.eventBus.onDeviceLeave(this, async (data) => {
+            if (data.device) {
+                await this.callOnEvent(data.device, 'stop', {});
             }
         });
-    }
-
-    private convertData(data: KeyValue): KeyValue {
-        return {...data, device: data.device.zh};
+        this.eventBus.onDeviceInterview(this, async (data) => {
+            await this.callOnEvent(data.device, 'deviceInterview', {});
+        });
+        this.eventBus.onDeviceAnnounce(this, async (data) => {
+            await this.callOnEvent(data.device, 'deviceAnnounce', {});
+        });
+        this.eventBus.onDeviceNetworkAddressChanged(this, async (data) => {
+            await this.callOnEvent(data.device, 'deviceNetworkAddressChanged', {});
+        });
+        this.eventBus.onEntityOptionsChanged(this, async (data) => {
+            if (data.entity.isDevice()) {
+                await this.callOnEvent(data.entity, 'deviceOptionsChanged', {});
+                this.eventBus.emitDevicesChanged();
+            }
+        });
     }
 
     override async stop(): Promise<void> {
@@ -38,12 +55,15 @@ export default class OnEvent extends Extension {
         }
     }
 
-    private async callOnEvent(device: Device, type: zhc.OnEventType, data: KeyValue): Promise<void> {
-        if (device.options.disabled) return;
-        const state = this.state.get(device);
-        const deviceExposesChanged = (): void => this.eventBus.emitExposesAndDevicesChanged(data.device);
+    private async callOnEvent(device: Device, type: Parameters<typeof onEvent>[0], data: Parameters<typeof onEvent>[1]): Promise<void> {
+        if (device.options.disabled) {
+            return;
+        }
 
-        await zhc.onEvent(type, data, device.zh, {deviceExposesChanged});
+        const state = this.state.get(device);
+        const deviceExposesChanged = (): void => this.eventBus.emitExposesAndDevicesChanged(device);
+
+        await onEvent(type, data, device.zh, {deviceExposesChanged});
 
         if (device.definition?.onEvent) {
             const options: KeyValue = device.options;

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -71,7 +71,7 @@ declare global {
         type EntityOptionsChanged = {entity: Device | Group; from: KeyValue; to: KeyValue};
         type ExposesChanged = {device: Device};
         type Reconfigure = {device: Device};
-        type DeviceLeave = {ieeeAddr: string; name: string};
+        type DeviceLeave = {ieeeAddr: string; name: string; device?: Device};
         type GroupMembersChanged = {group: Group; action: 'remove' | 'add' | 'remove_all'; endpoint: zh.Endpoint; skipDisableReporting: boolean};
         type PublishEntityState = {entity: Group | Device; message: KeyValue; stateChangeReason?: StateChangeReason; payload: KeyValue};
         type DeviceMessage = {
@@ -79,7 +79,7 @@ declare global {
             device: Device;
             endpoint: zh.Endpoint;
             linkquality: number;
-            groupID: number;
+            groupID: number; // XXX: should this be `?`
             cluster: string | number;
             data: KeyValue | Array<string | number>;
             meta: {zclTransactionSequenceNumber?: number; manufacturerCode?: number; frameControl?: ZHFrameControl};

--- a/test/extensions/onEvent.test.ts
+++ b/test/extensions/onEvent.test.ts
@@ -1,101 +1,180 @@
 import * as data from '../mocks/data';
 import {mockLogger} from '../mocks/logger';
 import {mockMQTTPublishAsync} from '../mocks/mqtt';
-import {flushPromises, getZhcBaseDefinitions} from '../mocks/utils';
-import {devices, events as mockZHEvents} from '../mocks/zigbeeHerdsman';
+import {flushPromises} from '../mocks/utils';
+import {devices, events as mockZHEvents, returnDevices} from '../mocks/zigbeeHerdsman';
 
-import {MockInstance} from 'vitest';
+import type {MockInstance} from 'vitest';
+import type {OnEvent as DefinitionOnEvent} from 'zigbee-herdsman-converters/lib/types';
+
+import type Device from '../../lib/model/device';
 
 import * as zhc from 'zigbee-herdsman-converters';
 
 import {Controller} from '../../lib/controller';
+import OnEvent from '../../lib/extension/onEvent';
 import * as settings from '../../lib/util/settings';
 
-const mockOnEvent = vi.spyOn(zhc, 'onEvent');
-const mocksClear = [mockMQTTPublishAsync, mockLogger.warning, mockLogger.debug, mockOnEvent];
+const mocksClear = [mockMQTTPublishAsync, mockLogger.warning, mockLogger.debug];
+
+returnDevices.push(devices.bulb.ieeeAddr, devices.LIVOLO.ieeeAddr);
 
 describe('Extension: OnEvent', () => {
     let controller: Controller;
-    let mockLivoloOnEvent: MockInstance;
+    let onEventSpy: MockInstance<typeof zhc.onEvent>;
+    let deviceOnEventSpy: MockInstance<DefinitionOnEvent>;
+
+    const getZ2MDevice = (zhDevice: unknown): Device => {
+        // @ts-expect-error private
+        return controller.zigbee.resolveEntity(zhDevice)! as Device;
+    };
+
+    const clearOnEventSpies = (): void => {
+        onEventSpy.mockClear();
+        deviceOnEventSpy.mockClear();
+    };
 
     beforeAll(async () => {
-        const livoloDefinition = (await getZhcBaseDefinitions()).find((d) => d.zigbeeModel?.includes(devices.LIVOLO.modelID!))!;
-        mockLivoloOnEvent = vi.spyOn(livoloDefinition, 'onEvent');
-    });
-
-    beforeEach(async () => {
         vi.useFakeTimers();
         data.writeDefaultConfiguration();
         settings.reRead();
+
         controller = new Controller(vi.fn(), vi.fn());
         await controller.start();
         await flushPromises();
+
+        onEventSpy = vi.spyOn(zhc, 'onEvent');
+        deviceOnEventSpy = vi.spyOn(getZ2MDevice(devices.LIVOLO).definition!, 'onEvent');
     });
 
     beforeEach(async () => {
-        // @ts-expect-error private
-        controller.state.state = {};
-        data.writeDefaultConfiguration();
-        settings.reRead();
-        mocksClear.forEach((m) => m.mockClear());
+        for (const mock of mocksClear) {
+            mock.mockClear();
+        }
+
+        await controller.removeExtension(controller.getExtension('OnEvent')!);
+        clearOnEventSpies();
+        await controller.addExtension(new OnEvent(...controller.extensionArgs));
     });
 
     afterAll(async () => {
-        await controller?.stop();
+        await controller.stop();
         await flushPromises();
         vi.useRealTimers();
     });
 
-    it('Should call with start event', async () => {
-        expect(mockLivoloOnEvent).toHaveBeenCalledTimes(1);
-        const call = mockLivoloOnEvent.mock.calls[0];
-        expect(call[0]).toBe('start');
-        expect(call[1]).toStrictEqual({});
-        expect(call[2]).toBe(devices.LIVOLO);
-        expect(call[3]).toStrictEqual(settings.getDevice(devices.LIVOLO.ieeeAddr));
-        expect(call[4]).toStrictEqual({});
-    });
-
-    it('Should call with stop event', async () => {
-        mockLivoloOnEvent.mockClear();
-        await controller.stop();
-        await flushPromises();
-        expect(mockLivoloOnEvent).toHaveBeenCalledTimes(1);
-        const call = mockLivoloOnEvent.mock.calls[0];
-        expect(call[0]).toBe('stop');
-        expect(call[1]).toStrictEqual({});
-        expect(call[2]).toBe(devices.LIVOLO);
-    });
-
-    it('Should call with zigbee event', async () => {
-        mockLivoloOnEvent.mockClear();
-        await mockZHEvents.deviceAnnounce({device: devices.LIVOLO});
-        await flushPromises();
-        expect(mockLivoloOnEvent).toHaveBeenCalledTimes(1);
-        expect(mockLivoloOnEvent).toHaveBeenCalledWith(
-            'deviceAnnounce',
-            {device: devices.LIVOLO},
+    it('starts & stops', async () => {
+        expect(onEventSpy).toHaveBeenCalledTimes(2);
+        expect(deviceOnEventSpy).toHaveBeenCalledTimes(1);
+        expect(deviceOnEventSpy).toHaveBeenNthCalledWith(
+            1,
+            'start',
+            {},
             devices.LIVOLO,
             settings.getDevice(devices.LIVOLO.ieeeAddr),
             {},
-            {
-                deviceExposesChanged: expect.any(Function),
-            },
+            {deviceExposesChanged: expect.any(Function)},
         );
 
-        // Test deviceExposesChanged
-        mockMQTTPublishAsync.mockClear();
-        console.log(mockLivoloOnEvent.mock.calls[0][5].deviceExposesChanged());
-        expect(mockMQTTPublishAsync.mock.calls[0][0]).toStrictEqual('zigbee2mqtt/bridge/devices');
+        await controller.stop();
+
+        expect(onEventSpy).toHaveBeenCalledTimes(4);
+        expect(deviceOnEventSpy).toHaveBeenCalledTimes(2);
+        expect(deviceOnEventSpy).toHaveBeenNthCalledWith(
+            2,
+            'stop',
+            {},
+            devices.LIVOLO,
+            settings.getDevice(devices.LIVOLO.ieeeAddr),
+            {},
+            {deviceExposesChanged: expect.any(Function)},
+        );
     });
 
-    it('Should call index onEvent with zigbee event', async () => {
-        mockOnEvent.mockClear();
+    it('calls on device events', async () => {
+        clearOnEventSpies();
         await mockZHEvents.deviceAnnounce({device: devices.LIVOLO});
         await flushPromises();
-        expect(mockOnEvent).toHaveBeenCalledTimes(1);
-        expect(zhc.onEvent).toHaveBeenCalledWith('deviceAnnounce', {device: devices.LIVOLO}, devices.LIVOLO, {
-            deviceExposesChanged: expect.any(Function),
+
+        expect(deviceOnEventSpy).toHaveBeenCalledTimes(1);
+        expect(deviceOnEventSpy).toHaveBeenNthCalledWith(
+            1,
+            'deviceAnnounce',
+            {},
+            devices.LIVOLO,
+            settings.getDevice(devices.LIVOLO.ieeeAddr),
+            {},
+            {deviceExposesChanged: expect.any(Function)},
+        );
+
+        const emitExposesAndDevicesChangedSpy = vi.spyOn(
+            // @ts-expect-error protected
+            controller.getExtension('OnEvent')!.eventBus,
+            'emitExposesAndDevicesChanged',
+        );
+
+        deviceOnEventSpy.mock.calls[0][5]!.deviceExposesChanged();
+
+        expect(emitExposesAndDevicesChangedSpy).toHaveBeenCalledTimes(1);
+        expect(emitExposesAndDevicesChangedSpy).toHaveBeenCalledWith(getZ2MDevice(devices.LIVOLO));
+
+        await mockZHEvents.deviceLeave({ieeeAddr: devices.LIVOLO.ieeeAddr});
+        await flushPromises();
+
+        expect(deviceOnEventSpy).toHaveBeenCalledTimes(2);
+        expect(deviceOnEventSpy).toHaveBeenNthCalledWith(
+            2,
+            'stop',
+            {},
+            devices.LIVOLO,
+            settings.getDevice(devices.LIVOLO.ieeeAddr),
+            {},
+            {deviceExposesChanged: expect.any(Function)},
+        );
+    });
+
+    it('calls on device message', async () => {
+        clearOnEventSpies();
+
+        await mockZHEvents.message({
+            type: 'attributeReport',
+            device: devices.LIVOLO,
+            endpoint: devices.LIVOLO.endpoints[0],
+            linkquality: 213,
+            groupID: 0,
+            cluster: 'genBasic',
+            data: {zclVersion: 8},
+            meta: {zclTransactionSequenceNumber: 1, manufacturerCode: devices.LIVOLO.manufacturerID},
         });
+        await flushPromises();
+
+        expect(deviceOnEventSpy).toHaveBeenCalledTimes(1);
+        expect(deviceOnEventSpy).toHaveBeenCalledWith(
+            'message',
+            {
+                type: 'attributeReport',
+                endpoint: devices.LIVOLO.endpoints[0],
+                cluster: 'genBasic',
+                data: {zclVersion: 8},
+                meta: {zclTransactionSequenceNumber: 1, manufacturerCode: devices.LIVOLO.manufacturerID},
+            },
+            devices.LIVOLO,
+            settings.getDevice(devices.LIVOLO.ieeeAddr),
+            {},
+            {deviceExposesChanged: expect.any(Function)},
+        );
+    });
+
+    it('does not block startup on failure', async () => {
+        await controller.removeExtension(controller.getExtension('OnEvent')!);
+        clearOnEventSpies();
+        deviceOnEventSpy.mockImplementationOnce(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 10000));
+            throw new Error('Failed');
+        });
+        await controller.addExtension(new OnEvent(...controller.extensionArgs));
+
+        expect(onEventSpy).toHaveBeenCalledTimes(2);
+        expect(deviceOnEventSpy).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
- Call `onEvent` `stop` when device leaves (ensures cleared timers, no use of stale refs)
- Pass proper data to `onEvent`
- Fix `deviceExposesChanged` using `Zh.Device` instead of `Device` (used by HA discovery, `KeyValue` typing was hiding it)
  - _looks like a test for HA extension should be added to cover this_
- Use `Map` for `Device`/`Group` lookups
- Fix `resolveGroup` typing possibly `undefined`
- Rewrite `OnEvent` tests

_Rest is mostly pre-emptive strikes for biome move._