### PR TITLE
fix: Bump Alpine to 3.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,27 +57,27 @@ jobs:
                   password: ${{ secrets.GH_TOKEN }}
 
             - name: Docker setup - QEMU
-              if: (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
+              # if: (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
               uses: docker/setup-qemu-action@v3
               with:
                   platforms: all
 
             - name: Docker setup - Buildx
-              if: (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
+              # if: (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
               id: buildx
               uses: docker/setup-buildx-action@v3
               with:
                   version: latest
 
             - name: dev - Docker build and push
-              if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+              # if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
               uses: docker/build-push-action@v6
               with:
                   context: .
                   file: docker/Dockerfile
                   platforms: linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7,linux/riscv64,linux/386
                   tags: koenkk/zigbee2mqtt:latest-dev,ghcr.io/koenkk/zigbee2mqtt:latest-dev
-                  push: true
+                  push: false
                   build-args: |
                       COMMIT=${{ github.sha }}
                       VERSION=dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
                   file: docker/Dockerfile
                   platforms: linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7,linux/riscv64,linux/386
                   tags: koenkk/zigbee2mqtt:latest-dev,ghcr.io/koenkk/zigbee2mqtt:latest-dev
-                  push: false
+                  push: true
                   build-args: |
                       COMMIT=${{ github.sha }}
                       VERSION=dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,20 +57,20 @@ jobs:
                   password: ${{ secrets.GH_TOKEN }}
 
             - name: Docker setup - QEMU
-              # if: (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
+              if: (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
               uses: docker/setup-qemu-action@v3
               with:
                   platforms: all
 
             - name: Docker setup - Buildx
-              # if: (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
+              if: (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
               id: buildx
               uses: docker/setup-buildx-action@v3
               with:
                   version: latest
 
             - name: dev - Docker build and push
-              # if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+              if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
               uses: docker/build-push-action@v6
               with:
                   context: .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml ./
 # Make and such are needed to compile serialport for riscv64
 RUN apk add make gcc g++ python3 linux-headers pnpm && \
-    pnpm self-update $(sed -n 's/.*"packageManager": "pnpm@\([0-9.]*\)".*/\1/p' package.json) && \
+    npm install -g pnpm@$(sed -n 's/.*"packageManager": "pnpm@\([0-9.]*\)".*/\1/p' package.json) && \
     pnpm install --frozen-lockfile --no-optional && \
     # serialport has outdated prebuilds that appear to fail on some archs, force build on target platform
     rm -rf `find ./node_modules/.pnpm/ -wholename "*/@serialport/bindings-cpp/prebuilds" -type d` && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ FROM base AS deps
 
 COPY package.json pnpm-lock.yaml ./
 # Make and such are needed to compile serialport for riscv64
-RUN apk add make gcc g++ python3 linux-headers pnpm && \
+RUN apk add make gcc g++ python3 linux-headers npm && \
     npm install -g pnpm@$(sed -n 's/.*"packageManager": "pnpm@\([0-9.]*\)".*/\1/p' package.json) && \
     pnpm install --frozen-lockfile --no-optional && \
     # serialport has outdated prebuilds that appear to fail on some archs, force build on target platform

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG TARGETPLATFORM
 
-FROM alpine:3.21 AS base
+FROM alpine:3.22 AS base
 
 ENV NODE_ENV=production
 WORKDIR /app
@@ -12,7 +12,7 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml ./
 # Make and such are needed to compile serialport for riscv64
 RUN apk add make gcc g++ python3 linux-headers npm && \
-    npm install -g pnpm@10.4.1 && \
+    corepack enable && \
     pnpm install --frozen-lockfile --no-optional && \
     # serialport has outdated prebuilds that appear to fail on some archs, force build on target platform
     rm -rf `find ./node_modules/.pnpm/ -wholename "*/@serialport/bindings-cpp/prebuilds" -type d` && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml ./
 # Make and such are needed to compile serialport for riscv64
 RUN apk add make gcc g++ python3 linux-headers npm && \
-    corepack enable && \
+    npm install -g pnpm@$(sed -n 's/.*"packageManager": "pnpm@\([0-9.]*\)".*/\1/p' package.json) && \
     pnpm install --frozen-lockfile --no-optional && \
     # serialport has outdated prebuilds that appear to fail on some archs, force build on target platform
     rm -rf `find ./node_modules/.pnpm/ -wholename "*/@serialport/bindings-cpp/prebuilds" -type d` && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,8 @@ FROM base AS deps
 
 COPY package.json pnpm-lock.yaml ./
 # Make and such are needed to compile serialport for riscv64
-RUN apk add make gcc g++ python3 linux-headers npm && \
-    npm install -g pnpm@$(sed -n 's/.*"packageManager": "pnpm@\([0-9.]*\)".*/\1/p' package.json) && \
+RUN apk add make gcc g++ python3 linux-headers pnpm && \
+    pnpm self-update $(sed -n 's/.*"packageManager": "pnpm@\([0-9.]*\)".*/\1/p' package.json) && \
     pnpm install --frozen-lockfile --no-optional && \
     # serialport has outdated prebuilds that appear to fail on some archs, force build on target platform
     rm -rf `find ./node_modules/.pnpm/ -wholename "*/@serialport/bindings-cpp/prebuilds" -type d` && \


### PR DESCRIPTION
Alpine node doesn't include `corepack`, so grabbing the pnpm version with a regex instead.