### PR TITLE
fix: log dir tz format not working on some systems

### DIFF
--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -21,8 +21,13 @@ class Logger {
     public init(): void {
         // What transports to enable
         this.output = settings.get().advanced.log_output;
-        // NOTE: Sweden uses ISO standard, hence, this works for our purpose (equiv of toISOString with proper tz)
-        const timestamp = new Date().toLocaleString("sv-SE").slice(0, 19).replace(" ", ".").replaceAll(":", "-");
+        const date = new Date();
+        // offset UTC by current timezone, ISO keeps "Z" (UTC) which is then wrong but we strip it
+        const timestamp = new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+            .toISOString()
+            .slice(0, 19)
+            .replace("T", ".")
+            .replaceAll(":", "-");
         this.directory = settings.get().advanced.log_directory.replace("%TIMESTAMP%", timestamp);
         const logFilename = settings.get().advanced.log_file.replace("%TIMESTAMP%", timestamp);
         this.level = settings.get().advanced.log_level;

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -51,6 +51,7 @@ describe("Logger", () => {
     it("Create log directory", () => {
         const dirs = fs.readdirSync(dir.name);
         expect(dirs.length).toBe(1);
+        expect(dirs[0]).toMatch(/^[0-9]{4}-[0-9]{2}-[0-9]{2}\.[0-9]{2}-[0-9]{2}-[0-9]{2}$/);
     });
 
     it("Should cleanup (default setting)", () => {


### PR DESCRIPTION
Re https://github.com/Koenkk/zigbee2mqtt/pull/30297
Looks like some systems don't have all locales or something and it falls back to system locale when not, which can make a mess with path-like formats in some countries... hopefully this works better.