### PR TITLE
feat(homeassistant): use json_attributes for TRVZB weekly_schedule sensor

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -291,7 +291,7 @@ const LIST_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     level_config: {entity_category: "diagnostic"},
     programming_mode: {icon: "mdi:calendar-clock"},
     schedule_settings: {icon: "mdi:calendar-clock"},
-    weekly_schedule: {
+    schedule: {
         icon: "mdi:calendar-clock",
         entity_category: "config",
         value_template:
@@ -1640,6 +1640,10 @@ export class HomeAssistant extends Extension {
 
             if (payload.temperature_high_state_topic) {
                 payload.temperature_high_state_topic = stateTopic;
+            }
+
+            if (payload.json_attributes_topic) {
+                payload.json_attributes_topic = stateTopic;
             }
 
             if (payload.temperature_command_topic) {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -291,6 +291,15 @@ const LIST_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     level_config: {entity_category: "diagnostic"},
     programming_mode: {icon: "mdi:calendar-clock"},
     schedule_settings: {icon: "mdi:calendar-clock"},
+    weekly_schedule: {
+        icon: "mdi:calendar-clock",
+        entity_category: "config",
+        value_template:
+            "{% set s = value_json.weekly_schedule %}" +
+            "{% if s %}{{ s.keys() | list | length }} days configured{% else %}Not configured{% endif %}",
+        json_attributes_topic: true,
+        json_attributes_template: `{{ {'schedule': value_json.weekly_schedule} | tojson }}`,
+    },
 } as const;
 
 const featurePropertyWithoutEndpoint = (feature: zhc.Feature): string => {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -95,53 +95,53 @@ describe("Extension: HomeAssistant", () => {
 
     it("Should discover weekly_schedule sensor with json_attributes instead of truncated value", () => {
         // Create a SONOFF TRVZB expose definition with schedule (composite type)
-                const trvzbExposes = [
+        const trvzbExposes = [
+            {
+                type: "climate",
+                features: [
                     {
-                        type: "climate",
-                        features: [
-                            {
-                                name: "occupied_heating_setpoint",
-                                property: "occupied_heating_setpoint",
-                                type: "numeric",
-                                access: 7,
-                                value_min: 4,
-                                value_max: 35,
-                                value_step: 0.5,
-                            },
-                            {name: "local_temperature", property: "local_temperature", type: "numeric", access: 5},
-                            {name: "system_mode", property: "system_mode", type: "enum", access: 7, values: ["off", "auto", "heat"]},
-                            {name: "running_state", property: "running_state", type: "enum", access: 5, values: ["idle", "heat"]},
-                        ],
+                        name: "occupied_heating_setpoint",
+                        property: "occupied_heating_setpoint",
+                        type: "numeric",
+                        access: 7,
+                        value_min: 4,
+                        value_max: 35,
+                        value_step: 0.5,
                     },
-                    {
-                        type: "composite",
-                        name: "schedule",
-                        property: "weekly_schedule",
-                        label: "Schedule",
-                        access: 3,
-                        category: "config",
-                        features: [
-                            {name: "sunday", property: "sunday", type: "text", access: 3},
-                            {name: "monday", property: "monday", type: "text", access: 3},
-                            {name: "tuesday", property: "tuesday", type: "text", access: 3},
-                            {name: "wednesday", property: "wednesday", type: "text", access: 3},
-                            {name: "thursday", property: "thursday", type: "text", access: 3},
-                            {name: "friday", property: "friday", type: "text", access: 3},
-                            {name: "saturday", property: "saturday", type: "text", access: 3},
-                        ],
-                    },
-                ];
+                    {name: "local_temperature", property: "local_temperature", type: "numeric", access: 5},
+                    {name: "system_mode", property: "system_mode", type: "enum", access: 7, values: ["off", "auto", "heat"]},
+                    {name: "running_state", property: "running_state", type: "enum", access: 5, values: ["idle", "heat"]},
+                ],
+            },
+            {
+                type: "composite",
+                name: "schedule",
+                property: "weekly_schedule",
+                label: "Schedule",
+                access: 3,
+                category: "config",
+                features: [
+                    {name: "sunday", property: "sunday", type: "text", access: 3},
+                    {name: "monday", property: "monday", type: "text", access: 3},
+                    {name: "tuesday", property: "tuesday", type: "text", access: 3},
+                    {name: "wednesday", property: "wednesday", type: "text", access: 3},
+                    {name: "thursday", property: "thursday", type: "text", access: 3},
+                    {name: "friday", property: "friday", type: "text", access: 3},
+                    {name: "saturday", property: "saturday", type: "text", access: 3},
+                ],
+            },
+        ];
 
-                // Create a mock device with TRVZB exposes
-                const mockDevice = {
-                    definition: {vendor: "SONOFF", model: "TRVZB"},
-                    isDevice: () => true,
-                    isGroup: () => false,
-                    options: {ID: "0x1234567890abcdef"},
-                    exposes: () => trvzbExposes,
-                    zh: {endpoints: []},
-                    name: "test_trvzb",
-                };
+        // Create a mock device with TRVZB exposes
+        const mockDevice = {
+            definition: {vendor: "SONOFF", model: "TRVZB"},
+            isDevice: () => true,
+            isGroup: () => false,
+            options: {ID: "0x1234567890abcdef"},
+            exposes: () => trvzbExposes,
+            zh: {endpoints: []},
+            name: "test_trvzb",
+        };
 
         // @ts-expect-error private
         const configs = extension.getConfigs(mockDevice);


### PR DESCRIPTION
The weekly_schedule composite expose produces JSON that exceeds Home Assistant's 255 character state limit. This change:

- Shows a human-readable summary in the state ("7 days configured")
- Stores the full schedule data as entity attributes
- Allows access to individual days via state_attr()

Fixes the truncated weekly_schedule sensor for Sonoff TRVZB and other TRV devices with schedule support.

Attached the outcome on Home Assistant
<img width="1388" height="485" alt="Screenshot 2025-12-16 at 21 38 04" src="https://github.com/user-attachments/assets/eaedf8f4-c5b0-4c24-a40f-099bfc34f6bb" />
