### PR TITLE
Fix TypeError when environment variable path contains string values

### DIFF
--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -387,7 +387,10 @@ function applyEnvironmentVariables(settings: Partial<Settings>): void {
                     if (envVariable) {
                         const setting = path.reduce((acc, val) => {
                             // @ts-expect-error ignore typing
-                            acc[val] = acc[val] || {};
+                            if (typeof acc[val] !== "object" || acc[val] === null) {
+                                // @ts-expect-error ignore typing
+                                acc[val] = {};
+                            }
                             // @ts-expect-error ignore typing
                             return acc[val];
                         }, settings);


### PR DESCRIPTION
## Summary

This PR fixes a bug where Zigbee2MQTT would crash with a TypeError when environment variable processing encounters string values in the configuration path.

### Problem
When using environment variables to configure nested settings, the code would fail with:
```
TypeError: Cannot create property 'port' on string '/dev/serial/by-id/usb-ITead_Sonoff_Zigbee_3.0_USB_Dongle_Plus_...'
```

This happened because the path reduction logic in `applyEnvironmentVariables` function would try to treat existing string values as objects and assign properties to them.

### Solution
Added a type check to ensure that when traversing the configuration path, we properly handle cases where intermediate values are strings by replacing them with objects before attempting to set properties.

### Testing
- All existing tests pass
- Build completes successfully
- The fix prevents the TypeError without breaking existing functionality

Fixes #27958