### PR TITLE
chore: maintain built-dev branch for use in external packages

### DIFF
--- a/.github/workflows/maintain-built-dev.yml
+++ b/.github/workflows/maintain-built-dev.yml
@@ -1,0 +1,52 @@
+name: Maintain built dev branch
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [dev]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Unshallow fetch
+        run: git fetch --unshallow
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+          cache: pnpm
+
+      - name: Switch to built branch
+        run: git switch --force-create built-dev
+
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Setup git
+        run: |
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Commit dist and force push to built branch
+        run: |
+            git add --force ./dist
+            git commit -m "Rebuild" || echo 'Nothing to commit'
+            git push --force --set-upstream origin built-dev


### PR DESCRIPTION
@Koenkk current behavior is to overwrite the `built-dev` branch on every run (last commit is always "Rebuild", and the one before always matches `dev`), not sure if you'd prefer maintaining a commit history (extra logic required to merge/rebuild).