### PR TITLE
fix: handle empty or null Home Assistant name in device settings

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -925,7 +925,7 @@
                     "title": "Home Assistant",
                     "properties": {
                         "name": {
-                            "type": "string",
+                            "type": ["string", "null"],
                             "title": "Home Assistant name",
                             "description": "Name of the device in Home Assistant"
                         }

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -640,14 +640,11 @@ export function changeEntityOptions(IDorName: string, newOptions: KeyValue): boo
     const settings = getPersistedSettings();
     delete newOptions.friendly_name;
     delete newOptions.devices;
-    // biome-ignore lint/style/noNonNullAssertion: If Home Assistant name is set to null or empty string, remove it (treat as no override)
     if (newOptions.homeassistant && typeof newOptions.homeassistant === 'object' && 'name' in newOptions.homeassistant) {
         if (newOptions.homeassistant.name === '' || newOptions.homeassistant.name === null) {
             if (Object.keys(newOptions.homeassistant).length === 1) {
-                // biome-ignore lint/style/noNonNullAssertion: Only 'name' present, remove the whole homeassistant object
                 newOptions.homeassistant = null;
             } else {
-                // biome-ignore lint/style/noNonNullAssertion: Remove the 'name' field, keep other overrides if any
                 delete newOptions.homeassistant.name;
             }
         }

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -640,14 +640,14 @@ export function changeEntityOptions(IDorName: string, newOptions: KeyValue): boo
     const settings = getPersistedSettings();
     delete newOptions.friendly_name;
     delete newOptions.devices;
-    // If Home Assistant name is set to null or empty string, remove it (treat as no override)
+    // biome-ignore lint/style/noNonNullAssertion: If Home Assistant name is set to null or empty string, remove it (treat as no override)
     if (newOptions.homeassistant && typeof newOptions.homeassistant === 'object' && 'name' in newOptions.homeassistant) {
         if (newOptions.homeassistant.name === '' || newOptions.homeassistant.name === null) {
             if (Object.keys(newOptions.homeassistant).length === 1) {
-                // Only 'name' present, remove the whole homeassistant object
+                // biome-ignore lint/style/noNonNullAssertion: Only 'name' present, remove the whole homeassistant object
                 newOptions.homeassistant = null;
             } else {
-                // Remove the 'name' field, keep other overrides if any
+                // biome-ignore lint/style/noNonNullAssertion: Remove the 'name' field, keep other overrides if any
                 delete newOptions.homeassistant.name;
             }
         }

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -640,6 +640,18 @@ export function changeEntityOptions(IDorName: string, newOptions: KeyValue): boo
     const settings = getPersistedSettings();
     delete newOptions.friendly_name;
     delete newOptions.devices;
+    // If Home Assistant name is set to null or empty string, remove it (treat as no override)
+    if (newOptions.homeassistant && typeof newOptions.homeassistant === 'object' && 'name' in newOptions.homeassistant) {
+        if (newOptions.homeassistant.name === '' || newOptions.homeassistant.name === null) {
+            if (Object.keys(newOptions.homeassistant).length === 1) {
+                // Only 'name' present, remove the whole homeassistant object
+                newOptions.homeassistant = null;
+            } else {
+                // Remove the 'name' field, keep other overrides if any
+                delete newOptions.homeassistant.name;
+            }
+        }
+    }
     let validator: ValidateFunction;
     const device = getDevice(IDorName);
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -995,54 +995,52 @@ describe("Settings", () => {
 
     it("Should keep homeassistant null property on device setting change", () => {
         write(configurationFile, {
-            devices: {"0x12345678": {friendly_name: "custom discovery", homeassistant: {entityXYZ: {entity_category: null}}}},
+            devices: {
+                "0x12345678": {
+                    friendly_name: "custom discovery",
+                    homeassistant: {
+                        entityXYZ: {
+                            entity_category: null,
+                        },
+                    },
+                },
+            },
         });
         settings.changeEntityOptions("0x12345678", {disabled: true});
 
         const actual = read(configurationFile);
         const expected = {
-            devices: {"0x12345678": {friendly_name: "custom discovery", disabled: true, homeassistant: {entityXYZ: {entity_category: null}}}},
+            devices: {
+                "0x12345678": {
+                    friendly_name: "custom discovery",
+                    disabled: true,
+                    homeassistant: {
+                        entityXYZ: {
+                            entity_category: null,
+                        },
+                    },
+                },
+            },
         };
         expect(actual).toStrictEqual(expected);
     });
 
     it("Should keep homeassistant null properties on apply", () => {
         write(configurationFile, {
-            device_options: {homeassistant: {temperature: null}},
-            devices: {"0x1234567812345678": {friendly_name: "custom discovery", homeassistant: {humidity: null}}},
+            device_options: {
+                homeassistant: {temperature: null},
+            },
+            devices: {
+                "0x1234567812345678": {
+                    friendly_name: "custom discovery",
+                    homeassistant: {humidity: null},
+                },
+            },
         });
         settings.reRead();
         settings.apply({external_converters: []});
         expect(settings.get().device_options.homeassistant).toStrictEqual({temperature: null});
         expect(settings.get().devices["0x1234567812345678"].homeassistant).toStrictEqual({humidity: null});
-    });
-
-    it("handles homeassistant name null with other props", () => {
-        write(configurationFile, {
-            devices: {"0x1234567812345678": {friendly_name: "custom discovery", homeassistant: {name: "abcd", temperature: 1}}},
-        });
-        settings.reRead();
-        settings.changeEntityOptions("0x1234567812345678", {homeassistant: {name: null}});
-
-        const actual = read(configurationFile);
-        const expected = {
-            devices: {"0x1234567812345678": {friendly_name: "custom discovery", homeassistant: {temperature: 1}}},
-        };
-        expect(actual).toStrictEqual(expected);
-    });
-
-    it("handles homeassistant name null no other props", () => {
-        write(configurationFile, {
-            devices: {"0x1234567812345678": {friendly_name: "custom discovery", homeassistant: {name: "abcd"}}},
-        });
-        settings.reRead();
-        settings.changeEntityOptions("0x1234567812345678", {homeassistant: {name: null}});
-
-        const actual = read(configurationFile);
-        const expected = {
-            devices: {"0x1234567812345678": {friendly_name: "custom discovery"}},
-        };
-        expect(actual).toStrictEqual(expected);
     });
 
     it("Frontend config", () => {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -995,52 +995,54 @@ describe("Settings", () => {
 
     it("Should keep homeassistant null property on device setting change", () => {
         write(configurationFile, {
-            devices: {
-                "0x12345678": {
-                    friendly_name: "custom discovery",
-                    homeassistant: {
-                        entityXYZ: {
-                            entity_category: null,
-                        },
-                    },
-                },
-            },
+            devices: {"0x12345678": {friendly_name: "custom discovery", homeassistant: {entityXYZ: {entity_category: null}}}},
         });
         settings.changeEntityOptions("0x12345678", {disabled: true});
 
         const actual = read(configurationFile);
         const expected = {
-            devices: {
-                "0x12345678": {
-                    friendly_name: "custom discovery",
-                    disabled: true,
-                    homeassistant: {
-                        entityXYZ: {
-                            entity_category: null,
-                        },
-                    },
-                },
-            },
+            devices: {"0x12345678": {friendly_name: "custom discovery", disabled: true, homeassistant: {entityXYZ: {entity_category: null}}}},
         };
         expect(actual).toStrictEqual(expected);
     });
 
     it("Should keep homeassistant null properties on apply", () => {
         write(configurationFile, {
-            device_options: {
-                homeassistant: {temperature: null},
-            },
-            devices: {
-                "0x1234567812345678": {
-                    friendly_name: "custom discovery",
-                    homeassistant: {humidity: null},
-                },
-            },
+            device_options: {homeassistant: {temperature: null}},
+            devices: {"0x1234567812345678": {friendly_name: "custom discovery", homeassistant: {humidity: null}}},
         });
         settings.reRead();
         settings.apply({external_converters: []});
         expect(settings.get().device_options.homeassistant).toStrictEqual({temperature: null});
         expect(settings.get().devices["0x1234567812345678"].homeassistant).toStrictEqual({humidity: null});
+    });
+
+    it("handles homeassistant name null with other props", () => {
+        write(configurationFile, {
+            devices: {"0x1234567812345678": {friendly_name: "custom discovery", homeassistant: {name: "abcd", temperature: 1}}},
+        });
+        settings.reRead();
+        settings.changeEntityOptions("0x1234567812345678", {homeassistant: {name: null}});
+
+        const actual = read(configurationFile);
+        const expected = {
+            devices: {"0x1234567812345678": {friendly_name: "custom discovery", homeassistant: {temperature: 1}}},
+        };
+        expect(actual).toStrictEqual(expected);
+    });
+
+    it("handles homeassistant name null no other props", () => {
+        write(configurationFile, {
+            devices: {"0x1234567812345678": {friendly_name: "custom discovery", homeassistant: {name: "abcd"}}},
+        });
+        settings.reRead();
+        settings.changeEntityOptions("0x1234567812345678", {homeassistant: {name: null}});
+
+        const actual = read(configurationFile);
+        const expected = {
+            devices: {"0x1234567812345678": {friendly_name: "custom discovery"}},
+        };
+        expect(actual).toStrictEqual(expected);
     });
 
     it("Frontend config", () => {


### PR DESCRIPTION
- Allow 'homeassistant.name' to be null in the schema
- Remove 'name' field or entire 'homeassistant' object when the name is empty or null
- Prevents invalid config and startup errors when clearing the Home Assistant Name in the frontend
- Fixes https://github.com/Koenkk/zigbee2mqtt/issues/26229