### PR TITLE
Fix HA discovery conflict with color_mode and supported_color_modes

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1714,6 +1714,12 @@ export class HomeAssistant extends Extension {
                 }
             }
 
+            // Ensure deprecated color_mode field is not present when supported_color_modes is used
+            // This prevents Home Assistant from rejecting the discovery due to conflicting fields
+            if (payload.supported_color_modes && payload.color_mode === true) {
+                delete payload.color_mode;
+            }
+
             const topic = this.getDiscoveryTopic(config, entity);
             const payloadStr = stringify(payload);
             newDiscoveredTopics.add(topic);


### PR DESCRIPTION
## Overview
This PR fixes an issue where Home Assistant would reject device discovery due to conflicting `color_mode` and `supported_color_modes` fields in the discovery payload. When both fields are present, Home Assistant treats it as an error. The fix ensures that the deprecated `color_mode` field is removed when `supported_color_modes` is present.

## Checklist
- [ ] Code changes are complete
- [ ] Tests pass
- [ ] Documentation updated (if applicable)

## Proof that changes are correct
The fix is a simple conditional check that removes the `color_mode` field when `supported_color_modes` is present in the payload. This prevents the conflict that was causing Home Assistant to reject the discovery. The change is backwards compatible as it only removes the deprecated field in cases where the preferred field is present.