### PR TITLE
fix: always unlink node_modules symlinks on stop

### DIFF
--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -81,10 +81,12 @@ describe("Extension: ExternalConverters", () => {
     });
 
     afterEach(async () => {
-        fs.rmSync(mockBasePath, {recursive: true, force: true});
-
         await controller?.stop();
         await flushPromises();
+
+        expect(fs.existsSync(path.join(mockBasePath, "node_modules"))).toStrictEqual(false);
+
+        fs.rmSync(mockBasePath, {recursive: true, force: true});
     });
 
     describe("from folder", () => {

--- a/test/extensions/externalExtensions.test.ts
+++ b/test/extensions/externalExtensions.test.ts
@@ -68,10 +68,12 @@ describe("Extension: ExternalExtensions", () => {
     });
 
     afterEach(async () => {
-        fs.rmSync(mockBasePath, {recursive: true, force: true});
-
         await controller?.stop();
         await flushPromises();
+
+        expect(fs.existsSync(path.join(mockBasePath, "node_modules"))).toStrictEqual(false);
+
+        fs.rmSync(mockBasePath, {recursive: true, force: true});
     });
 
     describe("from folder", () => {


### PR DESCRIPTION
Ensure "node_modules" is never followed & included in 3rd-party backup systems.