### PR TITLE
fix: update zigbee2mqtt-windfront to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "zigbee-herdsman": "6.0.1",
         "zigbee-herdsman-converters": "25.9.0",
         "zigbee2mqtt-frontend": "0.9.20",
-        "zigbee2mqtt-windfront": "1.8.1"
+        "zigbee2mqtt-windfront": "2.0.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 0.9.20
         version: 0.9.20
       zigbee2mqtt-windfront:
-        specifier: 1.8.1
-        version: 1.8.1
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.1.4
@@ -1618,9 +1618,9 @@ packages:
     resolution: {integrity: sha512-P+GpOueoqWu7j002MQPuGYj3DFQb3jus88v1+Rude7a88yu1lf75oHwjo0sdp5YTpLDqObGR8sCP5qBF5nmS4Q==}
     engines: {node: '>=20.11'}
 
-  zigbee2mqtt-windfront@1.8.1:
-    resolution: {integrity: sha512-R0kTbyNTvNF7XSMg/axG6HX1SqlSofNwXAmohZws1BBs2HTPx9B3+vMcJnmlV3KapubYPdK+0CAMvQmbrXqBrw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  zigbee2mqtt-windfront@2.0.0:
+    resolution: {integrity: sha512-a400vqf5l6kEu4s1oAbRk+UK1C42L8+uIeEGua3EYFQsMyX7JulppWQXmu0QTI/5V4hX44RNYygWbLUhJTGyHg==}
+    engines: {node: '>=22.12.0'}
 
 snapshots:
 
@@ -3066,4 +3066,4 @@ snapshots:
 
   zigbee2mqtt-frontend@0.9.20: {}
 
-  zigbee2mqtt-windfront@1.8.1: {}
+  zigbee2mqtt-windfront@2.0.0: {}


### PR DESCRIPTION
Breaking changes, see: https://github.com/Nerivec/zigbee2mqtt-windfront/discussions/205

(not tagged `(ignore)` since major)