### PR TITLE
fix: publish definition source in `bridge/devices`

### DIFF
--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -837,6 +837,7 @@ export default class Bridge extends Extension {
         }
 
         const payload: Zigbee2MQTTDevice["definition"] = {
+            source: device.definition.externalConverterName ? "external" : device.definition.generated ? "generated" : "native",
             model: device.definition.model,
             vendor: device.definition.vendor,
             description: device.definition.description,

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -220,6 +220,7 @@ export interface Zigbee2MQTTDeviceEndpointConfiguredReporting {
 }
 
 export interface Zigbee2MQTTDeviceDefinition {
+    source: "native" | "generated" | "external";
     model: string;
     vendor: string;
     description: string;

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -368,6 +368,7 @@ describe("Extension: Bridge", () => {
                 },
                 {
                     definition: {
+                        source: "native",
                         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 980 lm",
                         exposes: [
                             {
@@ -625,6 +626,7 @@ describe("Extension: Bridge", () => {
                 {
                     date_code: "2019.09",
                     definition: {
+                        source: "native",
                         description: "Hue Go",
                         exposes: [
                             {
@@ -820,6 +822,7 @@ describe("Extension: Bridge", () => {
                 },
                 {
                     definition: {
+                        source: "native",
                         description: "Hue dimmer switch",
                         exposes: [
                             {
@@ -956,6 +959,7 @@ describe("Extension: Bridge", () => {
                 },
                 {
                     definition: {
+                        source: "generated",
                         description: "Automatically generated definition",
                         exposes: [
                             {
@@ -1050,6 +1054,7 @@ describe("Extension: Bridge", () => {
                 },
                 {
                     definition: {
+                        source: "native",
                         description: "Wireless mini switch",
                         exposes: [
                             {
@@ -1160,6 +1165,7 @@ describe("Extension: Bridge", () => {
                 },
                 {
                     definition: {
+                        source: "native",
                         description: "Temperature and humidity sensor",
                         exposes: [
                             {
@@ -1302,6 +1308,7 @@ describe("Extension: Bridge", () => {
                 },
                 {
                     definition: {
+                        source: "native",
                         description: "Mi smart plug",
                         exposes: [
                             {
@@ -1449,6 +1456,7 @@ describe("Extension: Bridge", () => {
                 },
                 {
                     definition: {
+                        source: "native",
                         description: "zigfred plus smart in-wall switch",
                         exposes: [
                             {
@@ -1957,6 +1965,7 @@ describe("Extension: Bridge", () => {
                 },
                 {
                     definition: {
+                        source: "native",
                         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 980 lm",
                         exposes: [
                             {
@@ -2391,6 +2400,7 @@ describe("Extension: Bridge", () => {
             stringify({
                 data: {
                     definition: {
+                        source: "native",
                         description: "TRADFRI bulb E26/E27, white spectrum, globe, opal, 980 lm",
                         exposes: [
                             {
@@ -2626,6 +2636,7 @@ describe("Extension: Bridge", () => {
             stringify({
                 data: {
                     definition: {
+                        source: "generated",
                         description: "Automatically generated definition",
                         exposes: [
                             {


### PR DESCRIPTION
To better display in frontend.