### PR TITLE
fix(ignore): add test to specifically check HA envs

### DIFF
--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -165,6 +165,43 @@ describe("Settings", () => {
         writeAndCheck();
     });
 
+    it("Should apply Home Assistant environment variables", () => {
+        // should be kept in sync with envs in https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/blob/master/common/rootfs/docker-entrypoint.sh
+        process.env.ZIGBEE2MQTT_CONFIG_FRONTEND_ENABLED = "true";
+        process.env.ZIGBEE2MQTT_CONFIG_FRONTEND_PORT = "8099";
+        process.env.ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED = "true";
+        process.env.ZIGBEE2MQTT_CONFIG_SERIAL_PORT =
+            "/dev/serial/by-id/usb-ITead_Sonoff_Zigbee_3.0_USB_Dongle_Plus_48be7a7468d8ed11bfea786ff2c613ac-if00-port0";
+        process.env.ZIGBEE2MQTT_CONFIG_MQTT_SERVER = "mqtt://core-mosquitto:1883";
+        process.env.ZIGBEE2MQTT_CONFIG_MQTT_USER = "addons";
+        process.env.ZIGBEE2MQTT_CONFIG_MQTT_PASSWORD = "7RbR4NBSskS8TKG4ugzdRilXw6TPQ4NKFs259j2DxeultOFtl5JwciNZFd6feT5o";
+
+        write(configurationFile, {});
+
+        // @ts-expect-error workaround
+        const expected = objectAssignDeep.noMutate({}, settings.testing.defaults);
+        expected.frontend.enabled = true;
+        expected.frontend.port = 8099;
+        expected.homeassistant.enabled = true;
+        expected.serial.port = "/dev/serial/by-id/usb-ITead_Sonoff_Zigbee_3.0_USB_Dongle_Plus_48be7a7468d8ed11bfea786ff2c613ac-if00-port0";
+        expected.mqtt.server = "mqtt://core-mosquitto:1883";
+        expected.mqtt.user = "addons";
+        expected.mqtt.password = "7RbR4NBSskS8TKG4ugzdRilXw6TPQ4NKFs259j2DxeultOFtl5JwciNZFd6feT5o";
+        expected.devices = {};
+        expected.groups = {};
+
+        const writeAndCheck = (): void => {
+            expect(settings.write()); // trigger writing of ENVs
+            expect(settings.validate()).toStrictEqual([]);
+            expect(settings.get()).toStrictEqual(expected);
+        };
+
+        // Write trice to ensure there are no side effects.
+        writeAndCheck();
+        writeAndCheck();
+        writeAndCheck();
+    });
+
     it("Should write environment variables as overrides to configuration.yaml, not in the ref file", () => {
         write(secretFile, {password: "password-in-secret-file"}, false);
         write(configurationFile, {mqtt: {password: "!secret password", server: "server"}});


### PR DESCRIPTION
Just an extra test to check against the exact set of configs used by HA add-on.