### PR TITLE
fix: Home Assistant: Remove whitespaces from BTH-RA discovery payload

### DIFF
--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1117,10 +1117,10 @@ describe("Extension: HomeAssistant", () => {
             },
             max_temp: "30",
             min_temp: "5",
-            mode_command_template: `{% set values = { 'auto':'schedule', 'heat':'manual', 'off':'pause' } %}{"operating_mode": "{{ values[value] if value in values.keys() else 'pause' }}"}`,
+            mode_command_template: `{% set values = { 'auto':'schedule','heat':'manual','off':'pause'} %}{"operating_mode": "{{ values[value] if value in values.keys() else 'pause' }}"}`,
             mode_command_topic: "zigbee2mqtt/bosch_radiator/set",
             mode_state_template:
-                "{% set values = { 'schedule':'auto', 'manual':'heat', 'pause':'off' } %}{% set value = value_json.operating_mode %}{{ values[value] if value in values.keys() else 'off' }}",
+                "{% set values = {'schedule':'auto','manual':'heat','pause':'off'} %}{% set value = value_json.operating_mode %}{{ values[value] if value in values.keys() else 'off' }}",
             mode_state_topic: "zigbee2mqtt/bosch_radiator",
             modes: ["off", "heat", "auto"],
             name: null,


### PR DESCRIPTION
_Should_ allow tests to finish without errors. 🤞

Related: https://github.com/Koenkk/zigbee2mqtt/pull/29659