### PR TITLE
fix: ignore symbolic links in `data` during backup

### DIFF
--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -318,7 +318,7 @@ export default class Bridge extends Extension {
         const files = utils
             .getAllFiles(dataPath)
             .map((f) => [f, f.substring(dataPath.length + 1)])
-            .filter((f) => !f[1].startsWith("log") && !f[1].startsWith("external_extensions/node_modules"));
+            .filter((f) => !f[1].startsWith("log"));
         const zip = new JSZip();
 
         for (const f of files) {

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -318,7 +318,7 @@ export default class Bridge extends Extension {
         const files = utils
             .getAllFiles(dataPath)
             .map((f) => [f, f.substring(dataPath.length + 1)])
-            .filter((f) => !f[1].startsWith("log"));
+            .filter((f) => !f[1].startsWith("log") && !f[1].startsWith("external_extensions/node_modules"));
         const zip = new JSZip();
 
         for (const f of files) {

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -319,7 +319,7 @@ export default class Bridge extends Extension {
         const files = utils
             .getAllFiles(dataPath)
             .map((f) => [f, f.substring(dataPath.length + 1)])
-            .filter((f) => !f[1].startsWith("log"));
+            .filter((f) => !f[1].startsWith("log") && !f[1].startsWith("external_extensions/node_modules"));
         const zip = new JSZip();
 
         for (const f of files) {

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -319,7 +319,7 @@ export default class Bridge extends Extension {
         const files = utils
             .getAllFiles(dataPath)
             .map((f) => [f, f.substring(dataPath.length + 1)])
-            .filter((f) => !f[1].startsWith("log") && !f[1].startsWith("external_extensions/node_modules"));
+            .filter((f) => !f[1].startsWith("log"));
         const zip = new JSZip();
 
         for (const f of files) {

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -202,12 +202,18 @@ function containsControlCharacter(str: string): boolean {
 
 function getAllFiles(path_: string): string[] {
     const result = [];
-    for (let item of fs.readdirSync(path_)) {
-        item = path.join(path_, item);
-        if (fs.lstatSync(item).isFile()) {
-            result.push(item);
+
+    for (let item of fs.readdirSync(path_, { withFileTypes: true })) {
+        const fileName = path.join(path_, item.name);
+
+        if (item.isSymbolicLink()) {
+            continue;
+        }
+
+        if (fs.lstatSync(fileName).isFile()) {
+            result.push(fileName);
         } else {
-            result.push(...getAllFiles(item));
+            result.push(...getAllFiles(fileName));
         }
     }
     return result;

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -204,11 +204,11 @@ function getAllFiles(path_: string): string[] {
     const result = [];
 
     for (const item of fs.readdirSync(path_, {withFileTypes: true})) {
-        const fileName = path.join(path_, item.name);
-
         if (item.isSymbolicLink()) {
             continue;
         }
+
+        const fileName = path.join(path_, item.name);
 
         if (fs.lstatSync(fileName).isFile()) {
             result.push(fileName);

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -203,7 +203,7 @@ function containsControlCharacter(str: string): boolean {
 function getAllFiles(path_: string): string[] {
     const result = [];
 
-    for (let item of fs.readdirSync(path_, { withFileTypes: true })) {
+    for (const item of fs.readdirSync(path_, {withFileTypes: true})) {
         const fileName = path.join(path_, item.name);
 
         if (item.isSymbolicLink()) {

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -200,12 +200,18 @@ function containsControlCharacter(str: string): boolean {
 
 function getAllFiles(path_: string): string[] {
     const result = [];
-    for (let item of fs.readdirSync(path_)) {
-        item = path.join(path_, item);
-        if (fs.lstatSync(item).isFile()) {
-            result.push(item);
+
+    for (let item of fs.readdirSync(path_, { withFileTypes: true })) {
+        const fileName = path.join(path_, item.name);
+
+        if (item.isSymbolicLink()) {
+            continue;
+        }
+
+        if (fs.lstatSync(fileName).isFile()) {
+            result.push(fileName);
         } else {
-            result.push(...getAllFiles(item));
+            result.push(...getAllFiles(fileName));
         }
     }
     return result;

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -9,6 +9,7 @@ import {CUSTOM_CLUSTERS, devices, groups, mockController as mockZHController, ev
 
 import assert from "node:assert";
 import fs from "node:fs";
+import {platform} from "node:os";
 import path from "node:path";
 import stringify from "json-stable-stringify-without-jsonify";
 import type {Mock} from "vitest";
@@ -3841,6 +3842,11 @@ describe("Extension: Bridge", () => {
         fs.writeFileSync(path.join(data.mockDir, "log", "log.log"), "test123");
         fs.mkdirSync(path.join(data.mockDir, "ext_converters", "123"));
         fs.writeFileSync(path.join(data.mockDir, "ext_converters", "123", "myfile.js"), "test123");
+        fs.symlinkSync(
+            path.join(data.mockDir, "ext_converters"),
+            path.join(data.mockDir, "ext_converters_sym"),
+            platform() === "win32" ? "junction" : "dir",
+        );
         mockMQTTPublishAsync.mockClear();
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/backup", "");
         await flushPromises();


### PR DESCRIPTION
When using an external data folder with `ZIGBEE2MQTT_DATA`,  [externalJs.symlinkNodeModulesIfNecessary](https://github.com/Koenkk/zigbee2mqtt/blob/ffdd353e16e6e6170942070c2112cffbe6afea9b/lib/extension/externalJS.ts#L50C13-L50C42) creates a `node_modules` folder in `external_extensions` ([source PR](https://github.com/Koenkk/zigbee2mqtt/pull/27397)).

    [2025-07-31 13:10:26] error: 	z2m: Request 'zigbee2mqtt/bridge/request/backup' failed with error: 'ENOTDIR: not a directory, scandir '/home/zigbee2mqtt/external_extensions/node_modules/.ignored_rimraf/node_modules/.bin/glob''

Some of modules have symbolic links to items outside of the symlinked `node_modules` folder. 
[utils.getAllFiles](https://github.com/Koenkk/zigbee2mqtt/blob/ffdd353e16e6e6170942070c2112cffbe6afea9b/lib/util/utils.ts#L201)  will throw an exception on broken symbolic links and not complete successfully (defined behavior of `fs.readdirSync`)

This PR updates the logic to ignore any symbolic links, with achieves:
* Not including `external_extensions/node_modules`, since its a symbolic link
* Ignore any other possibly broken symbolic links which would block the backup process and should most likely not end up in the .zip archive generated.