### PR TITLE
fix: log error message when external JS fails to load

### DIFF
--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -196,7 +196,7 @@ export default abstract class ExternalJSExtension<M> extends Extension {
                     `Invalid external ${this.mqttTopic} '${extension.name}' was ignored and renamed to prevent interference with Zigbee2MQTT.`,
                 );
                 // biome-ignore lint/style/noNonNullAssertion: always Error
-                logger.debug((error as Error).stack!);
+                logger.error((error as Error).stack!);
             }
         }
     }

--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -193,10 +193,10 @@ export default abstract class ExternalJSExtension<M> extends Extension {
                 fs.renameSync(filePath, `${filePath}.invalid`);
 
                 logger.error(
-                    `Invalid external ${this.mqttTopic} '${extension.name}' was ignored and renamed to prevent interference with Zigbee2MQTT.`,
+                    `Invalid external ${this.mqttTopic} '${extension.name}' was ignored and renamed to prevent interference with Zigbee2MQTT. (${(error as Error).message})`,
                 );
                 // biome-ignore lint/style/noNonNullAssertion: always Error
-                logger.error((error as Error).stack!);
+                logger.debug((error as Error).stack!);
             }
         }
     }

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -348,7 +348,7 @@ describe("Extension: ExternalConverters", () => {
             );
             expect(fs.existsSync(filepath)).toStrictEqual(false);
             expect(fs.existsSync(path.join(mockBasePath, "invalid.mjs.invalid"))).toStrictEqual(true);
-            expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining("Parse failure: Expected ';', '}' or <eof>"))
+            expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining("Parse failure: Expected ';', '}' or <eof>"));
         });
     });
 

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -348,6 +348,7 @@ describe("Extension: ExternalConverters", () => {
             );
             expect(fs.existsSync(filepath)).toStrictEqual(false);
             expect(fs.existsSync(path.join(mockBasePath, "invalid.mjs.invalid"))).toStrictEqual(true);
+            expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining("Parse failure: Expected ';', '}' or <eof>"))
         });
     });
 


### PR DESCRIPTION
Change log level of external extension error stack from debug to error.

-> Makes it easier to debug.
-> Makes it easier for end users to report the stack when filing a bug report.