### PR TITLE
Bosch `BTH-RA`: Fix broken integration test due to missing whitespaces

### DIFF
--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1046,10 +1046,10 @@ describe("Extension: HomeAssistant", () => {
             },
             max_temp: "30",
             min_temp: "5",
-            mode_command_template: `{% set values = { 'auto':'schedule','heat':'manual','off':'pause'} %}{"operating_mode": "{{ values[value] if value in values.keys() else 'pause' }}"}`,
+            mode_command_template: `{% set values = { 'auto':'schedule', 'heat':'manual', 'off':'pause' } %}{"operating_mode": "{{ values[value] if value in values.keys() else 'pause' }}"}`,
             mode_command_topic: "zigbee2mqtt/bosch_radiator/set",
             mode_state_template:
-                "{% set values = {'schedule':'auto','manual':'heat','pause':'off'} %}{% set value = value_json.operating_mode %}{{ values[value] if value in values.keys() else 'off' }}",
+                "{% set values = { 'schedule':'auto', 'manual':'heat', 'pause':'off' } %}{% set value = value_json.operating_mode %}{{ values[value] if value in values.keys() else 'off' }}",
             mode_state_topic: "zigbee2mqtt/bosch_radiator",
             modes: ["off", "heat", "auto"],
             name: null,


### PR DESCRIPTION
In this [pull request](https://github.com/Koenkk/zigbee-herdsman-converters/pull/10309), I changed the spacing of the templates to make it consistent and a bit more readable. This makes this change in the integration test necessary, otherwise, it will fail.