### PR TITLE
fix: Require at least Node ^20.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/Koenkk/zigbee2mqtt.git"
     },
     "engines": {
-        "node": "^20 || ^22 || ^24"
+        "node": "^20.15.0 || ^22 || ^24"
     },
     "keywords": [
         "xiaomi",


### PR DESCRIPTION
Because of https://github.com/Koenkk/zigbee-herdsman-converters/pull/10511

CC: @Nerivec 