### PR TITLE
Re-order loadFiles() so that logging occurs prior to renaming failed converters

### DIFF
--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -202,14 +202,14 @@ export default abstract class ExternalJSExtension<M> extends Extension {
                 const mod = await this.importFile(filePath);
                 await this.loadJS(extension.name, mod.default);
             } catch (error) {
-                // change ext so Z2M doesn't try to load it again and again
-                fs.renameSync(filePath, `${filePath}.invalid`);
-
                 logger.error(
                     `Invalid external ${this.mqttTopic} '${extension.name}' was ignored and renamed to prevent interference with Zigbee2MQTT. (${(error as Error).message})`,
                 );
                 // biome-ignore lint/style/noNonNullAssertion: always Error
                 logger.debug((error as Error).stack!);
+
+                // change ext so Z2M doesn't try to load it again and again
+                fs.renameSync(filePath, `${filePath}.invalid`);
             }
         }
     }


### PR DESCRIPTION
When LoadFiles() in externalJS encounters an invalid converter, it attempts to rename this to converter.invalid prior to performing any logging. In the case where renaming the file is not possible (e.g. because the fs is read-only), the function never logs what was actually wrong with the converter (the error is swallowed).