### PR TITLE
Add pi cooling demand to Home Assistant autodiscovery

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -722,6 +722,24 @@ export class HomeAssistant extends Extension {
                     discoveryEntries.push(discoveryEntry);
                 }
 
+                const piCoolingDemand = (firstExpose as zhc.Climate).features.filter(isNumericExpose).find((f) => f.name === "pi_cooling_demand");
+                if (piCoolingDemand) {
+                    const discoveryEntry: DiscoveryEntry = {
+                        type: "sensor",
+                        object_id: endpoint ? /* v8 ignore next */ `${piCoolingDemand.name}_${endpoint}` : `${piCoolingDemand.name}`,
+                        mockProperties: [{property: piCoolingDemand.property, value: null}],
+                        discovery_payload: {
+                            name: endpoint ? /* v8 ignore next */ `${piCoolingDemand.label} ${endpoint}` : piCoolingDemand.label,
+                            value_template: `{{ value_json.${piCoolingDemand.property} }}`,
+                            ...(piCoolingDemand.unit && {unit_of_measurement: piCoolingDemand.unit}),
+                            entity_category: "diagnostic",
+                            icon: "mdi:radiator",
+                        },
+                    };
+
+                    discoveryEntries.push(discoveryEntry);
+                }
+
                 discoveryEntries.push(discoveryEntry);
                 break;
             }

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -733,7 +733,7 @@ export class HomeAssistant extends Extension {
                             value_template: `{{ value_json.${piCoolingDemand.property} }}`,
                             ...(piCoolingDemand.unit && {unit_of_measurement: piCoolingDemand.unit}),
                             entity_category: "diagnostic",
-                            icon: "mdi:radiator",
+                            icon: "mdi:air-conditioner",
                         },
                     };
 


### PR DESCRIPTION
Cooling demand is equal to heating demand (`piHeatingDemand` / `pi_heating_demand`) and therefore this code is almost equal.
By lack of a better icon, the `mdi:radiator` is also used here.