### PR TITLE
Set icon and state class for orientation sensors

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -236,9 +236,12 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
         device_class: "water",
         state_class: "total_increasing",
     },
-    x_axis: {icon: "mdi:axis-x-arrow"},
-    y_axis: {icon: "mdi:axis-y-arrow"},
-    z_axis: {icon: "mdi:axis-z-arrow"},
+    x: {icon: "mdi:axis-x-arrow", state_class: "measurement"},
+    x_axis: {icon: "mdi:axis-x-arrow", state_class: "measurement"},
+    y: {icon: "mdi:axis-y-arrow", state_class: "measurement"},
+    y_axis: {icon: "mdi:axis-y-arrow", state_class: "measurement"},
+    z: {icon: "mdi:axis-z-arrow", state_class: "measurement"},
+    z_axis: {icon: "mdi:axis-z-arrow", state_class: "measurement"},
 } as const;
 const ENUM_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     action: {icon: "mdi:gesture-double-tap"},


### PR DESCRIPTION
Hello,

I have [Tuya ZG-103Z](https://www.zigbee2mqtt.io/devices/ZG-103Z.html) device and after adding it to the home assistant, I don't have charts with XYZ values. It turned out that for the charts to work, we must set the `state_class` to `measurement`.  By the way, I set an icon for these entities.

Best regards,
Kamil Breguła
