### PR TITLE
fix: settings schema defaults

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -249,7 +249,7 @@
                     "title": "Baudrate",
                     "requiresRestart": true,
                     "description": "Baud rate speed for serial port, this can be anything firmware support but default is 115200 for Z-Stack and EZSP, 38400 for Deconz, however note that some EZSP firmware need 57600",
-                    "examples": [38400, 57600, 115200]
+                    "examples": [115200, 921600, 460800, 230400, 57600, 38400]
                 },
                 "rtscts": {
                     "type": "boolean",

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -291,13 +291,16 @@
                                     "type": "object",
                                     "properties": {
                                         "enddevice": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": "#fff8ce"
                                         },
                                         "coordinator": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": "#e04e5d"
                                         },
                                         "router": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": "#4ea3e0"
                                         }
                                     }
                                 },
@@ -305,13 +308,16 @@
                                     "type": "object",
                                     "properties": {
                                         "enddevice": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": "#000000"
                                         },
                                         "coordinator": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": "#ffffff"
                                         },
                                         "router": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": "#ffffff"
                                         }
                                     }
                                 },
@@ -319,10 +325,12 @@
                                     "type": "object",
                                     "properties": {
                                         "active": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": "#009900"
                                         },
                                         "inactive": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "default": "#994444"
                                         }
                                     }
                                 }
@@ -515,7 +523,8 @@
                         "enum": ["console", "file", "syslog"]
                     },
                     "title": "Log output",
-                    "description": "Output location of the log, leave empty to suppress logging"
+                    "description": "Output location of the log, leave empty to suppress logging",
+                    "default": ["console", "file"]
                 },
                 "log_directory": {
                     "type": "string",
@@ -530,7 +539,7 @@
                     "requiresRestart": true,
                     "description": "Log file name, can also contain timestamp",
                     "examples": ["zigbee2mqtt_%TIMESTAMP%.log"],
-                    "default": "log.txt"
+                    "default": "log.log"
                 },
                 "log_level": {
                     "type": "string",
@@ -659,7 +668,8 @@
                     ],
                     "title": "Pan ID",
                     "requiresRestart": true,
-                    "description": "ZigBee pan ID, changing requires re-pairing all devices!"
+                    "description": "ZigBee pan ID, changing requires re-pairing all devices!",
+                    "default": 6754
                 },
                 "ext_pan_id": {
                     "oneOf": [
@@ -677,7 +687,8 @@
                     ],
                     "title": "Ext Pan ID",
                     "requiresRestart": true,
-                    "description": "Zigbee extended pan ID, changing requires re-pairing all devices!"
+                    "description": "Zigbee extended pan ID, changing requires re-pairing all devices!",
+                    "default": [221, 221, 221, 221, 221, 221, 221, 221]
                 },
                 "channel": {
                     "type": "number",
@@ -695,6 +706,7 @@
                     "type": ["number", "null"],
                     "minimum": 1,
                     "maximum": 64,
+                    "default": null,
                     "description": "Adapter concurrency (e.g. 2 for CC2531 or 16 for CC26X2R1) (default: null, uses recommended value)"
                 },
                 "adapter_delay": {
@@ -703,6 +715,7 @@
                     "title": "Adapter delay",
                     "minimum": 0,
                     "maximum": 1000,
+                    "default": null,
                     "description": "Adapter delay"
                 },
                 "cache_state": {
@@ -752,14 +765,16 @@
                     ],
                     "title": "Network key",
                     "requiresRestart": true,
-                    "description": "Network encryption key, changing requires re-pairing all devices!"
+                    "description": "Network encryption key, changing requires re-pairing all devices!",
+                    "default": [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13]
                 },
                 "timestamp_format": {
                     "type": "string",
                     "title": "Timestamp format",
                     "requiresRestart": true,
                     "description": "Log timestamp format",
-                    "examples": ["YYYY-MM-DD HH:mm:ss"]
+                    "default": "YYYY-MM-DD HH:mm:ss",
+                    "examples": ["YYYY-MM-DD HH:mm:ss.SSS"]
                 },
                 "transmit_power": {
                     "type": ["number", "null"],
@@ -773,7 +788,8 @@
                     "type": "string",
                     "enum": ["attribute_and_json", "attribute", "json"],
                     "title": "MQTT output type",
-                    "description": "Examples when 'state' of a device is published json: topic: 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}' attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON' attribute_and_json: both json and attribute (see above)"
+                    "description": "Examples when 'state' of a device is published json: topic: 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}' attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON' attribute_and_json: both json and attribute (see above)",
+                    "default": "json"
                 }
             }
         },

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -843,7 +843,8 @@
                     "description": "Sets the MQTT Message Expiry in seconds, Make sure to set mqtt.version to 5"
                 },
                 "qos": {
-                    "type": "number",
+                    "type": ["number"],
+                    "enum": [0, 1, 2],
                     "title": "QoS",
                     "description": "QoS level for MQTT messages of this device"
                 },
@@ -933,13 +934,16 @@
                     "type": "boolean"
                 },
                 "qos": {
-                    "type": "number"
+                    "type": ["number"],
+                    "enum": [0, 1, 2],
+                    "title": "QoS",
+                    "description": "QoS level for MQTT messages of this group"
                 },
                 "off_state": {
                     "type": ["string"],
                     "enum": ["all_members_off", "last_member_state"],
                     "title": "Group off state",
-                    "default": "auto",
+                    "default": "all_members_off",
                     "requiresRestart": true,
                     "description": "Control when to publish state OFF or CLOSE for a group. 'all_members_off': only publish state OFF/CLOSE when all group members are in state OFF/CLOSE,  'last_member_state': publish state OFF whenever one of its members changes to OFF"
                 },

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -248,7 +248,7 @@
                     "type": "number",
                     "title": "Baudrate",
                     "requiresRestart": true,
-                    "description": "Baud rate speed for serial port, this can be anything firmware support but default is 115200 for Z-Stack and EZSP, 38400 for Deconz, however note that some EZSP firmware need 57600",
+                    "description": "Baud rate speed for the serial port. This must match what the firmware on your adapter supports (most commonly 115200).",
                     "examples": [115200, 921600, 460800, 230400, 57600, 38400]
                 },
                 "rtscts": {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -52,6 +52,9 @@ export const defaults = {
         force_disable_retain: false,
         // 1MB = roughly 3.5KB per device * 300 devices for `/bridge/devices`
         maximum_packet_size: 1048576,
+        keepalive: 60,
+        reject_unauthorized: true,
+        version: 4,
     },
     serial: {
         disable_led: false,
@@ -294,9 +297,6 @@ export function validate(): string[] {
         names.push(e.friendly_name);
         if ("icon" in e && e.icon && !e.icon.startsWith("http://") && !e.icon.startsWith("https://") && !e.icon.startsWith("device_icons/")) {
             errors.push(`Device icon of '${e.friendly_name}' should start with 'device_icons/', got '${e.icon}'`);
-        }
-        if (e.qos != null && ![0, 1, 2].includes(e.qos)) {
-            errors.push(`QOS for '${e.friendly_name}' not valid, should be 0, 1 or 2 got ${e.qos}`);
         }
     };
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -112,6 +112,8 @@ describe("Controller", () => {
         expect(mockMQTTConnectAsync).toHaveBeenCalledWith("mqtt://localhost", {
             will: {payload: Buffer.from('{"state":"offline"}'), retain: true, topic: "zigbee2mqtt/bridge/state", qos: 1},
             properties: {maximumPacketSize: 1048576},
+            keepalive: 60,
+            protocolVersion: 4,
         });
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bulb",
@@ -1045,6 +1047,8 @@ describe("Controller", () => {
         expect(mockMQTTConnectAsync).toHaveBeenCalledTimes(1);
         const expected = {
             will: {payload: Buffer.from('{"state":"offline"}'), retain: false, topic: "zigbee2mqtt/bridge/state", qos: 1},
+            keepalive: 60,
+            protocolVersion: 4,
             properties: {maximumPacketSize: 1048576},
         };
         expect(mockMQTTConnectAsync).toHaveBeenCalledWith("mqtt://localhost", expected);

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -309,6 +309,9 @@ describe("Extension: Bridge", () => {
                         force_disable_retain: false,
                         include_device_information: false,
                         maximum_packet_size: 1048576,
+                        keepalive: 60,
+                        reject_unauthorized: true,
+                        version: 4,
                         server: "mqtt://localhost",
                     },
                     ota: {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -312,6 +312,9 @@ describe("Settings", () => {
             base_topic: "zigbee2mqtt",
             include_device_information: false,
             maximum_packet_size: 1048576,
+            keepalive: 60,
+            reject_unauthorized: true,
+            version: 4,
             force_disable_retain: false,
             password: "mysecretpassword",
             server: "my.mqtt.server",
@@ -357,6 +360,9 @@ describe("Settings", () => {
             base_topic: "zigbee2mqtt",
             include_device_information: false,
             maximum_packet_size: 1048576,
+            keepalive: 60,
+            reject_unauthorized: true,
+            version: 4,
             force_disable_retain: false,
             password: "mysecretpassword",
             server: "my.mqtt.server",
@@ -675,6 +681,9 @@ describe("Settings", () => {
             base_topic: "zigbee2mqtt",
             include_device_information: false,
             maximum_packet_size: 1048576,
+            keepalive: 60,
+            reject_unauthorized: true,
+            version: 4,
             force_disable_retain: false,
             server: "my.mqtt.server",
             user: "myusername",
@@ -865,7 +874,7 @@ describe("Settings", () => {
 
         settings.reRead();
 
-        const error = `QOS for 'myname' not valid, should be 0, 1 or 2 got 3`;
+        const error = "devices/0x0017880104e45519/qos must be equal to one of the allowed values";
         expect(settings.validate()).toEqual(expect.arrayContaining([error]));
     });
 


### PR DESCRIPTION
Match schema to 
https://github.com/Koenkk/zigbee2mqtt/blob/c465ef83526c434cac6555836d82e7707072b754/lib/util/settings.ts#L30-L119

@Koenkk there are a few things that still don't match. How do you want to handle this?
- `mqtt` has a few defaults in schema that are derived from mqtt.js (I assume, haven't checked), but not actually in the default settings of Z2M (could eventually mismatch with mqtt.js dep updates).
- `definitions`>`group`>`off_state` has a default not in the enum.
- `mqtt`>`qos` (and others) should be an enum?
- could use [this](https://ajv.js.org/guide/modifying-data.html#assigning-defaults) instead of having separate (copied) defaults in ts.
