### PR TITLE
fix: Fix `DatabaseEntry with ID 'X' does not exist` when adding device to delete group ID

### DIFF
--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -619,14 +619,26 @@ export default class Bridge extends Extension {
         try {
             logger.info(`Removing ${entityType} '${friendlyName}'${blockForceLog}`);
 
-            await this.zigbee.removeEntity(entity, force);
-
             if (entity instanceof Device) {
                 if (block) {
                     settings.blockDevice(entity.ieeeAddr);
                 }
+
+                if (force) {
+                    entity.zh.removeFromDatabase();
+                } else {
+                    await entity.zh.removeFromNetwork();
+                }
+
                 settings.removeDevice(entity.ID as string);
             } else {
+                if (force) {
+                    entity.zh.removeFromDatabase();
+                } else {
+                    await entity.zh.removeFromNetwork();
+                }
+
+                this.zigbee.removeGroupFromLookup(entity.ID);
                 settings.removeGroup(entity.ID);
             }
 

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -619,25 +619,14 @@ export default class Bridge extends Extension {
         try {
             logger.info(`Removing ${entityType} '${friendlyName}'${blockForceLog}`);
 
+            await this.zigbee.removeEntity(entity, force);
+
             if (entity instanceof Device) {
                 if (block) {
                     settings.blockDevice(entity.ieeeAddr);
                 }
-
-                if (force) {
-                    entity.zh.removeFromDatabase();
-                } else {
-                    await entity.zh.removeFromNetwork();
-                }
-
                 settings.removeDevice(entity.ID as string);
             } else {
-                if (force) {
-                    entity.zh.removeFromDatabase();
-                } else {
-                    await entity.zh.removeFromNetwork();
-                }
-
                 settings.removeGroup(entity.ID);
             }
 

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -433,24 +433,7 @@ export default class Zigbee {
         return this.resolveGroup(id);
     }
 
-    async removeEntity(entity: Device | Group, force: boolean): Promise<void> {
-        if (entity instanceof Device) {
-            if (force) {
-                entity.zh.removeFromDatabase();
-            } else {
-                await entity.zh.removeFromNetwork();
-            }
-
-            // Don't remove from `deviceLookup` as zigbee-herdsman keeps the object in memory
-            // i.e. in case the device would re-join, the same object would be used.
-        } else {
-            if (force) {
-                entity.zh.removeFromDatabase();
-            } else {
-                await entity.zh.removeFromNetwork();
-            }
-
-            this.groupLookup.delete(entity.ID);
-        }
+    removeGroupFromLookup(id: number): void {
+        this.groupLookup.delete(id);
     }
 }

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -432,4 +432,25 @@ export default class Zigbee {
     groupByID(id: number): Group | undefined {
         return this.resolveGroup(id);
     }
+
+    async removeEntity(entity: Device | Group, force: boolean): Promise<void> {
+        if (entity instanceof Device) {
+            if (force) {
+                entity.zh.removeFromDatabase();
+            } else {
+                await entity.zh.removeFromNetwork();
+            }
+
+            // Don't remove from `deviceLookup` as zigbee-herdsman keeps the object in memory
+            // i.e. in case the device would re-join, the same object would be used.
+        } else {
+            if (force) {
+                entity.zh.removeFromDatabase();
+            } else {
+                await entity.zh.removeFromNetwork();
+            }
+
+            this.groupLookup.delete(entity.ID);
+        }
+    }
 }

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1168,4 +1168,14 @@ describe("Controller", () => {
             await controller.enableDisableExtension(false, "Availability");
         }).rejects.toThrow("Built-in extension Availability cannot be disabled at runtime");
     });
+
+    it("should clear group references", async () => {
+        await controller.start();
+
+        const groupOld = controller.zigbee.createGroup(1);
+        await controller.zigbee.removeEntity(groupOld, false);
+        const groupNew = controller.zigbee.createGroup(1);
+        expect(groupOld).not.toBe(groupNew);
+        expect(controller.zigbee.resolveEntity("1")).toBe(groupNew);
+    });
 });

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1168,14 +1168,4 @@ describe("Controller", () => {
             await controller.enableDisableExtension(false, "Availability");
         }).rejects.toThrow("Built-in extension Availability cannot be disabled at runtime");
     });
-
-    it("should clear group references", async () => {
-        await controller.start();
-
-        const groupOld = controller.zigbee.createGroup(1);
-        await controller.zigbee.removeEntity(groupOld, false);
-        const groupNew = controller.zigbee.createGroup(1);
-        expect(groupOld).not.toBe(groupNew);
-        expect(controller.zigbee.resolveEntity("1")).toBe(groupNew);
-    });
 });

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -2971,11 +2971,13 @@ describe("Extension: Bridge", () => {
 
     it("Should allow to remove group", async () => {
         const group = groups.group_1;
+        const removeGroupFromLookup = vi.spyOn(controller.zigbee, "removeGroupFromLookup");
         mockMQTTPublishAsync.mockClear();
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/group/remove", "group_1");
         await flushPromises();
         expect(group.removeFromNetwork).toHaveBeenCalledTimes(1);
         expect(settings.getGroup("group_1")).toBeUndefined();
+        expect(removeGroupFromLookup).toHaveBeenCalledWith(1);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/groups", expect.any(String), expect.any(Object));
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/group/remove",


### PR DESCRIPTION
This fixes an issue that in case a group is deleted and a new group is created with the same ID a `Failed to add from group (DatabaseEntry with ID 'X' does not exist)` error is thrown. This is because z2m still has the old group object in memory while zh created a different one with a different databaseId.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/23929