### PR TITLE
chore(github): fix link to "fail to start" FAQ in problem report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem_report.yaml
+++ b/.github/ISSUE_TEMPLATE/problem_report.yaml
@@ -6,7 +6,7 @@ body:
       attributes:
           value: |
               **IMPORTANT:** Before submitting:
-              - Zigbee2MQTT fails to start? Read [this](https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start.html)
+              - Zigbee2MQTT fails to start? Read [this](https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.html)
               - Raspberry Pi users? Make sure to check [this](https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.html#raspberry-pi-users-use-a-good-power-supply)
               - You read the [FAQ](https://www.zigbee2mqtt.io/guide/faq/)
               - Are you using an EZSP adapter (e.g. Dongle-E/SkyConnect)? Try the [new driver](https://github.com/Koenkk/zigbee2mqtt/discussions/21462) 


### PR DESCRIPTION
While opening #28243 and reading through the issue template instructions, I noticed that the:

> Zigbee2MQTT fails to start? Read [this](https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start.html)

was leading to a 404 page.

This PR fixes that with what seemed to be the closest page to me :slightly_smiling_face: 
