### PR TITLE
fix: Fix `onEvent` called twice first time when device options are changed

### DIFF
--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -69,13 +69,11 @@ export default class OnEvent extends Extension {
             return;
         }
 
-        if (event.type !== "start" && event.type !== "stop" && !this.#startCalled.has(device.ieeeAddr) && device.definition?.onEvent) {
-            this.#startCalled.add(device.ieeeAddr);
-            await device.definition.onEvent({type: "start", data: this.#getOnEventBaseData(device)});
-        }
-
         if (event.type === "start") {
             this.#startCalled.add(device.ieeeAddr);
+        } else if (event.type !== "stop" && !this.#startCalled.has(device.ieeeAddr) && device.definition?.onEvent) {
+            this.#startCalled.add(device.ieeeAddr);
+            await device.definition.onEvent({type: "start", data: this.#getOnEventBaseData(device)});
         }
 
         await onEvent(event);

--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -74,6 +74,10 @@ export default class OnEvent extends Extension {
             await device.definition.onEvent({type: "start", data: this.#getOnEventBaseData(device)});
         }
 
+        if (event.type === "start") {
+            this.#startCalled.add(device.ieeeAddr);
+        }
+
         await onEvent(event);
         await device.definition?.onEvent?.(event);
 

--- a/test/extensions/onEvent.test.ts
+++ b/test/extensions/onEvent.test.ts
@@ -28,11 +28,6 @@ describe("Extension: OnEvent", () => {
         return controller.zigbee.resolveEntity(zhDevice)! as Device;
     };
 
-    const clearOnEventSpies = (): void => {
-        onEventSpy.mockClear();
-        deviceOnEventSpy.mockClear();
-    };
-
     beforeAll(async () => {
         vi.useFakeTimers();
         data.writeDefaultConfiguration();
@@ -52,7 +47,8 @@ describe("Extension: OnEvent", () => {
         }
 
         await controller.removeExtension(controller.getExtension("OnEvent")!);
-        clearOnEventSpies();
+        onEventSpy.mockClear();
+        deviceOnEventSpy.mockClear();
         await controller.addExtension(new OnEvent(...controller.extensionArgs));
     });
 
@@ -88,7 +84,6 @@ describe("Extension: OnEvent", () => {
     });
 
     it("calls on device events", async () => {
-        clearOnEventSpies();
         await mockZHEvents.deviceAnnounce({device: devices.LIVOLO});
         await flushPromises();
 
@@ -177,14 +172,10 @@ describe("Extension: OnEvent", () => {
 
     it("does not block startup on failure", async () => {
         await controller.removeExtension(controller.getExtension("OnEvent")!);
-        clearOnEventSpies();
         deviceOnEventSpy.mockImplementationOnce(async () => {
             await new Promise((resolve) => setTimeout(resolve, 10000));
             throw new Error("Failed");
         });
         await controller.addExtension(new OnEvent(...controller.extensionArgs));
-
-        expect(onEventSpy).toHaveBeenCalledTimes(2);
-        expect(deviceOnEventSpy).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee-herdsman-converters/issues/10520