### PR TITLE
Fix import error on Windows (ERR_UNSUPPORTED_ESM_URL_SCHEME)

### DIFF
--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -218,6 +218,7 @@ export default abstract class ExternalJSExtension<M> extends Extension {
         fs.copyFileSync(file, tmpFile);
         try {
             // Do `replaceAll("\\", "/")` to prevent issues on Windows
+            /* v8 ignore next */
             const mod = await import(os.platform() === "win32" ? `file:///${tmpFile.replaceAll("\\", "/")}` : tmpFile);
             return mod;
         } finally {

--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -218,7 +218,7 @@ export default abstract class ExternalJSExtension<M> extends Extension {
         fs.copyFileSync(file, tmpFile);
         try {
             // Do `replaceAll("\\", "/")` to prevent issues on Windows
-            const mod = await import(tmpFile.replaceAll("\\", "/"));
+            const mod = await import(os.platform() === "win32" ? `file:///${tmpFile.replaceAll("\\", "/")}` : tmpFile);
             return mod;
         } finally {
             fs.rmSync(tmpFile);


### PR DESCRIPTION
Error:
```
[2025-05-26 20:06:46] debug:    z2m: Error: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:209:11)
    at defaultLoad (node:internal/modules/esm/load:107:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:670:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:483:43)
    at ModuleLoader.#createModuleJob (node:internal/modules/esm/loader:507:36)
    at ModuleLoader.#getJobFromResolveResult (node:internal/modules/esm/loader:275:34)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:243:41)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:546:25)
```