### PR TITLE
fix: rerun onboarding if Z2M start failed after previous onboarding

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -163,6 +163,8 @@ export class Controller {
         logger.info("Zigbee2MQTT started!");
 
         this.sdNotify = await initSdNotify();
+
+        settings.setOnboarding(false);
     }
 
     @bind async enableDisableExtension(enable: boolean, name: string): Promise<void> {

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -69,6 +69,8 @@ export interface Zigbee2MQTTGroupOptions {
 
 export interface Zigbee2MQTTSettings {
     version?: number;
+    /** only used internally during startup, removed on successful Z2M start */
+    onboarding?: true;
     homeassistant: {
         enabled: boolean;
         discovery_topic: string;

--- a/lib/util/onboarding.ts
+++ b/lib/util/onboarding.ts
@@ -396,8 +396,6 @@ async function startOnboardingServer(): Promise<boolean> {
 
                     req.on("end", () => {
                         const result = parse(body) as unknown as OnboardSettings;
-                        console.log(JSON.stringify(currentSettings));
-                        console.log(JSON.stringify(result));
                         const frontendEnabled = result.frontend_enabled === "on";
                         const updatedSettings: RecursivePartial<Settings> = {
                             mqtt: {
@@ -540,7 +538,9 @@ export async function onboard(): Promise<boolean> {
 
     // use `configuration.yaml` file to detect "brand new install"
     // env allows to re-run onboard even with existing install
-    if (!process.env.Z2M_ONBOARD_NO_SERVER && (process.env.Z2M_ONBOARD_FORCE_RUN || !confExists)) {
+    if (!process.env.Z2M_ONBOARD_NO_SERVER && (process.env.Z2M_ONBOARD_FORCE_RUN || !confExists || settings.get().onboarding)) {
+        settings.setOnboarding(true);
+
         const success = await startOnboardingServer();
 
         if (!success) {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -179,6 +179,22 @@ export function writeMinimalDefaults(): void {
     loadSettingsWithDefaults();
 }
 
+export function setOnboarding(value: boolean): void {
+    const settings = getPersistedSettings();
+
+    if (value) {
+        if (!settings.onboarding) {
+            settings.onboarding = value;
+
+            write();
+        }
+    } else if (settings.onboarding) {
+        delete settings.onboarding;
+
+        write();
+    }
+}
+
 export function write(): void {
     const settings = getPersistedSettings();
     const toWrite: KeyValue = objectAssignDeep({}, settings);


### PR DESCRIPTION
Should take care of issues like https://github.com/getumbrel/umbrel-apps/pull/2472
