### PR TITLE
fix: Use Map for State

### DIFF
--- a/lib/eventBus.ts
+++ b/lib/eventBus.ts
@@ -35,7 +35,7 @@ type EventBusListener<K> = K extends keyof EventBusMap
     : never;
 
 export default class EventBus {
-    private callbacksByExtension: Map<string, {event: keyof EventBusMap; callback: EventBusListener<keyof EventBusMap>}[]> = new Map();
+    private callbacksByExtension = new Map<string, {event: keyof EventBusMap; callback: EventBusListener<keyof EventBusMap>}[]>();
     private emitter = new events.EventEmitter<EventBusMap>();
 
     constructor() {

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -20,15 +20,15 @@ const RETRIEVE_ON_RECONNECT: readonly {keys: string[]; condition?: (state: KeyVa
 
 export default class Availability extends Extension {
     /** Mapped by IEEE address */
-    private readonly timers: Map<string, NodeJS.Timeout> = new Map();
+    private readonly timers = new Map<string, NodeJS.Timeout>();
     /** Mapped by IEEE address or Group ID */
-    private readonly lastPublishedAvailabilities: Map<string | number, boolean> = new Map();
+    private readonly lastPublishedAvailabilities = new Map<string | number, boolean>();
     /** Mapped by IEEE address */
-    private readonly pingBackoffs: Map<string, number> = new Map();
+    private readonly pingBackoffs = new Map<string, number>();
     /** IEEE addresses, waiting for last seen changes to take them out of "availability sleep" */
-    private readonly backoffPausedDevices: Set<string> = new Set();
+    private readonly backoffPausedDevices = new Set<string>();
     /** Mapped by IEEE address */
-    private readonly retrieveStateDebouncers: Map<string, () => void> = new Map();
+    private readonly retrieveStateDebouncers = new Map<string, () => void>();
     private pingQueue: Device[] = [];
     private pingQueueExecuting = false;
     private stopped = false;

--- a/lib/extension/bind.ts
+++ b/lib/extension/bind.ts
@@ -567,7 +567,7 @@ export default class Bind extends Extension {
         );
 
         if (polls.length) {
-            const toPoll: Set<zh.Endpoint> = new Set();
+            const toPoll = new Set<zh.Endpoint>();
 
             // Add bound devices
             for (const endpoint of data.device.zh.endpoints) {

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -106,7 +106,7 @@ export default class Groups extends Extension {
                 // Invalidate the last optimistic group state when group state is changed directly.
                 delete this.lastOptimisticState[entity.ID];
 
-                const groupsToPublish: Set<Group> = new Set();
+                const groupsToPublish = new Set<Group>();
 
                 for (const member of entity.zh.members) {
                     const device = this.zigbee.resolveEntity(member.getDevice()) as Device;

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1472,7 +1472,7 @@ export class HomeAssistant extends Extension {
         const discovered = this.getDiscovered(entity);
         discovered.discovered = true;
         const lastDiscoveredTopics = Object.keys(discovered.messages);
-        const newDiscoveredTopics: Set<string> = new Set();
+        const newDiscoveredTopics = new Set<string>();
 
         for (const config of this.getConfigs(entity)) {
             const payload = {...config.discovery_payload};

--- a/lib/extension/networkMap.ts
+++ b/lib/extension/networkMap.ts
@@ -185,9 +185,9 @@ export default class NetworkMap extends Extension {
 
     async networkScan(includeRoutes: boolean): Promise<Zigbee2MQTTNetworkMap> {
         logger.info(`Starting network scan (includeRoutes '${includeRoutes}')`);
-        const lqis: Map<Device, zh.LQI> = new Map();
-        const routingTables: Map<Device, zh.RoutingTable> = new Map();
-        const failed: Map<Device, string[]> = new Map();
+        const lqis = new Map<Device, zh.LQI>();
+        const routingTables = new Map<Device, zh.RoutingTable>();
+        const failed = new Map<Device, string[]>();
         const requestWithRetry = async <T>(request: () => Promise<T>): Promise<T> => {
             try {
                 const result = await request();

--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -14,7 +14,7 @@ import utils from './util/utils';
 const NS = 'z2m:mqtt';
 
 export default class MQTT {
-    private publishedTopics: Set<string> = new Set();
+    private publishedTopics = new Set<string>();
     private connectionTimer?: NodeJS.Timeout;
     private client!: MqttClient;
     private eventBus: EventBus;

--- a/lib/util/settingsMigration.ts
+++ b/lib/util/settingsMigration.ts
@@ -510,7 +510,7 @@ export function migrateIfNecessary(): void {
     while (currentSettings.version !== finalVersion) {
         let migrationNotesFileName: string | undefined;
         // don't duplicate outputs
-        const migrationNotes: Set<string> = new Set();
+        const migrationNotes = new Set<string>();
         const transfers: SettingsTransfer[] = [];
         const changes: SettingsChange[] = [];
         const additions: SettingsAdd[] = [];

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -21,8 +21,8 @@ export default class Zigbee {
     // @ts-expect-error initialized in start
     private herdsman: Controller;
     private eventBus: EventBus;
-    private groupLookup: Map<number /* group ID */, Group> = new Map();
-    private deviceLookup: Map<string /* IEEE address */, Device> = new Map();
+    private groupLookup = new Map<number /* group ID */, Group>();
+    private deviceLookup = new Map<string /* IEEE address */, Device>();
 
     constructor(eventBus: EventBus) {
         this.eventBus = eventBus;

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -78,7 +78,7 @@ describe('Extension: Bridge', () => {
         // @ts-expect-error private
         extension.restartRequired = false;
         // @ts-expect-error private
-        controller.state.state = {[devices.bulb.ieeeAddr]: {brightness: 50}};
+        controller.state.state = new Map([[devices.bulb.ieeeAddr, {brightness: 50}]]);
         fs.rmSync(deviceIconsDir, {force: true, recursive: true});
     });
 
@@ -2809,7 +2809,7 @@ describe('Extension: Bridge', () => {
         mockMQTTEvents.message('zigbee2mqtt/bridge/request/device/remove', 'bulb');
         await flushPromises();
         // @ts-expect-error private
-        expect(controller.state[device.ieeeAddr]).toBeUndefined();
+        expect(controller.state.state.get(device.ieeeAddr)).toBeUndefined();
         expect(device.removeFromNetwork).toHaveBeenCalledTimes(1);
         expect(device.removeFromDatabase).not.toHaveBeenCalled();
         expect(settings.getDevice('bulb')).toBeUndefined();

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -46,7 +46,7 @@ describe('Extension: Groups', () => {
         groups.gledopto_group.command.mockClear();
         zhcGlobalStore.clear();
         // @ts-expect-error private
-        controller.state.state = {};
+        controller.state.clear();
     });
 
     it('Should publish group state change when a device in it changes state', async () => {
@@ -461,7 +461,7 @@ describe('Extension: Groups', () => {
         await flushPromises();
         mockMQTTPublishAsync.mockClear();
         // @ts-expect-error private
-        controller.state.state = {};
+        controller.state.clear();
 
         await mockMQTTEvents.message('zigbee2mqtt/bulb_color/set', stringify({state: 'OFF'}));
         await flushPromises();

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -70,7 +70,7 @@ describe('Extension: OTAUpdate', () => {
         updateSpy.mockClear();
         isUpdateAvailableSpy.mockClear();
         // @ts-expect-error private
-        controller.state.state = {};
+        controller.state.clear();
     });
 
     afterEach(() => {

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -43,7 +43,7 @@ describe('Extension: Publish', () => {
     beforeEach(async () => {
         data.writeDefaultConfiguration();
         // @ts-expect-error private
-        controller.state.state = {};
+        controller.state.clear();
         settings.reRead();
         loadTopicGetSetRegex();
         mocksClear.forEach((m) => m.mockClear());

--- a/test/extensions/receive.test.ts
+++ b/test/extensions/receive.test.ts
@@ -25,7 +25,7 @@ describe('Extension: Receive', () => {
 
     beforeEach(async () => {
         // @ts-expect-error private
-        controller.state.state = {};
+        controller.state.clear();
         data.writeDefaultConfiguration();
         settings.reRead();
         mocksClear.forEach((m) => m.mockClear());


### PR DESCRIPTION
Should provide a [decent perf change](https://github.com/Nerivec/node-ts-testing/pull/1) (1.2-1.3x). Map should be more efficient with lots of get/set ops too.
Fixed start/stop to ensure keys are proper type (device vs group).
Fixed couple of tests.

Rest is just typing changes (merge type/ctor for `Map`/`Set` to cleanup a bit).