### PR TITLE
fix: Home Assistant: use "occupancy" device_class for human presence sensors

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -81,7 +81,7 @@ const BINARY_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     noise_detected: {device_class: "sound"},
     occupancy: {device_class: "occupancy"},
     power_outage_memory: {entity_category: "config", icon: "mdi:memory"},
-    presence: {device_class: "presence"},
+    presence: {device_class: "occupancy"},
     setup: {device_class: "running"},
     smoke: {device_class: "smoke"},
     sos: {device_class: "safety"},


### PR DESCRIPTION
This addresses a semantic difference in how the term "presence" is used by Home Assistant. Home Assistant uses the "presence" device_class for binary_sensor entities that track the presence of something mobile or portable. To that end, Home Assistant reports state changes in binary_sensor entities with the "presence" device_class like "**_binary_sensor_ was detected at home**" or "**_binary_sensor_ was detected away**".

I have verified that all devices currently supported by zigbee2mqtt that expose a "presence" sensor are human presence sensors (sensors that detect the presence of a person or people in a physical space) which is a more appropriate use case for the "occupancy" device_class in Home Assistant.

State changes in binary_sensor entities with the "occupancy" device_class are reported by Home Assistant like "**_binary_sensor_ detected occupancy**" or "**_binary_sensor_ cleared (no occupancy detected)**", which is a much more coherent message for these sensors.