### PR TITLE
feat: Home Assistant: Expose `current_humidity` attribute for supported `climate` entities

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -752,9 +752,7 @@ export class HomeAssistant extends Extension {
                     discoveryEntries.push(discoveryEntry);
                 }
 
-                const currentHumidity = allExposes
-                    ?.filter(isNumericExpose)
-                    .find((e) => ["humidity"].includes(e.name) && e.access === ACCESS_STATE);
+                const currentHumidity = allExposes?.filter(isNumericExpose).find((e) => ["humidity"].includes(e.name) && e.access === ACCESS_STATE);
                 if (currentHumidity) {
                     discoveryEntry.discovery_payload.current_humidity_template = `{{ value_json.${currentHumidity.property} }}`;
                     discoveryEntry.discovery_payload.current_humidity_topic = true;

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -752,7 +752,7 @@ export class HomeAssistant extends Extension {
                     discoveryEntries.push(discoveryEntry);
                 }
 
-                const currentHumidity = allExposes?.filter(isNumericExpose).find((e) => ["humidity"].includes(e.name) && e.access === ACCESS_STATE);
+                const currentHumidity = allExposes?.filter(isNumericExpose).find((e) => e.name === "humidity" && e.access === ACCESS_STATE);
                 if (currentHumidity) {
                     discoveryEntry.discovery_payload.current_humidity_template = `{{ value_json.${currentHumidity.property} }}`;
                     discoveryEntry.discovery_payload.current_humidity_topic = true;

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -752,6 +752,14 @@ export class HomeAssistant extends Extension {
                     discoveryEntries.push(discoveryEntry);
                 }
 
+                const currentHumidity = allExposes
+                    ?.filter(isNumericExpose)
+                    .find((e) => ["humidity"].includes(e.name) && e.access === ACCESS_STATE);
+                if (currentHumidity) {
+                    discoveryEntry.discovery_payload.current_humidity_template = `{{ value_json.${currentHumidity.property} }}`;
+                    discoveryEntry.discovery_payload.current_humidity_topic = true;
+                }
+
                 discoveryEntries.push(discoveryEntry);
                 break;
             }


### PR DESCRIPTION
In ZCL, humidity sensors have their own cluster and are not part of the thermostat cluster.
However, in HA and other ecosystems, thermostats _can_ provide current humidity readings. 

That's probably one of the reasons why `current_humidity` is not part of the `climate` feature and exposed separately by Z2M. @Koenkk Feel free to correct me on this. 😊

To preserve backwards-compatibility (and not break entire setups), we'll keep the separate humidity sensor ([for now](https://github.com/Koenkk/zigbee2mqtt/issues/29686#issuecomment-3549559555)).
If all goes right with this PR, the `climate` card in HA will show the current humidity level automatically.
