### PR TITLE
Check if database.db is sane before starting.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.21 AS base
 
 ENV NODE_ENV=production
 WORKDIR /app
-RUN apk add --no-cache tzdata eudev tini nodejs
+RUN apk add --no-cache tzdata eudev tini nodejs file
 
 # Dependencies and build
 FROM base AS deps

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,6 +1,20 @@
 #!/bin/sh
 set -e
 
+sanity_check_database_db() { # <path_to_database_db_file>
+  # 'file' should be availabe in the container
+  MIMETYPE=`file -b -i "${1:?}" | sed 's/;.*//; q;'`
+  case "${MIMETYPE:-}" in
+  application/*json|application/*jason)
+    true
+    ;;
+  *)
+    echo "Database contents of ${1:-} was not recognized as being JSON, rather ${MIMETYPE:-N/A}" 1>&2
+    false
+    ;;
+  esac
+}
+
 if [ ! -z "$ZIGBEE2MQTT_DATA" ]; then
     DATA="$ZIGBEE2MQTT_DATA"
 else
@@ -8,5 +22,19 @@ else
 fi
 
 echo "Using '$DATA' as data directory"
+
+DATABASE="$DATA/database.db"
+if [ -f "$DATABASE" ]; then
+    if sanity_check_database_db "$DATABASE"; then
+        echo "Database file $DATABASE looks sane"
+    else
+        echo "Database file $DATABASE did not pass the sanity check!" 1>&2
+        DATETIMESTAMP=`date +'%Y-%m-%dT%H:%M:%S%z'` # same format as -Isec
+        RENAMED="$DATABASE.$DATETIMESTAMP~"
+        mv "$DATABASE" "$RENAMED"
+        echo "Renamed database file $DATABASE to $RENAMED"
+        echo "Starting without database file"
+    fi
+fi
 
 exec "$@"


### PR DESCRIPTION
In case database.db cannot be identified as JSON content, rename the file 'out of the way' and start without a `database.db`.

I have been using this for a while now, as I suffered a lot from the `database.db` becoming corrupted due to either sudden powerloss or kernel hangups.

I'm not sure how I can spin a docker image based on this PR though...