### PR TITLE
fix(ignore): Cleanup publish options

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -333,8 +333,8 @@ export class Controller {
             message = newState;
         }
 
-        const options: MakePartialExcept<MqttPublishOptions, "publishOptions" | "meta"> = {
-            publishOptions: {
+        const options: MakePartialExcept<MqttPublishOptions, "clientOptions" | "meta"> = {
+            clientOptions: {
                 retain: utils.getObjectProperty(entity.options, "retain", false),
                 qos: utils.getObjectProperty(entity.options, "qos", 0),
             },
@@ -345,7 +345,7 @@ export class Controller {
         const retention = utils.getObjectProperty<number | false>(entity.options, "retention", false);
 
         if (retention !== false) {
-            options.publishOptions.properties = {messageExpiryInterval: retention};
+            options.clientOptions.properties = {messageExpiryInterval: retention};
         }
 
         if (entity.isDevice() && settings.get().mqtt.include_device_information) {

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -206,7 +206,7 @@ export default class Availability extends Extension {
 
         this.eventBus.onEntityRenamed(this, async (data) => {
             if (utils.isAvailabilityEnabledForEntity(data.entity, settings.get())) {
-                await this.mqtt.publish(`${data.from}/availability`, "", {publishOptions: {retain: true, qos: 1}});
+                await this.mqtt.publish(`${data.from}/availability`, "", {clientOptions: {retain: true, qos: 1}});
                 await this.publishAvailability(data.entity, false, true);
             }
         });
@@ -265,7 +265,7 @@ export default class Availability extends Extension {
         const topic = `${entity.name}/availability`;
         const payload: Zigbee2MQTTAPI["{friendlyName}/availability"] = {state: available ? "online" : "offline"};
         this.lastPublishedAvailabilities.set(entity.ID, available);
-        await this.mqtt.publish(topic, JSON.stringify(payload), {publishOptions: {retain: true, qos: 1}});
+        await this.mqtt.publish(topic, JSON.stringify(payload), {clientOptions: {retain: true, qos: 1}});
 
         if (!skipGroups && entity.isDevice()) {
             for (const group of this.zigbee.groupsIterator()) {

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -128,7 +128,7 @@ export default class Bridge extends Extension {
                 data: {friendly_name: data.device.name, ieee_address: data.device.ieeeAddr},
             };
 
-            await this.mqtt.publish("bridge/event", stringify(payload), {publishOptions: {retain: false, qos: 0}});
+            await this.mqtt.publish("bridge/event", stringify(payload));
         });
         this.eventBus.onDeviceLeave(this, async (data) => {
             await this.publishDevices();
@@ -136,7 +136,7 @@ export default class Bridge extends Extension {
 
             const payload: Zigbee2MQTTAPI["bridge/event"] = {type: "device_leave", data: {ieee_address: data.ieeeAddr, friendly_name: data.name}};
 
-            await this.mqtt.publish("bridge/event", stringify(payload), {publishOptions: {retain: false, qos: 0}});
+            await this.mqtt.publish("bridge/event", stringify(payload));
         });
         this.eventBus.onDeviceNetworkAddressChanged(this, async () => {
             await this.publishDevices();
@@ -164,7 +164,7 @@ export default class Bridge extends Extension {
                 };
             }
 
-            await this.mqtt.publish("bridge/event", stringify(payload), {publishOptions: {retain: false, qos: 0}});
+            await this.mqtt.publish("bridge/event", stringify(payload));
         });
         this.eventBus.onDeviceAnnounce(this, async (data) => {
             await this.publishDevices();
@@ -174,7 +174,7 @@ export default class Bridge extends Extension {
                 data: {friendly_name: data.device.name, ieee_address: data.device.ieeeAddr},
             };
 
-            await this.mqtt.publish("bridge/event", stringify(payload), {publishOptions: {retain: false, qos: 0}});
+            await this.mqtt.publish("bridge/event", stringify(payload));
         });
 
         await this.publishInfo();
@@ -711,7 +711,7 @@ export default class Bridge extends Extension {
             config_schema: settings.schemaJson,
         };
 
-        await this.mqtt.publish("bridge/info", stringify(payload), {publishOptions: {retain: true, qos: 0}, skipLog: true});
+        await this.mqtt.publish("bridge/info", stringify(payload), {publishOptions: {retain: true}, skipLog: true});
     }
 
     async publishDevices(): Promise<void> {
@@ -773,7 +773,7 @@ export default class Bridge extends Extension {
             });
         }
 
-        await this.mqtt.publish("bridge/devices", stringify(devices), {publishOptions: {retain: true, qos: 0}, skipLog: true});
+        await this.mqtt.publish("bridge/devices", stringify(devices), {publishOptions: {retain: true}, skipLog: true});
     }
 
     async publishGroups(): Promise<void> {
@@ -795,7 +795,7 @@ export default class Bridge extends Extension {
             });
         }
 
-        await this.mqtt.publish("bridge/groups", stringify(groups), {publishOptions: {retain: true, qos: 0}, skipLog: true});
+        await this.mqtt.publish("bridge/groups", stringify(groups), {publishOptions: {retain: true}, skipLog: true});
     }
 
     async publishDefinitions(): Promise<void> {
@@ -808,7 +808,7 @@ export default class Bridge extends Extension {
             data.custom_clusters[device.ieeeAddr] = device.customClusters;
         }
 
-        await this.mqtt.publish("bridge/definitions", stringify(data), {publishOptions: {retain: true, qos: 0}, skipLog: true});
+        await this.mqtt.publish("bridge/definitions", stringify(data), {publishOptions: {retain: true}, skipLog: true});
     }
 
     getDefinitionPayload(device: Device): Zigbee2MQTTDevice["definition"] | undefined {

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -572,7 +572,7 @@ export default class Bridge extends Extension {
         settings.changeFriendlyName(from, to);
 
         // Clear retained messages
-        await this.mqtt.publish(oldFriendlyName, "", {publishOptions: {retain: true}});
+        await this.mqtt.publish(oldFriendlyName, "", {clientOptions: {retain: true}});
 
         this.eventBus.emitEntityRenamed({entity: entity, homeAssisantRename, from: oldFriendlyName, to});
 
@@ -641,7 +641,7 @@ export default class Bridge extends Extension {
             this.state.remove(entity.ID);
 
             // Clear any retained messages
-            await this.mqtt.publish(friendlyName, "", {publishOptions: {retain: true}});
+            await this.mqtt.publish(friendlyName, "", {clientOptions: {retain: true}});
 
             logger.info(`Successfully removed ${entityType} '${friendlyName}'${blockForceLog}`);
 
@@ -711,7 +711,7 @@ export default class Bridge extends Extension {
             config_schema: settings.schemaJson,
         };
 
-        await this.mqtt.publish("bridge/info", stringify(payload), {publishOptions: {retain: true}, skipLog: true});
+        await this.mqtt.publish("bridge/info", stringify(payload), {clientOptions: {retain: true}, skipLog: true});
     }
 
     async publishDevices(): Promise<void> {
@@ -773,7 +773,7 @@ export default class Bridge extends Extension {
             });
         }
 
-        await this.mqtt.publish("bridge/devices", stringify(devices), {publishOptions: {retain: true}, skipLog: true});
+        await this.mqtt.publish("bridge/devices", stringify(devices), {clientOptions: {retain: true}, skipLog: true});
     }
 
     async publishGroups(): Promise<void> {
@@ -795,7 +795,7 @@ export default class Bridge extends Extension {
             });
         }
 
-        await this.mqtt.publish("bridge/groups", stringify(groups), {publishOptions: {retain: true}, skipLog: true});
+        await this.mqtt.publish("bridge/groups", stringify(groups), {clientOptions: {retain: true}, skipLog: true});
     }
 
     async publishDefinitions(): Promise<void> {
@@ -808,7 +808,7 @@ export default class Bridge extends Extension {
             data.custom_clusters[device.ieeeAddr] = device.customClusters;
         }
 
-        await this.mqtt.publish("bridge/definitions", stringify(data), {publishOptions: {retain: true}, skipLog: true});
+        await this.mqtt.publish("bridge/definitions", stringify(data), {clientOptions: {retain: true}, skipLog: true});
     }
 
     getDefinitionPayload(device: Device): Zigbee2MQTTDevice["definition"] | undefined {

--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -226,7 +226,7 @@ export default abstract class ExternalJSExtension<M> extends Extension {
 
     private async publishExternalJS(): Promise<void> {
         await this.mqtt.publish(`bridge/${this.mqttTopic}s`, stringify(Array.from(this.getFiles(true))), {
-            publishOptions: {retain: true, qos: 0},
+            publishOptions: {retain: true},
             skipLog: true,
         });
     }

--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -226,7 +226,7 @@ export default abstract class ExternalJSExtension<M> extends Extension {
 
     private async publishExternalJS(): Promise<void> {
         await this.mqtt.publish(`bridge/${this.mqttTopic}s`, stringify(Array.from(this.getFiles(true))), {
-            publishOptions: {retain: true},
+            clientOptions: {retain: true},
             skipLog: true,
         });
     }

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1221,7 +1221,7 @@ export class HomeAssistant extends Extension {
         const discovered = this.getDiscovered(data.id);
 
         for (const topic of Object.keys(discovered.messages)) {
-            await this.mqtt.publish(topic, "", {publishOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
+            await this.mqtt.publish(topic, "", {clientOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
         }
 
         delete this.discovered[data.id];
@@ -1305,7 +1305,7 @@ export class HomeAssistant extends Extension {
         if (data.homeAssisantRename) {
             const discovered = this.getDiscovered(data.entity);
             for (const topic of Object.keys(discovered.messages)) {
-                await this.mqtt.publish(topic, "", {publishOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
+                await this.mqtt.publish(topic, "", {clientOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
             }
             discovered.messages = {};
 
@@ -1686,7 +1686,7 @@ export class HomeAssistant extends Extension {
                 discovered.messages[topic] = {payload: payloadStr, published: publish};
                 if (publish) {
                     await this.mqtt.publish(topic, payloadStr, {
-                        publishOptions: {retain: true, qos: 1},
+                        clientOptions: {retain: true, qos: 1},
                         baseTopic: this.discoveryTopic,
                         skipReceive: false,
                     });
@@ -1705,7 +1705,7 @@ export class HomeAssistant extends Extension {
         for (const topic of lastDiscoveredTopics) {
             const isDeviceAutomation = topic.match(this.discoveryRegexWoTopic)?.[1] === "device_automation";
             if (!newDiscoveredTopics.has(topic) && !isDeviceAutomation) {
-                await this.mqtt.publish(topic, "", {publishOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
+                await this.mqtt.publish(topic, "", {clientOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
             }
         }
     }
@@ -1755,7 +1755,7 @@ export class HomeAssistant extends Extension {
 
             if (clear) {
                 logger.debug(`Clearing outdated Home Assistant config '${data.topic}'`);
-                await this.mqtt.publish(topic, "", {publishOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
+                await this.mqtt.publish(topic, "", {clientOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
             } else if (entity) {
                 this.getDiscovered(entity).messages[topic] = {payload: stringify(message), published: true};
             }
@@ -1788,7 +1788,7 @@ export class HomeAssistant extends Extension {
 
         for (const topic of Object.keys(discovered.messages)) {
             if (topic.startsWith("scene")) {
-                await this.mqtt.publish(topic, "", {publishOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
+                await this.mqtt.publish(topic, "", {clientOptions: {retain: true, qos: 1}, baseTopic: this.discoveryTopic, skipReceive: false});
                 delete discovered.messages[topic];
             }
         }
@@ -1922,7 +1922,7 @@ export class HomeAssistant extends Extension {
         };
 
         await this.mqtt.publish(topic, stringify(payload), {
-            publishOptions: {retain: true, qos: 1},
+            clientOptions: {retain: true, qos: 1},
             baseTopic: this.discoveryTopic,
             skipReceive: false,
         });

--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -12,7 +12,6 @@ import * as settings from "./util/settings";
 import utils from "./util/utils";
 
 const NS = "z2m:mqtt";
-const DEFAULT_CLIENT_PUBLISH_OPTIONS: IClientPublishOptions = {qos: 0 as const, retain: false};
 
 export interface MqttPublishOptions {
     publishOptions: IClientPublishOptions;
@@ -142,7 +141,7 @@ export default class Mqtt {
 
         const stateData: Zigbee2MQTTAPI["bridge/state"] = {state: "offline"};
 
-        await this.publish("bridge/state", JSON.stringify(stateData), {publishOptions: {retain: true, qos: 0}});
+        await this.publish("bridge/state", JSON.stringify(stateData), {publishOptions: {retain: true}});
         this.eventBus.removeListeners(this);
         logger.info("Disconnecting from MQTT server");
         await this.client?.endAsync();
@@ -161,7 +160,7 @@ export default class Mqtt {
 
         const stateData: Zigbee2MQTTAPI["bridge/state"] = {state: "online"};
 
-        await this.publish("bridge/state", JSON.stringify(stateData), {publishOptions: {retain: true, qos: 0}});
+        await this.publish("bridge/state", JSON.stringify(stateData), {publishOptions: {retain: true}});
         await this.subscribe(`${settings.get().mqtt.base_topic}/#`);
     }
 
@@ -220,10 +219,9 @@ export default class Mqtt {
             logger.info(() => `MQTT publish: topic '${topic}', payload '${payload}'`, NS);
         }
 
-        const publishOptions: IClientPublishOptions = {...DEFAULT_CLIENT_PUBLISH_OPTIONS, ...finalOptions.publishOptions};
-
+        let publishOptions: IClientPublishOptions = finalOptions.publishOptions;
         if (settings.get().mqtt.force_disable_retain) {
-            publishOptions.retain = false;
+            publishOptions = {...finalOptions.publishOptions, retain: false};
         }
 
         try {

--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -14,7 +14,7 @@ import utils from "./util/utils";
 const NS = "z2m:mqtt";
 
 export interface MqttPublishOptions {
-    publishOptions: IClientPublishOptions;
+    clientOptions: IClientPublishOptions;
     baseTopic: string;
     skipLog: boolean;
     skipReceive: boolean;
@@ -33,7 +33,7 @@ export default class Mqtt {
     constructor(eventBus: EventBus) {
         this.eventBus = eventBus;
         this.defaultPublishOptions = {
-            publishOptions: {},
+            clientOptions: {},
             baseTopic: settings.get().mqtt.base_topic,
             skipLog: false,
             skipReceive: true,
@@ -141,7 +141,7 @@ export default class Mqtt {
 
         const stateData: Zigbee2MQTTAPI["bridge/state"] = {state: "offline"};
 
-        await this.publish("bridge/state", JSON.stringify(stateData), {publishOptions: {retain: true}});
+        await this.publish("bridge/state", JSON.stringify(stateData), {clientOptions: {retain: true}});
         this.eventBus.removeListeners(this);
         logger.info("Disconnecting from MQTT server");
         await this.client?.endAsync();
@@ -160,7 +160,7 @@ export default class Mqtt {
 
         const stateData: Zigbee2MQTTAPI["bridge/state"] = {state: "online"};
 
-        await this.publish("bridge/state", JSON.stringify(stateData), {publishOptions: {retain: true}});
+        await this.publish("bridge/state", JSON.stringify(stateData), {clientOptions: {retain: true}});
         await this.subscribe(`${settings.get().mqtt.base_topic}/#`);
     }
 
@@ -196,7 +196,7 @@ export default class Mqtt {
             this.publishedTopics.add(topic);
         }
 
-        if (finalOptions.publishOptions.retain) {
+        if (finalOptions.clientOptions.retain) {
             if (payload) {
                 this.retainedMessages[topic] = {payload, options: finalOptions, topic: topic.substring(finalOptions.baseTopic.length + 1)};
             } else {
@@ -219,13 +219,13 @@ export default class Mqtt {
             logger.info(() => `MQTT publish: topic '${topic}', payload '${payload}'`, NS);
         }
 
-        let publishOptions: IClientPublishOptions = finalOptions.publishOptions;
+        let clientOptions: IClientPublishOptions = finalOptions.clientOptions;
         if (settings.get().mqtt.force_disable_retain) {
-            publishOptions = {...finalOptions.publishOptions, retain: false};
+            clientOptions = {...finalOptions.clientOptions, retain: false};
         }
 
         try {
-            await this.client.publishAsync(topic, payload, publishOptions);
+            await this.client.publishAsync(topic, payload, clientOptions);
         } catch (error) {
             if (!finalOptions.skipLog) {
                 logger.error(`MQTT server error: ${(error as Error).message}`);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -559,7 +559,7 @@ describe("Controller", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_joined", data: {friendly_name: "bulb", ieee_address: device.ieeeAddr}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -621,7 +621,7 @@ describe("Controller", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_joined", data: {friendly_name: "bulb", ieee_address: device.ieeeAddr}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -634,7 +634,7 @@ describe("Controller", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_interview", data: {friendly_name: "bulb", status: "started", ieee_address: device.ieeeAddr}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -647,7 +647,7 @@ describe("Controller", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_interview", data: {friendly_name: "bulb", status: "failed", ieee_address: device.ieeeAddr}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -670,7 +670,7 @@ describe("Controller", () => {
         expect(parsedMessage.data.definition.description).toStrictEqual("TRADFRI bulb E26/E27, white spectrum, globe, opal, 980 lm");
         expect(parsedMessage.data.definition.exposes).toStrictEqual(expect.any(Array));
         expect(parsedMessage.data.definition.options).toStrictEqual(expect.any(Array));
-        expect(mockMQTTPublishAsync.mock.calls[1][2]).toStrictEqual({retain: false, qos: 0});
+        expect(mockMQTTPublishAsync.mock.calls[1][2]).toStrictEqual({});
     });
 
     it("On zigbee deviceInterview successful not supported", async () => {
@@ -692,7 +692,7 @@ describe("Controller", () => {
         expect(parsedMessage.data.definition.description).toStrictEqual("Automatically generated definition");
         expect(parsedMessage.data.definition.exposes).toStrictEqual(expect.any(Array));
         expect(parsedMessage.data.definition.options).toStrictEqual(expect.any(Array));
-        expect(mockMQTTPublishAsync.mock.calls[1][2]).toStrictEqual({retain: false, qos: 0});
+        expect(mockMQTTPublishAsync.mock.calls[1][2]).toStrictEqual({});
     });
 
     it("On zigbee event device announce", async () => {
@@ -705,7 +705,7 @@ describe("Controller", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_announce", data: {friendly_name: "bulb", ieee_address: device.ieeeAddr}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -721,7 +721,7 @@ describe("Controller", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_leave", data: {ieee_address: device.ieeeAddr, friendly_name: device.ieeeAddr}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -736,7 +736,7 @@ describe("Controller", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_leave", data: {ieee_address: device.ieeeAddr, friendly_name: "bulb"}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -1041,7 +1041,7 @@ describe("Controller", () => {
         await vi.advanceTimersByTimeAsync(2500); // before any startup configure triggers
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(retainedMessages);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
     });
 
     it("Should not republish retained messages on MQTT initial connect when retained message are sent", async () => {
@@ -1063,7 +1063,7 @@ describe("Controller", () => {
         await controller.mqtt.publish("fo", "bar", {retain: true});
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/fo", "bar", {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/fo", "bar", {retain: false});
     });
 
     it("Should publish last seen changes", async () => {

--- a/test/extensions/bind.test.ts
+++ b/test/extensions/bind.test.ts
@@ -108,10 +108,10 @@ describe("Extension: Bind", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
 
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
 
         // Teardown
         target.binds = originalTargetBinds;
@@ -125,7 +125,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -184,10 +184,10 @@ describe("Extension: Bind", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
 
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
 
         // Teardown
         target.binds = originalTargetBinds;
@@ -254,10 +254,10 @@ describe("Extension: Bind", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
 
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
 
         // Teardown
         target.configuredReportings = originalTargetCR;
@@ -277,7 +277,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {from: "remote", from_endpoint: "default", to: "bulb_color", clusters: ["genOnOff"], failed: []}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -292,7 +292,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {}, status: "error", error: "Nothing to bind"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -344,7 +344,7 @@ describe("Extension: Bind", () => {
                 data: {from: "remote", from_endpoint: "default", to: "bulb_color", clusters: ["genScenes", "genOnOff", "genLevelCtrl"], failed: []},
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
 
         // Teardown
@@ -370,7 +370,7 @@ describe("Extension: Bind", () => {
                 data: {from: "remote", from_endpoint: "default", to: "Coordinator", clusters: ["genScenes", "genOnOff", "genLevelCtrl"], failed: []},
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -401,7 +401,7 @@ describe("Extension: Bind", () => {
                 data: {from: "remote", from_endpoint: "default", to: "group_1", clusters: ["genScenes", "genOnOff", "genLevelCtrl"], failed: []},
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
 
         // Should configure reporting for device added to group
@@ -437,7 +437,7 @@ describe("Extension: Bind", () => {
                 data: {from: "remote", from_endpoint: "default", to: "group_1", clusters: ["genScenes", "genOnOff", "genLevelCtrl"], failed: []},
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -514,7 +514,7 @@ describe("Extension: Bind", () => {
                 data: {from: "remote", from_endpoint: "default", to: "1", clusters: ["genScenes", "genOnOff", "genLevelCtrl"], failed: []},
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -532,7 +532,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {}, status: "error", error: "Failed to bind"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -554,7 +554,7 @@ describe("Extension: Bind", () => {
                 data: {from: "remote", from_endpoint: "ep2", to: "wall_switch_double", to_endpoint: "right", clusters: ["genOnOff"], failed: []},
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -576,7 +576,7 @@ describe("Extension: Bind", () => {
                 data: {from: "remote", from_endpoint: 2, to: "wall_switch_double", to_endpoint: 3, clusters: ["genOnOff"], failed: []},
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -601,7 +601,7 @@ describe("Extension: Bind", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -617,7 +617,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {from: "remote", from_endpoint: "ep2", to: "wall_switch", clusters: ["genOnOff"], failed: []}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -644,7 +644,7 @@ describe("Extension: Bind", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -656,7 +656,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {}, status: "error", error: "Source device 'remote_not_existing' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -671,7 +671,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {}, status: "error", error: "Source device 'remote' does not have endpoint 'not_existing_endpoint'"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -683,7 +683,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {}, status: "error", error: "Target device or group 'bulb_color_not_existing' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -698,7 +698,7 @@ describe("Extension: Bind", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/bind",
             stringify({data: {}, status: "error", error: "Target device 'bulb_color' does not have endpoint 'not_existing_endpoint'"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -315,7 +315,7 @@ describe("Extension: Bridge", () => {
                 zigbee_herdsman: zhVersion,
                 zigbee_herdsman_converters: zhcVersion,
             }),
-            {retain: true, qos: 0},
+            {retain: true},
         );
     });
 
@@ -2160,7 +2160,7 @@ describe("Extension: Bridge", () => {
                     type: "Router",
                 },
             ]),
-            {retain: true, qos: 0},
+            {retain: true},
         );
     });
 
@@ -2168,7 +2168,6 @@ describe("Extension: Bridge", () => {
         await resetExtension();
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/definitions", expect.stringContaining(stringify(CUSTOM_CLUSTERS)), {
             retain: true,
-            qos: 0,
         });
     });
 
@@ -2181,7 +2180,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/logging",
             stringify({message: "this is a test", level: "info", namespace: "z2m"}),
-            {retain: false, qos: 0},
+            {},
         );
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
 
@@ -2203,7 +2202,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/logging",
             stringify({message: "this is a test", level: "info", namespace: "z2m"}),
-            {retain: false, qos: 0},
+            {},
         );
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
 
@@ -2278,7 +2277,7 @@ describe("Extension: Bridge", () => {
                     scenes: [],
                 },
             ]),
-            {retain: true, qos: 0},
+            {retain: true},
         );
     });
 
@@ -2289,7 +2288,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_joined", data: {friendly_name: "bulb", ieee_address: "0x000b57fffec6a5b2"}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2297,7 +2296,7 @@ describe("Extension: Bridge", () => {
         mockMQTTPublishAsync.mockClear();
         await mockZHEvents.deviceNetworkAddressChanged({device: devices.bulb});
         await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("Should publish event when device announces", async () => {
@@ -2308,7 +2307,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_announce", data: {friendly_name: "bulb", ieee_address: "0x000b57fffec6a5b2"}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2320,7 +2319,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_interview", data: {friendly_name: "bulb", status: "started", ieee_address: "0x000b57fffec6a5b2"}}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2332,9 +2331,9 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_interview", data: {friendly_name: "bulb", status: "failed", ieee_address: "0x000b57fffec6a5b2"}}),
-            {retain: false, qos: 0},
+            {},
         );
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("Should publish event and devices when device interview successful", async () => {
@@ -2577,7 +2576,7 @@ describe("Extension: Bridge", () => {
                 },
                 type: "device_interview",
             }),
-            {retain: false, qos: 0},
+            {},
         );
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
@@ -2662,10 +2661,10 @@ describe("Extension: Bridge", () => {
                 },
                 type: "device_interview",
             }),
-            {retain: false, qos: 0},
+            {},
         );
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/definitions", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/definitions", expect.any(String), {retain: true});
     });
 
     it("Should publish event and devices when device leaves", async () => {
@@ -2676,14 +2675,14 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({type: "device_leave", data: {ieee_address: "0x000b57fffec6a5b2", friendly_name: "bulb"}}),
-            {retain: false, qos: 0},
+            {},
         );
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             // Defintitions should be updated on device event
             "zigbee2mqtt/bridge/definitions",
             expect.any(String),
-            {retain: true, qos: 0},
+            {retain: true},
         );
     });
 
@@ -2692,10 +2691,7 @@ describe("Extension: Bridge", () => {
         await flushPromises();
         expect(mockZHController.permitJoin).toHaveBeenCalledTimes(1);
         expect(mockZHController.permitJoin).toHaveBeenCalledWith(1, undefined);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/permit_join", stringify({data: {time: 1}, status: "ok"}), {
-            retain: false,
-            qos: 0,
-        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/permit_join", stringify({data: {time: 1}, status: "ok"}), {});
     });
 
     it("Should disallow permit join on all", async () => {
@@ -2703,10 +2699,7 @@ describe("Extension: Bridge", () => {
         await flushPromises();
         expect(mockZHController.permitJoin).toHaveBeenCalledTimes(1);
         expect(mockZHController.permitJoin).toHaveBeenCalledWith(0, undefined);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/permit_join", stringify({data: {time: 0}, status: "ok"}), {
-            retain: false,
-            qos: 0,
-        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/permit_join", stringify({data: {time: 0}, status: "ok"}), {});
     });
 
     it("Should allow permit join with number string (automatically on all)", async () => {
@@ -2714,10 +2707,7 @@ describe("Extension: Bridge", () => {
         await flushPromises();
         expect(mockZHController.permitJoin).toHaveBeenCalledTimes(1);
         expect(mockZHController.permitJoin).toHaveBeenCalledWith(1, undefined);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/permit_join", stringify({data: {time: 1}, status: "ok"}), {
-            retain: false,
-            qos: 0,
-        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/permit_join", stringify({data: {time: 1}, status: "ok"}), {});
     });
 
     it("Should not allow permit join with invalid payload", async () => {
@@ -2727,7 +2717,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/permit_join",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2735,7 +2725,7 @@ describe("Extension: Bridge", () => {
         mockMQTTPublishAsync.mockClear();
         await mockZHEvents.permitJoinChanged({permitted: false, timeout: 10});
         await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
     });
 
     it("Shouldnt republish bridge info when permit join changes and hersman is stopping", async () => {
@@ -2743,7 +2733,7 @@ describe("Extension: Bridge", () => {
         mockZHController.isStopping.mockImplementationOnce(() => true);
         await mockZHEvents.permitJoinChanged({permitted: false, timeout: 10});
         await flushPromises();
-        expect(mockMQTTPublishAsync).not.toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).not.toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
     });
 
     it("Should allow permit join via device", async () => {
@@ -2756,7 +2746,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/permit_join",
             stringify({data: {time: 123, device: "bulb"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2768,7 +2758,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/permit_join",
             stringify({data: {}, status: "error", error: "Device 'bulb_not_existing_woeeee' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2779,7 +2769,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/permit_join",
             stringify({data: {time: 0}, status: "ok", transaction: 22}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2793,7 +2783,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/permit_join",
             stringify({data: {}, status: "error", error: "Failed to connect to adapter"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2804,7 +2794,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2830,7 +2820,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/health_check",
             stringify({data: {healthy: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2842,7 +2832,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/coordinator_check",
             stringify({data: {missing_routers: [{friendly_name: "bulb", ieee_address: "0x000b57fffec6a5b2"}]}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2856,12 +2846,12 @@ describe("Extension: Bridge", () => {
         expect(device.removeFromNetwork).toHaveBeenCalledTimes(1);
         expect(device.removeFromDatabase).not.toHaveBeenCalled();
         expect(settings.getDevice("bulb")).toBeUndefined();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb", "", {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb", "", {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), expect.any(Object));
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/remove",
             stringify({data: {id: "bulb", block: false, force: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
         expect(settings.get().blocklist).toStrictEqual([]);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), expect.any(Object));
@@ -2880,7 +2870,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/remove",
             stringify({data: {id: "bulb", block: false, force: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2896,7 +2886,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/remove",
             stringify({data: {id: "bulb", block: false, force: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2911,7 +2901,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/remove",
             stringify({data: {id: "bulb", block: true, force: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
         expect(settings.get().blocklist).toStrictEqual(["0x000b57fffec6a5b2"]);
     });
@@ -2927,7 +2917,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/remove",
             stringify({data: {id: "group_1", force: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2942,7 +2932,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/remove",
             stringify({data: {id: "group_1", force: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2964,7 +2954,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/remove",
             stringify({data: {}, status: "error", error: "Device 'non-existing-device' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2979,7 +2969,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/remove",
             stringify({data: {}, status: "error", error: "Failed to remove device 'bulb' (block: false, force: false) (Error: device timeout)"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -2994,13 +2984,13 @@ describe("Extension: Bridge", () => {
             retain: true,
             description: "this is my bulb",
         });
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb", "", {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb", "", {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), expect.any(Object));
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_new_name", stringify({brightness: 50}), expect.any(Object));
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/rename",
             stringify({data: {from: "bulb", to: "bulb_new_name", homeassistant_rename: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3011,7 +3001,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/rename",
             stringify({data: {}, status: "error", error: "MQTT wildcard (+ and #) not allowed in friendly_name ('living_room/blinds#')"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3025,7 +3015,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/rename",
             stringify({data: {from: "group_1", to: "group_new_name", homeassistant_rename: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3036,7 +3026,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/rename",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3047,7 +3037,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/rename",
             stringify({data: {}, status: "error", error: "Device 'bulb_not_existing' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3067,7 +3057,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/rename",
             stringify({data: {from: "bulb", to: "bulb_new_name", homeassistant_rename: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3078,7 +3068,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/rename",
             stringify({data: {}, status: "error", error: `Friendly name cannot end with a "/DIGIT" ('bulb_new_name/1')`}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3089,7 +3079,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/rename",
             stringify({data: {}, status: "error", error: "No device has joined since start"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3102,11 +3092,11 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/interview",
             stringify({data: {id: "bulb"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         // The following indicates that devices have published.
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("Should allow interviewing a device by ieeeAddr", async () => {
@@ -3124,11 +3114,11 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/interview",
             stringify({data: {id: "0x000b57fffec6a5b2"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         // The following indicates that devices have published.
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("Should throw error on invalid device interview payload", async () => {
@@ -3138,7 +3128,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/interview",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3149,7 +3139,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/interview",
             stringify({data: {}, status: "error", error: "Device 'bulb_not_existing' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3160,7 +3150,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/interview",
             stringify({data: {}, status: "error", error: "Device 'bulb/1' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3171,7 +3161,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/interview",
             stringify({data: {}, status: "error", error: "Device 'group_1' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3184,7 +3174,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/interview",
             stringify({data: {}, status: "error", error: "interview of 'bulb' (0x000b57fffec6a5b2) failed: Error: something went wrong"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3195,7 +3185,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/generate_external_definition",
             stringify({data: {}, error: "Invalid payload", status: "error"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3206,7 +3196,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/generate_external_definition",
             stringify({data: {}, error: "Device 'non_existing_device' does not exist", status: "error"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3233,7 +3223,7 @@ describe("Extension: Bridge", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3265,7 +3255,7 @@ describe("Extension: Bridge", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3297,7 +3287,7 @@ describe("Extension: Bridge", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3330,7 +3320,7 @@ describe("Extension: Bridge", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3362,7 +3352,7 @@ describe("Extension: Bridge", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3375,7 +3365,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/options",
             stringify({data: {from: {retain: false}, to: {retain: true, transition: 1}, restart_required: false, id: "group_1"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3396,7 +3386,7 @@ describe("Extension: Bridge", () => {
                 data: {from: {retain: false}, to: {retain: false, off_state: "all_members_off"}, restart_required: true, id: "group_1"},
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3407,7 +3397,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/options",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3420,7 +3410,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/add",
             stringify({data: {friendly_name: "group_193", id: 3}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3433,7 +3423,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/add",
             stringify({data: {friendly_name: "group_193", id: 92}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3444,7 +3434,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/add",
             stringify({data: {}, status: "error", error: "friendly_name must be at least 1 char long"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3455,7 +3445,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/add",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3469,7 +3459,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/touchlink/factory_reset",
             stringify({data: {}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3484,7 +3474,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/touchlink/factory_reset",
             stringify({data: {ieee_address: "0x1239", channel: 12}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3500,7 +3490,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/install_code/add",
             stringify({data: {value: "my-code"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         // By string
@@ -3512,7 +3502,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/install_code/add",
             stringify({data: {value: "my-code"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3525,7 +3515,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/install_code/add",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3539,7 +3529,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/touchlink/identify",
             stringify({data: {ieee_address: "0x1239", channel: 12}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3552,7 +3542,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/touchlink/identify",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3566,7 +3556,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/touchlink/factory_reset",
             stringify({data: {}, status: "error", error: "Failed to factory reset device through Touchlink"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3591,7 +3581,7 @@ describe("Extension: Bridge", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3636,9 +3626,9 @@ describe("Extension: Bridge", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("Should allow to configure reporting with endpoint as string", async () => {
@@ -3682,9 +3672,9 @@ describe("Extension: Bridge", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("Should throw error when configure reporting is called with malformed payload", async () => {
@@ -3709,7 +3699,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/configure_reporting",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3735,7 +3725,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/configure_reporting",
             stringify({data: {}, status: "error", error: "Device 'non_existing_device' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3761,7 +3751,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/configure_reporting",
             stringify({data: {}, status: "error", error: "Device '0x000b57fffec6a5b2' does not have endpoint 'non_existing_endpoint'"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3786,7 +3776,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/backup",
             stringify({data: {zip: "THISISBASE64"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3796,21 +3786,18 @@ describe("Extension: Bridge", () => {
         await flushPromises();
         vi.runOnlyPendingTimers();
         expect(mockRestart).toHaveBeenCalledTimes(1);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/restart", stringify({data: {}, status: "ok"}), {
-            retain: false,
-            qos: 0,
-        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/restart", stringify({data: {}, status: "ok"}), {});
     });
 
     it("Change options and apply - homeassistant", async () => {
         expect(controller.getExtension("HomeAssistant")).toBeUndefined();
         await mockMQTTEvents.message("zigbee2mqtt/bridge/request/options", stringify({options: {homeassistant: {enabled: true}}}));
         await expect(vi.waitUntil(() => controller.getExtension("HomeAssistant"))).resolves.toBeDefined();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {restart_required: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
         // revert
         await mockMQTTEvents.message("zigbee2mqtt/bridge/request/options", stringify({options: {homeassistant: {enabled: false}}}));
@@ -3823,11 +3810,11 @@ describe("Extension: Bridge", () => {
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/options", stringify({options: {advanced: {log_level: "debug"}}}));
         await flushPromises();
         expect(mockLogger.getLevel()).toStrictEqual("debug");
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {restart_required: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3837,11 +3824,11 @@ describe("Extension: Bridge", () => {
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/options", stringify({options: {advanced: {log_debug_namespace_ignore: nsIgnore}}}));
         await flushPromises();
         expect(mockLogger.getDebugNamespaceIgnore()).toStrictEqual(nsIgnore);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {restart_required: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3856,11 +3843,11 @@ describe("Extension: Bridge", () => {
         await flushPromises();
         expect(settings.get().advanced.log_namespaced_levels).toStrictEqual({"z2m:mqtt": "warning"});
         expect(mockLogger.getNamespacedLevels()).toStrictEqual({"z2m:mqtt": "warning"});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {restart_required: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/options", stringify({options: {advanced: {log_namespaced_levels: {"z2m:mqtt": null}}}}));
@@ -3878,7 +3865,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {restart_required: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3894,7 +3881,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {restart_required: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3907,7 +3894,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {restart_required: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3918,7 +3905,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {}, error: "Invalid payload", status: "error"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -3929,7 +3916,7 @@ describe("Extension: Bridge", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/options",
             stringify({data: {}, error: "advanced/log_level must be string", status: "error"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -4002,16 +3989,15 @@ describe("Extension: Bridge", () => {
 
         // console.log(mockMQTT.publish.mock.calls);
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(5);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/definitions", expect.stringContaining(stringify(CUSTOM_CLUSTERS)), {
             retain: true,
-            qos: 0,
         });
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/event",
             stringify({data: {friendly_name: "0x000b57fffec6a5c2", ieee_address: "0x000b57fffec6a5c2"}, type: "device_joined"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -4027,15 +4013,11 @@ describe("Extension: Bridge", () => {
 
         // console.log(mockMQTT.publish.mock.calls);
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(4);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/info", expect.any(String), {retain: true});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/definitions", expect.stringContaining(stringify(CUSTOM_CLUSTERS)), {
             retain: true,
-            qos: 0,
         });
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/device/configure", expect.any(String), {
-            retain: false,
-            qos: 0,
-        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/device/configure", expect.any(String), {});
     });
 });

--- a/test/extensions/configure.test.ts
+++ b/test/extensions/configure.test.ts
@@ -158,7 +158,7 @@ describe("Extension: Configure", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/configure",
             stringify({data: {id: "remote"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -168,7 +168,7 @@ describe("Extension: Configure", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/configure",
             stringify({data: {}, status: "error", error: "Device 'not_existing_device' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -179,7 +179,7 @@ describe("Extension: Configure", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/configure",
             stringify({data: {}, status: "error", error: "Failed to configure (Bind timeout after 10s)"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -189,7 +189,7 @@ describe("Extension: Configure", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/configure",
             stringify({data: {}, status: "error", error: "Device 'TS0601_thermostat' cannot be configured", transaction: 20}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -199,7 +199,7 @@ describe("Extension: Configure", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/configure",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -100,7 +100,7 @@ describe("Extension: ExternalConverters", () => {
             await controller.start();
             await flushPromises();
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/converters", stringify([]), {retain: true, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/converters", stringify([]), {retain: true});
         });
 
         it("CJS: loads converters", async () => {
@@ -121,7 +121,7 @@ describe("Extension: ExternalConverters", () => {
                     {name: "mock-external-converter-multiple.js", code: getFileCode("cjs", "mock-external-converter-multiple.js")},
                     {name: "mock-external-converter.js", code: getFileCode("cjs", "mock-external-converter.js")},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
             expect(zhcRemoveExternalDefinitionsSpy).toHaveBeenCalledTimes(2);
             expect(zhcRemoveExternalDefinitionsSpy).toHaveBeenNthCalledWith(1, "mock-external-converter-multiple.js");
@@ -191,7 +191,7 @@ describe("Extension: ExternalConverters", () => {
                     {name: "mock-external-converter-multiple.mjs", code: getFileCode("mjs", "mock-external-converter-multiple.mjs")},
                     {name: "mock-external-converter.mjs", code: getFileCode("mjs", "mock-external-converter.mjs")},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
             expect(zhcRemoveExternalDefinitionsSpy).toHaveBeenCalledTimes(2);
             expect(zhcRemoveExternalDefinitionsSpy).toHaveBeenNthCalledWith(1, "mock-external-converter-multiple.mjs");
@@ -263,7 +263,7 @@ describe("Extension: ExternalConverters", () => {
                     {name: "mock-external-converter-multiple.js", code: getFileCode("cjs", "mock-external-converter-multiple.js")},
                     {name: converterName, code: converterCode},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
 
             converterCode = converterCode.replace('posix.join("external", "converter")', 'posix.join("external", "converter", "edited")');
@@ -285,7 +285,7 @@ describe("Extension: ExternalConverters", () => {
                     {name: "mock-external-converter-multiple.js", code: getFileCode("cjs", "mock-external-converter-multiple.js")},
                     {name: "mock-external-converter.1.js", code: converterCode},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
             expect(zhcAddExternalDefinitionSpy).toHaveBeenLastCalledWith(
                 expect.objectContaining({
@@ -317,7 +317,7 @@ describe("Extension: ExternalConverters", () => {
                     {name: "mock-external-converter-multiple.js", code: getFileCode("cjs", "mock-external-converter-multiple.js")},
                     {name: "mock-external-converter.2.js", code: converterCode},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
             expect(zhcAddExternalDefinitionSpy).toHaveBeenLastCalledWith(
                 expect.objectContaining({
@@ -347,7 +347,7 @@ describe("Extension: ExternalConverters", () => {
                     {name: "mock-external-converter-multiple.mjs", code: getFileCode("mjs", "mock-external-converter-multiple.mjs")},
                     {name: "mock-external-converter.mjs", code: getFileCode("mjs", "mock-external-converter.mjs")},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
             expect(fs.existsSync(filepath)).toStrictEqual(false);
             expect(fs.existsSync(path.join(mockBasePath, "invalid.mjs.invalid"))).toStrictEqual(true);
@@ -398,7 +398,6 @@ describe("Extension: ExternalConverters", () => {
                 stringify([{name: converterName, code: converterCode}]),
                 {
                     retain: true,
-                    qos: 0,
                 },
             );
 
@@ -417,7 +416,7 @@ describe("Extension: ExternalConverters", () => {
             expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining(converterName), {force: true});
             expect(zhcRemoveExternalDefinitionsSpy).toHaveBeenCalledTimes(2);
             expect(zhcRemoveExternalDefinitionsSpy).toHaveBeenNthCalledWith(2, converterName);
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/converters", stringify([]), {retain: true, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/converters", stringify([]), {retain: true});
         });
 
         it("MJS: saves and removes", async () => {
@@ -463,7 +462,6 @@ describe("Extension: ExternalConverters", () => {
                 stringify([{name: converterName, code: converterCode}]),
                 {
                     retain: true,
-                    qos: 0,
                 },
             );
 
@@ -482,7 +480,7 @@ describe("Extension: ExternalConverters", () => {
             expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining(converterName), {force: true});
             expect(zhcRemoveExternalDefinitionsSpy).toHaveBeenCalledTimes(2);
             expect(zhcRemoveExternalDefinitionsSpy).toHaveBeenNthCalledWith(2, converterName);
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/converters", stringify([]), {retain: true, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/converters", stringify([]), {retain: true});
         });
 
         it("returns error on invalid code", async () => {
@@ -500,7 +498,7 @@ describe("Extension: ExternalConverters", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/converter/save",
                 expect.stringContaining(`"error":"${converterName} contains invalid code`),
-                {retain: false, qos: 0},
+                {},
             );
             expect(writeFileSyncSpy).toHaveBeenCalledWith(expect.stringContaining(converterName), converterCode, "utf8");
             expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining(converterName), {force: true});
@@ -520,7 +518,7 @@ describe("Extension: ExternalConverters", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/converter/remove",
                 expect.stringContaining("doesn't exists"),
-                {retain: false, qos: 0},
+                {},
             );
             expect(rmSyncSpy).not.toHaveBeenCalledWith(expect.stringContaining(converterName), {force: true});
         });
@@ -543,10 +541,7 @@ describe("Extension: ExternalConverters", () => {
                 message: {name: converterName, code: converterCode},
             });
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/converter/save", expect.stringContaining(errorMsg), {
-                retain: false,
-                qos: 0,
-            });
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/response/converter/save", expect.stringContaining(errorMsg), {});
             expect(writeFileSyncSpy).toHaveBeenCalledWith(expect.stringContaining(converterName), converterCode, "utf8");
             expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining(converterName), {force: true});
         });
@@ -579,7 +574,7 @@ describe("Extension: ExternalConverters", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/converter/remove",
                 stringify({data: {}, status: "error", error: errorMsg}),
-                {retain: false, qos: 0},
+                {},
             );
             expect(rmSyncSpy).not.toHaveBeenCalledWith(expect.stringContaining(converterName), {force: true});
         });
@@ -596,7 +591,7 @@ describe("Extension: ExternalConverters", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/converter/save",
                 stringify({data: {}, status: "error", error: "Invalid payload", transaction: 1}),
-                {retain: false, qos: 0},
+                {},
             );
 
             await (controller.getExtension("ExternalConverters")! as ExternalConverters).onMQTTMessage({
@@ -607,7 +602,7 @@ describe("Extension: ExternalConverters", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/converter/remove",
                 stringify({data: {}, status: "error", error: "Invalid payload", transaction: 2}),
-                {retain: false, qos: 0},
+                {},
             );
         });
     });

--- a/test/extensions/externalExtensions.test.ts
+++ b/test/extensions/externalExtensions.test.ts
@@ -83,7 +83,7 @@ describe("Extension: ExternalExtensions", () => {
             await controller.start();
             await flushPromises();
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/extensions", stringify([]), {retain: true, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/extensions", stringify([]), {retain: true});
         });
 
         it("CJS: loads extensions", async () => {
@@ -92,17 +92,17 @@ describe("Extension: ExternalExtensions", () => {
             await controller.start();
             await flushPromises();
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from constructor", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from start", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {retain: false, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from constructor", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from start", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {});
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/extensions",
                 stringify([
                     {name: "example2Extension.js", code: getFileCode("cjs", "example2Extension.js")},
                     {name: "exampleExtension.js", code: getFileCode("cjs", "exampleExtension.js")},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
         });
 
@@ -112,17 +112,17 @@ describe("Extension: ExternalExtensions", () => {
             await controller.start();
             await flushPromises();
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from constructor", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from start", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {retain: false, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from constructor", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from start", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {});
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/extensions",
                 stringify([
                     {name: "example2Extension.mjs", code: getFileCode("mjs", "example2Extension.mjs")},
                     {name: "exampleExtension.mjs", code: getFileCode("mjs", "exampleExtension.mjs")},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
         });
 
@@ -132,8 +132,8 @@ describe("Extension: ExternalExtensions", () => {
             await controller.start();
             await flushPromises();
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension/counter", "start 0", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).not.toHaveBeenCalledWith("zigbee2mqtt/example/extension/counter", "start 1", {retain: false, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension/counter", "start 0", {});
+            expect(mockMQTTPublishAsync).not.toHaveBeenCalledWith("zigbee2mqtt/example/extension/counter", "start 1", {});
         });
 
         it("loads all valid extensions, relocates & skips ones with errors", async () => {
@@ -152,7 +152,7 @@ describe("Extension: ExternalExtensions", () => {
                     {name: "example2Extension.mjs", code: getFileCode("mjs", "example2Extension.mjs")},
                     {name: "exampleExtension.mjs", code: getFileCode("mjs", "exampleExtension.mjs")},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
             expect(fs.existsSync(filepath)).toStrictEqual(false);
             expect(fs.existsSync(path.join(mockBasePath, "invalid.mjs.invalid"))).toStrictEqual(true);
@@ -166,17 +166,17 @@ describe("Extension: ExternalExtensions", () => {
             await controller.start();
             await flushPromises();
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from constructor", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from start", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {retain: false, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from constructor", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example2/extension", "call2 from start", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {});
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/extensions",
                 stringify([
                     {name: "example2Extension.js", code: getFileCode("cjs", "example2Extension.js")},
                     {name: extensionName, code: extensionCode},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
 
             extensionCode = extensionCode
@@ -189,15 +189,15 @@ describe("Extension: ExternalExtensions", () => {
                 message: {name: extensionName, code: extensionCode},
             });
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from stop", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start - edited", {retain: false, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from stop", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start - edited", {});
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/extensions",
                 stringify([
                     {name: "example2Extension.js", code: getFileCode("cjs", "example2Extension.js")},
                     {name: "exampleExtension.1.js", code: extensionCode},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
 
             extensionCode = extensionCode
@@ -210,15 +210,15 @@ describe("Extension: ExternalExtensions", () => {
                 message: {name: "exampleExtension.1.js", code: extensionCode},
             });
 
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from stop - edited", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {retain: false, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from stop - edited", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {});
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/extensions",
                 stringify([
                     {name: "example2Extension.js", code: getFileCode("cjs", "example2Extension.js")},
                     {name: "exampleExtension.2.js", code: extensionCode},
                 ]),
-                {retain: true, qos: 0},
+                {retain: true},
             );
         });
     });
@@ -238,14 +238,13 @@ describe("Extension: ExternalExtensions", () => {
             });
 
             expect(writeFileSyncSpy).toHaveBeenCalledWith(expect.stringContaining(extensionName), extensionCode, "utf8");
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {retain: false, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {});
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/extensions",
                 stringify([{name: extensionName, code: extensionCode}]),
                 {
                     retain: true,
-                    qos: 0,
                 },
             );
 
@@ -256,8 +255,8 @@ describe("Extension: ExternalExtensions", () => {
             });
 
             expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining(extensionName), {force: true});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from stop", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/extensions", stringify([]), {retain: true, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from stop", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/extensions", stringify([]), {retain: true});
         });
 
         it("MJS: saves and removes", async () => {
@@ -274,14 +273,13 @@ describe("Extension: ExternalExtensions", () => {
             });
 
             expect(writeFileSyncSpy).toHaveBeenCalledWith(expect.stringContaining(extensionName), extensionCode, "utf8");
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {retain: false, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from constructor", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from start", {});
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/extensions",
                 stringify([{name: extensionName, code: extensionCode}]),
                 {
                     retain: true,
-                    qos: 0,
                 },
             );
 
@@ -292,8 +290,8 @@ describe("Extension: ExternalExtensions", () => {
             });
 
             expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining(extensionName), {force: true});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from stop", {retain: false, qos: 0});
-            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/extensions", stringify([]), {retain: true, qos: 0});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/example/extension", "call from stop", {});
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/extensions", stringify([]), {retain: true});
         });
 
         it("returns error on invalid code", async () => {
@@ -311,7 +309,7 @@ describe("Extension: ExternalExtensions", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/extension/save",
                 expect.stringContaining(`"error":"${extensionName} contains invalid code`),
-                {retain: false, qos: 0},
+                {},
             );
             expect(writeFileSyncSpy).toHaveBeenCalledWith(expect.stringContaining(extensionName), extensionCode, "utf8");
             expect(rmSyncSpy).toHaveBeenCalledWith(expect.stringContaining(extensionName), {force: true});
@@ -331,7 +329,7 @@ describe("Extension: ExternalExtensions", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/extension/remove",
                 expect.stringContaining("doesn't exists"),
-                {retain: false, qos: 0},
+                {},
             );
             expect(rmSyncSpy).not.toHaveBeenCalledWith(expect.stringContaining(extensionName), {force: true});
         });
@@ -348,7 +346,7 @@ describe("Extension: ExternalExtensions", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/extension/save",
                 stringify({data: {}, status: "error", error: "Invalid payload", transaction: 1}),
-                {retain: false, qos: 0},
+                {},
             );
 
             await (controller.getExtension("ExternalExtensions")! as ExternalExtensions).onMQTTMessage({
@@ -359,7 +357,7 @@ describe("Extension: ExternalExtensions", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 "zigbee2mqtt/bridge/response/extension/remove",
                 stringify({data: {}, status: "error", error: "Invalid payload", transaction: 2}),
-                {retain: false, qos: 0},
+                {},
             );
         });
     });

--- a/test/extensions/frontend.test.ts
+++ b/test/extensions/frontend.test.ts
@@ -224,7 +224,7 @@ describe("Extension: Frontend", () => {
         await controller.stop();
     });
 
-    it("onlythis Websocket interaction", async () => {
+    it("Websocket interaction", async () => {
         controller = new Controller(vi.fn(), vi.fn());
         await controller.start();
         mockWSClient.readyState = "open";

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -487,7 +487,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {device: "bulb_color", endpoint: "default", group: "group_1"}, transaction: "123", status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -508,7 +508,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {}, status: "error", error: "Failed to add from group (timeout)"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -526,7 +526,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {device: "bulb_color", endpoint: "default", group: "group/with/slashes"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -546,7 +546,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {device: "wall_switch_double", endpoint: "right", group: "group_1"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -571,7 +571,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {device: "wall_switch_double", endpoint: "right", group: "group_1"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -588,7 +588,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/remove",
             stringify({data: {device: "bulb_color", endpoint: "default", group: "group_1"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -608,7 +608,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/remove",
             stringify({data: {device: "bulb_color", endpoint: "default", group: "group_1"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -628,7 +628,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/remove",
             stringify({data: {device: "0x0017880104e45542", endpoint: "3", group: "group_1"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -648,7 +648,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/remove",
             stringify({data: {device: "wall_switch_double", endpoint: "3", group: "group_1"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -668,7 +668,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/remove",
             stringify({data: {device: "0x0017880104e45542", endpoint: "right", group: "group_1"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -683,7 +683,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/remove_all",
             stringify({data: {device: "0x0017880104e45542", endpoint: "right"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -696,7 +696,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/remove",
             stringify({data: {}, status: "error", error: "Group 'group_1_not_existing' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -709,7 +709,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {}, status: "error", error: "Device 'bulb_color_not_existing' does not exist"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -725,7 +725,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {}, status: "error", error: "Device 'bulb_color' does not have endpoint 'not_existing_endpoint'"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -738,7 +738,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -751,7 +751,7 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/members/add",
             stringify({data: {}, status: "error", error: "Invalid payload"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1936,7 +1936,7 @@ describe("Extension: HomeAssistant", () => {
         await mockZHEvents.message(payload1);
         await flushPromises();
 
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/button/action", "single", {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/button/action", "single", expect.any(Object));
         expect(mockMQTTPublishAsync.mock.calls.filter((c) => c[1] === "single")).toHaveLength(1);
     });
 
@@ -2017,15 +2017,12 @@ describe("Extension: HomeAssistant", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/U202DST600ZB/l2",
             stringify({state: "ON", brightness: 20, effect: null, power_on_behavior: null}),
-            {qos: 0, retain: false},
+            {},
         );
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/U202DST600ZB/l1",
             stringify({state: null, effect: null, power_on_behavior: null}),
-            {
-                qos: 0,
-                retain: false,
-            },
+            {},
         );
     });
 

--- a/test/extensions/networkMap.test.ts
+++ b/test/extensions/networkMap.test.ts
@@ -473,7 +473,7 @@ describe("Extension: NetworkMap", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/networkmap",
             stringify({data: {}, status: "error", error: "Type 'not_existing' not supported, allowed are: raw,graphviz,plantuml"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -143,9 +143,9 @@ describe("Extension: OTAUpdate", () => {
                 },
                 status: "ok",
             }),
-            {retain: false, qos: 0},
+            {},
         );
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("handles when OTA update fails", async () => {
@@ -161,7 +161,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/update",
             stringify({data: {}, status: "error", error: "Update of 'bulb' failed (Update failed)"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -178,7 +178,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/update",
             stringify({data: {}, status: "error", error: "Update of 'bulb' failed (No image currently available)"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -192,7 +192,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/check",
             stringify({data: {id: "bulb", update_available: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         mockMQTTPublishAsync.mockClear();
@@ -205,7 +205,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/check",
             stringify({data: {id: "bulb", update_available: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
         isUpdateAvailableSpy.mockResolvedValueOnce({available: false, currentFileVersion: 10, otaFileVersion: 10});
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/ota_update/check/downgrade", "bulb");
@@ -216,7 +216,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/check",
             stringify({data: {id: "bulb", update_available: false}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         // @ts-expect-error private
@@ -234,7 +234,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/check",
             stringify({data: {id: "bulb", update_available: true}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         device.definition = originalDefinition;
@@ -254,7 +254,7 @@ describe("Extension: OTAUpdate", () => {
                 status: "error",
                 error: `Failed to check if update available for 'bulb' (RF signals disturbed because of dogs barking)`,
             }),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -264,7 +264,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/check",
             stringify({data: {}, status: "error", error: `Device 'not_existing_deviceooo' does not exist`}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -274,7 +274,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/check",
             stringify({data: {}, status: "error", error: `Device 'dimmer_wall_switch' does not support OTA updates`}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -318,7 +318,7 @@ describe("Extension: OTAUpdate", () => {
             expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
                 `zigbee2mqtt/bridge/response/device/ota_update/${type.replace("/downgrade", "")}`,
                 stringify({data: {}, status: "error", error: `Update or check for update already in progress for 'bulb'`}),
-                {retain: false, qos: 0},
+                {},
             );
         },
     );
@@ -332,7 +332,7 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/ota_update/update",
             stringify({data: {id: "bulb", from: undefined, to: undefined}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 
@@ -485,7 +485,7 @@ describe("Extension: OTAUpdate", () => {
             2,
             "zigbee2mqtt/bridge/response/device/ota_update/schedule",
             stringify({data: {id: "bulb"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         const data = {imageType: 12382};
@@ -519,7 +519,7 @@ describe("Extension: OTAUpdate", () => {
             stringify({update: {state: "idle", installed_version: 2, latest_version: 2}}),
             {retain: true, qos: 0},
         );
-        expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(6, "zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(6, "zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("schedules and cancels an update when no image available", async () => {
@@ -536,7 +536,7 @@ describe("Extension: OTAUpdate", () => {
             2,
             "zigbee2mqtt/bridge/response/device/ota_update/schedule",
             stringify({data: {id: "bulb"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         const data = {imageType: 12382};
@@ -575,7 +575,7 @@ describe("Extension: OTAUpdate", () => {
             2,
             "zigbee2mqtt/bridge/response/device/ota_update/schedule",
             stringify({data: {id: "bulb"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         const data = {imageType: 12382};
@@ -619,7 +619,7 @@ describe("Extension: OTAUpdate", () => {
             stringify({update: {state: "idle", installed_version: 2, latest_version: 2}}),
             {retain: true, qos: 0},
         );
-        expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(7, "zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(7, "zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
     });
 
     it("overwrites current schedule on re-schedule", async () => {
@@ -638,7 +638,7 @@ describe("Extension: OTAUpdate", () => {
                 2,
                 "zigbee2mqtt/bridge/response/device/ota_update/schedule",
                 stringify({data: {id: "bulb"}, status: "ok"}),
-                {retain: false, qos: 0},
+                {},
             );
 
             mockMQTTEvents.message(`zigbee2mqtt/bridge/request/device/ota_update/${overwriteType}`, "bulb");
@@ -652,7 +652,7 @@ describe("Extension: OTAUpdate", () => {
                 4,
                 "zigbee2mqtt/bridge/response/device/ota_update/schedule",
                 stringify({data: {id: "bulb"}, status: "ok"}),
-                {retain: false, qos: 0},
+                {},
             );
         }
     });
@@ -669,7 +669,7 @@ describe("Extension: OTAUpdate", () => {
             2,
             "zigbee2mqtt/bridge/response/device/ota_update/schedule",
             stringify({data: {id: "bulb"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
 
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/ota_update/unschedule", "bulb");
@@ -681,7 +681,7 @@ describe("Extension: OTAUpdate", () => {
             4,
             "zigbee2mqtt/bridge/response/device/ota_update/unschedule",
             stringify({data: {id: "bulb"}, status: "ok"}),
-            {retain: false, qos: 0},
+            {},
         );
     });
 

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -1601,8 +1601,8 @@ describe("Extension: Publish", () => {
         await flushPromises();
         expect(group.command).toHaveBeenCalledTimes(1);
         expect(group.command).toHaveBeenCalledWith("genScenes", "store", {groupid: 15071, sceneid: 1}, {});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/groups", expect.any(String), {retain: true, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/groups", expect.any(String), {retain: true});
 
         await mockMQTTEvents.message("zigbee2mqtt/bulb_color_2/set", stringify({state: "ON", brightness: 250, color_temp: 20}));
         await mockMQTTEvents.message("zigbee2mqtt/bulb_2/set", stringify({state: "ON", brightness: 110}));


### PR DESCRIPTION
Since `qos: 0, retain: false` is the default anyway there is no need to explicilty pass it.