### PR TITLE
 fix: Remove 60 MB (28%) of dev dependencies from final docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,11 +13,14 @@ COPY package.json pnpm-lock.yaml ./
 
 # Make and such are needed to compile serialport for riscv64
 # Install pnpm, configure a tmp-based store, then use it under a cache mount so each arch gets its own store
+# NOTE: We do not install devDependencies here (the --prod argument in pnpm install) as we use an already
+#       built artifact (./dist directory) from previous GitHub runner stages.  Omitting devDependencies here
+#       saves storage as this node_modules/ is being copied straight to the release stage later.
 RUN --mount=type=cache,id=pnpm-store,target=/tmp/pnpm-store \
     apk add --no-cache make gcc g++ python3 linux-headers npm && \
     npm install -g pnpm@$(sed -n 's/.*"packageManager": "pnpm@\([0-9.]*\)".*/\1/p' package.json) && \
     pnpm config set store-dir /tmp/pnpm-store && \
-    pnpm install --frozen-lockfile --no-optional && \
+    pnpm install --frozen-lockfile --prod --no-optional && \
     # serialport has outdated prebuilds that appear to fail on some archs, force build on target platform
     rm -rf $(find ./node_modules/.pnpm/ -wholename "*/@serialport/bindings-cpp/prebuilds" -type d) && \
     pnpm rebuild @serialport/bindings-cpp


### PR DESCRIPTION
All development dependencies were previously bundled in the final image.
Most notably, this included typescript compiler (22 MiB), esbuild (12.7 MiB), and some type declaration packages.
Not copying development dependencies saves about 60 MB of storage space.

For x86_64 this makes the image size go down from 217 MiB to 156 MiB, and similarly for arm64 – from 213 MiB to 153 MiB.

---
Honestly, I'm not familiar with docker and nodejs ecosystem much and I only started using z2m just this week.
Buuuut it seems working 😅, though idk if some package like typescript was also used for extensions..