### PR TITLE
fix: Fix devices not immediately marked as offline when timeout expires

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -76,7 +76,7 @@ export default class Availability extends Extension {
         if (entity.isDevice()) {
             const lastSeen = entity.zh.lastSeen ?? /* v8 ignore next */ 0;
 
-            return Date.now() - lastSeen < this.getTimeout(entity) + this.getMaxJitter(entity);
+            return Date.now() - lastSeen < this.getTimeout(entity);
         }
 
         for (const memberDevice of entity.membersDevices()) {


### PR DESCRIPTION
Given the jitter randomness in the code, I'm not entirely sure (and if it makes sense to) cover this by tests.