### PR TITLE
chore: add expose to dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,5 +52,8 @@ RUN mkdir /app/data
 ARG COMMIT
 RUN echo "$COMMIT" > dist/.hash
 
+# Expose the default frontend port (see lib/util/settings.ts defaults.frontend.port)
+EXPOSE 8080
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD [ "/sbin/tini", "--", "node", "index.js"]


### PR DESCRIPTION
I have added the `EXPOSE 8080` instruction to the application Dockerfile.

While working with Traefik locally, the service was not accessible because Traefik could not detect the correct port. By default, Traefik looks for the `EXPOSE` instruction to determine which port to route traffic to.

This change ensures:
1. Seamless integration with reverse proxies like Traefik (zero-config).
2. Better documentation of the container's intended listening port (see [Docker Docs](https://docs.docker.com/reference/dockerfile/#expose)).