### PR TITLE
improving update script for local changes and pnpm

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -36,6 +36,14 @@ else
     fi
 fi
 
+echo "Resetting local changes to package.json and pnpm-lock.yaml..."
+git checkout --quiet -- package.json pnpm-lock.yaml || true
+
+if ! command -v pnpm >/dev/null 2>&1; then
+    echo "pnpm not found, preparing with Corepack..."
+    corepack prepare pnpm@latest --activate
+fi
+
 echo "Updating..."
 git pull --no-rebase
 


### PR DESCRIPTION
Today I had problems with the update script again, due to alleged local changes and pnpm. So I tweaked the script a bit and hopefully made it a bit more failsafe and robust.

1.) The script now explicitly resets `package.json` and `pnpm-lock.yaml` before pulling updates. These files are often auto-modified by pnpm even without intentional user changes, which can cause `git pull` to fail. 

2.) Added a check to see if the pnpm command is available on the system. If not, it uses corepack to automatically prepare and activate the latest version. Useful on fresh or repaired systems where pnpm might not be globally installed, but is expected by z2m.