### PR TITLE
Fixed brokenzStackEraseAllNvMem script

### DIFF
--- a/scripts/zStackEraseAllNvMem.js
+++ b/scripts/zStackEraseAllNvMem.js
@@ -39,13 +39,13 @@ class ZStackNvMemEraser {
     async clearAllNvMemItems() {
         let maxNvMemId;
         switch (this.version.product) {
-            case ZnpVersion.zStack12:
+            case ZnpVersion.ZStack12:
                 maxNvMemId = 0x0302;
                 break;
-            case ZnpVersion.zStack30x:
+            case ZnpVersion.ZStack30x:
                 maxNvMemId = 0x033f;
                 break;
-            case ZnpVersion.zStack3x0:
+            case ZnpVersion.ZStack3x0:
                 maxNvMemId = 0x032f;
                 break;
         }


### PR DESCRIPTION
Since this commit https://github.com/Koenkk/zigbee2mqtt/commit/dfeaf22f703712e32dd1e27c96de7a374bc620c5 the major version 4 of the zigbee-herdsman package will be used.
In that major version the case of the enum names has been changed from lowercase to uppercase.
Previously used 3.5.2: https://github.com/Koenkk/zigbee-herdsman/blob/v3.5.2/src/adapter/z-stack/adapter/tstype.ts
Version 4.x.x: https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/z-stack/adapter/tstype.ts

If we execute the script right now we get an undefined:
```
Clearing all NVMEM items, from 0 to undefined
Clearing all NVMEM items finished, deleted 0 items
```