### PR TITLE
fix: Guard against ZHC throwing

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1671,7 +1671,11 @@ export class HomeAssistant extends Extension {
             }
 
             if (entity.isDevice()) {
-                entity.definition?.meta?.overrideHaDiscoveryPayload?.(payload);
+                try {
+                    entity.definition?.meta?.overrideHaDiscoveryPayload?.(payload);
+                } catch (error) {
+                    logger.error(`Failed to override HA discovery payload (${(error as Error).stack})`);
+                }
             }
 
             const topic = this.getDiscoveryTopic(config, entity);

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -5,6 +5,7 @@ import {flushPromises} from '../mocks/utils';
 import {devices, mockController as mockZHController, returnDevices} from '../mocks/zigbeeHerdsman';
 
 import type Device from '../../lib/model/device';
+import type {Device as ZhDevice} from '../mocks/zigbeeHerdsman';
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -50,7 +51,7 @@ describe('Extension: ExternalConverters', () => {
         return fs.readFileSync(path.join(__dirname, '..', 'assets', BASE_DIR, mtype, fileName), 'utf8');
     };
 
-    const getZ2MDevice = (zhDevice: unknown): Device => {
+    const getZ2MDevice = (zhDevice: string | number | ZhDevice): Device => {
         // @ts-expect-error private
         return controller.zigbee.resolveEntity(zhDevice)! as Device;
     };

--- a/test/extensions/onEvent.test.ts
+++ b/test/extensions/onEvent.test.ts
@@ -8,6 +8,7 @@ import type {MockInstance} from 'vitest';
 import type {OnEvent as DefinitionOnEvent} from 'zigbee-herdsman-converters/lib/types';
 
 import type Device from '../../lib/model/device';
+import type {Device as ZhDevice} from '../mocks/zigbeeHerdsman';
 
 import * as zhc from 'zigbee-herdsman-converters';
 
@@ -24,7 +25,7 @@ describe('Extension: OnEvent', () => {
     let onEventSpy: MockInstance<typeof zhc.onEvent>;
     let deviceOnEventSpy: MockInstance<DefinitionOnEvent>;
 
-    const getZ2MDevice = (zhDevice: unknown): Device => {
+    const getZ2MDevice = (zhDevice: string | number | ZhDevice): Device => {
         // @ts-expect-error private
         return controller.zigbee.resolveEntity(zhDevice)! as Device;
     };


### PR DESCRIPTION
In the same spirit as https://github.com/Koenkk/zigbee-herdsman-converters/pull/9169
Also align the behavior of `extension.stop` to `zigbee.stop` during `controller.stop` (exit 1).

With the aforementioned ZHC PR, I think it should cover all cases from the definition that could throw?