### PR TITLE
feat: improve OTA

### DIFF
--- a/data/configuration.example.yaml
+++ b/data/configuration.example.yaml
@@ -1,5 +1,5 @@
 # Indicates the configuration version (used by configuration migrations)
-version: 4
+version: 5
 
 # Home Assistant integration (MQTT discovery)
 homeassistant:
@@ -15,7 +15,7 @@ mqtt:
     # MQTT base topic for zigbee2mqtt MQTT messages
     base_topic: zigbee2mqtt
     # MQTT server URL
-    server: 'mqtt://localhost'
+    server: "mqtt://localhost"
     # MQTT server authentication, uncomment if required:
     # user: my_user
     # password: my_password

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -568,19 +568,8 @@ export default class Bridge extends Extension {
         }
 
         const device = this.getEntity("device", message.id);
-        logger.info(`Interviewing '${device.name}'`);
 
-        try {
-            await device.zh.interview(true);
-            logger.info(`Successfully interviewed '${device.name}'`);
-        } catch (error) {
-            throw new Error(`interview of '${device.name}' (${device.ieeeAddr}) failed: ${error}`, {cause: error});
-        }
-
-        // A re-interview can for example result in a different modelId, therefore reconsider the definition.
-        await device.resolveDefinition(true);
-        this.eventBus.emitDevicesChanged();
-        this.eventBus.emitExposesChanged({device});
+        await device.reInterview(this.eventBus);
 
         return utils.getResponse(message, {id: message.id});
     }

--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -75,6 +75,7 @@ export default class Configure extends Extension {
 
             await this.configure(data.device, "zigbee_event");
         });
+        // TODO: this is triggering for any `data.status`, but should only for `successful`? (relies on `device.definition?` early-return?)
         this.eventBus.onDeviceInterview(this, (data) => this.configure(data.device, "zigbee_event"));
         this.eventBus.onLastSeenChanged(this, (data) => this.configure(data.device, "zigbee_event"));
         this.eventBus.onMQTTMessage(this, this.onMQTTMessage);

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -427,6 +427,7 @@ export class HomeAssistant extends Extension {
         this.eventBus.onGroupMembersChanged(this, this.onGroupMembersChanged);
         this.eventBus.onDeviceAnnounce(this, this.onZigbeeEvent);
         this.eventBus.onDeviceJoined(this, this.onZigbeeEvent);
+        // TODO: this is triggering for any `data.status`?
         this.eventBus.onDeviceInterview(this, this.onZigbeeEvent);
         this.eventBus.onDeviceMessage(this, this.onZigbeeEvent);
         this.eventBus.onScenesChanged(this, this.onScenesChanged);

--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -37,6 +37,8 @@ export default class OnEvent extends Extension {
             }
         });
         this.eventBus.onDeviceInterview(this, async (data) => {
+            // TODO: this is triggering for any `data.status`, any use outside `successful`?
+            //       ZHC definition would skip from `device.definition?` but OnEvent from ZHC index wouldn't => triple triggering?
             await this.callOnEvent(data.device, {type: "deviceInterview", data: {...this.#getOnEventBaseData(data.device), status: data.status}});
         });
         this.eventBus.onDeviceAnnounce(this, async (data) => {

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
-import {writeFileSync} from "node:fs";
+import {existsSync, mkdirSync, writeFileSync} from "node:fs";
+import {join} from "node:path";
 import bind from "bind-decorator";
 import stringify from "json-stable-stringify-without-jsonify";
 import {setOtaConfiguration, Zcl} from "zigbee-herdsman";
@@ -34,7 +35,13 @@ function writeFirmwareHexToDataDir(hex: string, fileName: string | undefined, de
         fileName = `${deviceIeee}_${Date.now()}`;
     }
 
-    const filePath = dataDir.joinPath(fileName);
+    const baseDir = dataDir.joinPath("ota");
+
+    if (!existsSync(baseDir)) {
+        mkdirSync(baseDir, {recursive: true});
+    }
+
+    const filePath = join(baseDir, fileName);
 
     writeFileSync(Buffer.from(hex, "hex"), filePath);
 

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -514,7 +514,11 @@ export default class OTAUpdate extends Extension {
             device.zh.save();
         }
 
-        await device.reInterview(this.eventBus);
+        setTimeout(() => {
+            device.reInterview(this.eventBus).catch((error) => {
+                logger.error(`${error.message}. Re-try manually after some time.`);
+            });
+        }, 5000);
 
         return [from.fileVersion, to.fileVersion];
     }

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -488,7 +488,13 @@ export default class OTAUpdate extends Extension {
 
         logger.info(() => `Device '${device.name}' was OTA updated from '${from.fileVersion}' to '${to.fileVersion}'`);
 
-        // OTA update can bring new features & co
+        // OTA update can bring new features & co, force full re-interview and re-configure, same as a "device joined"
+        if (device.zh.meta.configured !== undefined) {
+            delete device.zh.meta.configured;
+
+            device.zh.save();
+        }
+
         await device.reInterview(this.eventBus);
 
         return [from.fileVersion, to.fileVersion];

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -329,8 +329,10 @@ export default class OTAUpdate extends Extension {
                             | Zigbee2MQTTAPI["bridge/request/device/ota_update/update/downgrade"];
 
                         if (payload.hex) {
+                            assert(payload.hex.data);
+
                             // write to `dataDir` and pass created path as source URL
-                            source.url = writeFirmwareHexToDataDir(payload.hex, payload.fileName, device.ieeeAddr);
+                            source.url = writeFirmwareHexToDataDir(payload.hex.data, payload.hex.file_name, device.ieeeAddr);
                         } else if (payload.url) {
                             source.url = payload.url;
                         } else if (!device.definition || !device.definition.ota) {
@@ -398,8 +400,10 @@ export default class OTAUpdate extends Extension {
                             | Zigbee2MQTTAPI["bridge/request/device/ota_update/schedule/downgrade"];
 
                         if (payload.hex) {
+                            assert(payload.hex.data);
+
                             // write to `dataDir` and pass created path as source URL
-                            source.url = writeFirmwareHexToDataDir(payload.hex, payload.fileName, device.ieeeAddr);
+                            source.url = writeFirmwareHexToDataDir(payload.hex.data, payload.hex.file_name, device.ieeeAddr);
                         } else if (payload.url) {
                             source.url = payload.url;
                         } else if (!device.definition || !device.definition.ota) {

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -69,8 +69,7 @@ export default class OTAUpdate extends Extension {
 
             // Reset update state, e.g. when Z2M restarted during update.
             if (this.state.get(device).update?.state === "updating") {
-                // TODO: should use idle instead?
-                this.state.get(device).update.state = "available";
+                this.state.get(device).update.state = "idle";
             }
         }
     }

--- a/lib/model/device.ts
+++ b/lib/model/device.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import {InterviewState} from "zigbee-herdsman/dist/controller/model/device";
+import type {OtaExtraMetas} from "zigbee-herdsman/dist/controller/tstype";
 import type {CustomClusters} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 import * as zhc from "zigbee-herdsman-converters";
 import {access, Numeric} from "zigbee-herdsman-converters";
@@ -38,7 +39,7 @@ export default class Device {
     get customClusters(): CustomClusters {
         return this.zh.customClusters;
     }
-    get otaExtraMetas(): zhc.Ota.ExtraMetas {
+    get otaExtraMetas(): OtaExtraMetas {
         return typeof this.definition?.ota === "object" ? this.definition.ota : {};
     }
     get hasScheduledOta(): boolean {

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -55,6 +55,7 @@ export interface Zigbee2MQTTDeviceOptions {
     friendly_name: string;
     description?: string;
     qos?: 0 | 1 | 2;
+    disable_automatic_update_check?: boolean;
 }
 
 export interface Zigbee2MQTTGroupOptions {
@@ -140,6 +141,7 @@ export interface Zigbee2MQTTSettings {
         update_check_interval: number;
         disable_automatic_update_check: boolean;
         zigbee_ota_override_index_location?: string;
+        image_block_request_timeout?: number;
         image_block_response_delay?: number;
         default_maximum_data_size?: number;
     };
@@ -599,51 +601,89 @@ export interface Zigbee2MQTTAPI {
 
     "bridge/request/device/ota_update/check": {
         id: string;
+        /** expected to point to an index json if provided */
+        url?: string;
     };
 
     "bridge/request/device/ota_update/check/downgrade": {
         id: string;
+        /** expected to point to an index json if provided */
+        url?: string;
     };
 
     "bridge/response/device/ota_update/check": {
         id: string;
         update_available: boolean;
+        source?: string;
+        release_notes?: string;
+        downgrade?: boolean;
     };
 
     "bridge/request/device/ota_update/update": {
         id: string;
+        url?: string;
+        /** full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`) */
+        hex?: string;
+        /** used in conjunction with `hex` */
+        fileName?: string;
+        image_block_request_timeout?: number;
+        image_block_response_delay?: number;
+        /** may be overridden internally to match specific device needs */
+        default_maximum_data_size?: number;
     };
 
     "bridge/request/device/ota_update/update/downgrade": {
         id: string;
+        url?: string;
+        /** full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`) */
+        hex?: string;
+        /** used in conjunction with `hex` */
+        fileName?: string;
+        image_block_request_timeout?: number;
+        image_block_response_delay?: number;
+        /** may be overridden internally to match specific device needs */
+        default_maximum_data_size?: number;
     };
 
     "bridge/response/device/ota_update/update": {
         id: string;
         from:
             | {
-                  software_build_id: string;
-                  date_code: string;
+                  file_version: number;
+                  software_build_id?: string;
+                  date_code?: string;
               }
             | undefined;
         to:
             | {
-                  software_build_id: string;
-                  date_code: string;
+                  file_version: number;
+                  software_build_id?: string;
+                  date_code?: string;
               }
             | undefined;
     };
 
     "bridge/request/device/ota_update/schedule": {
         id: string;
+        url?: string;
+        /** full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`) */
+        hex?: string;
+        /** used in conjunction with `hex` */
+        fileName?: string;
     };
 
     "bridge/request/device/ota_update/schedule/downgrade": {
         id: string;
+        url?: string;
+        /** full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`) */
+        hex?: string;
+        /** used in conjunction with `hex` */
+        fileName?: string;
     };
 
     "bridge/response/device/ota_update/schedule": {
         id: string;
+        url?: string;
     };
 
     "bridge/request/device/ota_update/unschedule": {

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -602,13 +602,13 @@ export interface Zigbee2MQTTAPI {
     "bridge/request/device/ota_update/check": {
         id: string;
         /** expected to point to an index json if provided */
-        url?: string;
+        url?: string | null;
     };
 
     "bridge/request/device/ota_update/check/downgrade": {
         id: string;
         /** expected to point to an index json if provided */
-        url?: string;
+        url?: string | null;
     };
 
     "bridge/response/device/ota_update/check": {
@@ -621,30 +621,30 @@ export interface Zigbee2MQTTAPI {
 
     "bridge/request/device/ota_update/update": {
         id: string;
-        url?: string;
+        url?: string | null;
         /**
          * Full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`)
          * If file name supplied, will be used instead of <ieee_utc> to store firmware in data dir.
          */
-        hex?: {data: string; file_name?: string};
-        image_block_request_timeout?: number;
-        image_block_response_delay?: number;
+        hex?: {data: string; file_name?: string} | null;
+        image_block_request_timeout?: number | null;
+        image_block_response_delay?: number | null;
         /** may be overridden internally to match specific device needs */
-        default_maximum_data_size?: number;
+        default_maximum_data_size?: number | null;
     };
 
     "bridge/request/device/ota_update/update/downgrade": {
         id: string;
-        url?: string;
+        url?: string | null;
         /**
          * Full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`)
          * If file name supplied, will be used instead of <ieee_utc> to store firmware in data dir.
          */
-        hex?: {data: string; file_name?: string};
-        image_block_request_timeout?: number;
-        image_block_response_delay?: number;
+        hex?: {data: string; file_name?: string} | null;
+        image_block_request_timeout?: number | null;
+        image_block_response_delay?: number | null;
         /** may be overridden internally to match specific device needs */
-        default_maximum_data_size?: number;
+        default_maximum_data_size?: number | null;
     };
 
     "bridge/response/device/ota_update/update": {
@@ -667,22 +667,22 @@ export interface Zigbee2MQTTAPI {
 
     "bridge/request/device/ota_update/schedule": {
         id: string;
-        url?: string;
+        url?: string | null;
         /**
          * Full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`)
          * If file name supplied, will be used instead of <ieee_utc> to store firmware in data dir.
          */
-        hex?: {data: string; file_name?: string};
+        hex?: {data: string; file_name?: string} | null;
     };
 
     "bridge/request/device/ota_update/schedule/downgrade": {
         id: string;
-        url?: string;
+        url?: string | null;
         /**
          * Full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`)
          * If file name supplied, will be used instead of <ieee_utc> to store firmware in data dir.
          */
-        hex?: {data: string; file_name?: string};
+        hex?: {data: string; file_name?: string} | null;
     };
 
     "bridge/response/device/ota_update/schedule": {

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -622,10 +622,11 @@ export interface Zigbee2MQTTAPI {
     "bridge/request/device/ota_update/update": {
         id: string;
         url?: string;
-        /** full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`) */
-        hex?: string;
-        /** used in conjunction with `hex` */
-        fileName?: string;
+        /**
+         * Full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`)
+         * If file name supplied, will be used instead of <ieee_utc> to store firmware in data dir.
+         */
+        hex?: {data: string; file_name?: string};
         image_block_request_timeout?: number;
         image_block_response_delay?: number;
         /** may be overridden internally to match specific device needs */
@@ -635,10 +636,11 @@ export interface Zigbee2MQTTAPI {
     "bridge/request/device/ota_update/update/downgrade": {
         id: string;
         url?: string;
-        /** full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`) */
-        hex?: string;
-        /** used in conjunction with `hex` */
-        fileName?: string;
+        /**
+         * Full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`)
+         * If file name supplied, will be used instead of <ieee_utc> to store firmware in data dir.
+         */
+        hex?: {data: string; file_name?: string};
         image_block_request_timeout?: number;
         image_block_response_delay?: number;
         /** may be overridden internally to match specific device needs */
@@ -666,19 +668,21 @@ export interface Zigbee2MQTTAPI {
     "bridge/request/device/ota_update/schedule": {
         id: string;
         url?: string;
-        /** full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`) */
-        hex?: string;
-        /** used in conjunction with `hex` */
-        fileName?: string;
+        /**
+         * Full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`)
+         * If file name supplied, will be used instead of <ieee_utc> to store firmware in data dir.
+         */
+        hex?: {data: string; file_name?: string};
     };
 
     "bridge/request/device/ota_update/schedule/downgrade": {
         id: string;
         url?: string;
-        /** full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`) */
-        hex?: string;
-        /** used in conjunction with `hex` */
-        fileName?: string;
+        /**
+         * Full firmware file in hex form (expected compatible with `Buffer.from(hex, "hex")`)
+         * If file name supplied, will be used instead of <ieee_utc> to store firmware in data dir.
+         */
+        hex?: {data: string; file_name?: string};
     };
 
     "bridge/response/device/ota_update/schedule": {

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -372,16 +372,14 @@
                     "description": "Timeout (in milliseconds) during OTA updates. You can increase this value if your device is requesting blocks too slowly.",
                     "default": 150000,
                     "minimum": 10000,
-                    "maximum": 2147483647,
-                    "requiresRestart": true
+                    "maximum": 2147483647
                 },
                 "image_block_response_delay": {
                     "type": "number",
                     "title": "Image block response delay",
                     "description": "Limits the rate of requests (in milliseconds) during OTA updates to reduce network congestion. You can increase this value if your network appears unstable during OTA.",
                     "default": 250,
-                    "minimum": 50,
-                    "requiresRestart": true
+                    "minimum": 50
                 },
                 "default_maximum_data_size": {
                     "type": "number",
@@ -389,8 +387,7 @@
                     "description": "The size of file chunks sent during an update (in bytes). Note: This value may get ignored for manufacturers that require specific values.",
                     "default": 50,
                     "minimum": 10,
-                    "maximum": 100,
-                    "requiresRestart": true
+                    "maximum": 100
                 }
             }
         },

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -366,6 +366,15 @@
                     "description": "Location of override OTA index file",
                     "examples": ["index.json"]
                 },
+                "image_block_request_timeout": {
+                    "type": "number",
+                    "title": "Image block request timeout",
+                    "description": "Timeout (in milliseconds) during OTA updates. You can increase this value if your device is requesting blocks too slowly.",
+                    "default": 150000,
+                    "minimum": 10000,
+                    "maximum": 2147483647,
+                    "requiresRestart": true
+                },
                 "image_block_response_delay": {
                     "type": "number",
                     "title": "Image block response delay",
@@ -930,6 +939,12 @@
                             "description": "Name of the device in Home Assistant"
                         }
                     }
+                },
+                "disable_automatic_update_check": {
+                    "type": "boolean",
+                    "title": "Disable automatic update check",
+                    "description": "Zigbee devices may request a firmware update, and do so frequently, causing Zigbee2MQTT to reach out to third party servers. If you disable these device initiated checks, you can still initiate a firmware update check manually.",
+                    "default": false
                 }
             },
             "required": ["friendly_name"]

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -82,6 +82,7 @@ export const defaults = {
     ota: {
         update_check_interval: 24 * 60,
         disable_automatic_update_check: false,
+        image_block_request_timeout: 150000,
         image_block_response_delay: 250,
         default_maximum_data_size: 50,
     },

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -10,7 +10,7 @@ import yaml from "./yaml";
 export {schemaJson};
 // When updating also update:
 // - https://github.com/Koenkk/zigbee2mqtt/blob/dev/data/configuration.example.yaml#L2
-export const CURRENT_VERSION = 4;
+export const CURRENT_VERSION = 5;
 /** NOTE: by order of priority, lower index is lower level (more important) */
 export const LOG_LEVELS: readonly string[] = ["error", "warning", "info", "debug"] as const;
 export type LogLevel = "error" | "warning" | "info" | "debug";

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -4086,6 +4086,8 @@ describe("Extension: Bridge", () => {
         fs.writeFileSync(path.join(data.mockDir, "ext_converters", "afile.js"), "test123");
         fs.mkdirSync(path.join(data.mockDir, "log"));
         fs.writeFileSync(path.join(data.mockDir, "log", "log.log"), "test123");
+        fs.mkdirSync(path.join(data.mockDir, "ota"));
+        fs.writeFileSync(path.join(data.mockDir, "ota", "my.ota"), "test123");
         fs.mkdirSync(path.join(data.mockDir, "ext_converters", "123"));
         fs.writeFileSync(path.join(data.mockDir, "ext_converters", "123", "myfile.js"), "test123");
         fs.symlinkSync(

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -322,6 +322,7 @@ describe("Extension: Bridge", () => {
                     ota: {
                         default_maximum_data_size: 50,
                         disable_automatic_update_check: false,
+                        image_block_request_timeout: 150000,
                         image_block_response_delay: 250,
                         update_check_interval: 1440,
                     },

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -3264,7 +3264,7 @@ describe("Extension: Bridge", () => {
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/bridge/response/device/interview",
-            stringify({data: {}, status: "error", error: "interview of 'bulb' (0x000b57fffec6a5b2) failed: Error: something went wrong"}),
+            stringify({data: {}, status: "error", error: "Interview of 'bulb' (0x000b57fffec6a5b2) failed: Error: something went wrong"}),
             {},
         );
     });

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -1272,7 +1272,7 @@ describe("Extension: OTAUpdate", () => {
         const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
         controller.state.set(device, {update: {progress: 100, remaining: 10, state: "updating"}});
         await resetExtension();
-        expect(controller.state.get(device)).toStrictEqual({update: {state: "available"}});
+        expect(controller.state.get(device)).toStrictEqual({update: {state: "idle"}});
     });
 
     it("[DEPRECATED] handles message as device id string", async () => {

--- a/test/mocks/data.ts
+++ b/test/mocks/data.ts
@@ -1,9 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-
 import stringify from "json-stable-stringify-without-jsonify";
 import tmp from "tmp";
-
+import {vi} from "vitest";
 import yaml from "../../lib/util/yaml";
 
 export const mockDir: string = tmp.dirSync().name;
@@ -278,6 +277,10 @@ export function stateExists(): boolean {
     return fs.existsSync(stateFile);
 }
 
+export function readState(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(stateFile, "utf8"));
+}
+
 const defaultState = {
     "0x000b57fffec6a5b2": {
         state: "ON",
@@ -297,8 +300,8 @@ export function getDefaultState(): typeof defaultState {
     return defaultState;
 }
 
-export function writeDefaultState(): void {
-    fs.writeFileSync(path.join(mockDir, "state.json"), stringify(defaultState));
+export function writeDefaultState(data: Record<string, unknown> = defaultState): void {
+    fs.writeFileSync(stateFile, stringify(data));
 }
 
 export function writeEmptyDatabase(): void {

--- a/test/mocks/logger.ts
+++ b/test/mocks/logger.ts
@@ -1,5 +1,5 @@
+import {vi} from "vitest";
 import type Transport from "winston-transport";
-
 import type {LogLevel} from "../../lib/util/settings";
 
 let level: LogLevel = "info";

--- a/test/settingsMigration.test.ts
+++ b/test/settingsMigration.test.ts
@@ -1,12 +1,13 @@
 // biome-ignore assist/source/organizeImports: import mocks first
-import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import * as data from "./mocks/data";
 
-import {existsSync, readFileSync, rmSync} from "node:fs";
+import {existsSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import objectAssignDeep from "object-assign-deep";
 import mockedData from "../lib/util/data";
 import * as settings from "../lib/util/settings";
 import * as settingsMigration from "../lib/util/settingsMigration";
+import path from "node:path";
 
 describe("Settings Migration", () => {
     beforeAll(() => {});
@@ -969,6 +970,26 @@ describe("Settings Migration", () => {
             delete (migratedState[1] as Record<string, unknown>).update;
 
             expect(data.readState()).toStrictEqual(migratedState);
+        });
+
+        it("handles errors gracefully", () => {
+            const consoleErrorSpy = vi.spyOn(console, "error");
+            writeFileSync(path.join(data.mockDir, "state.json"), "notjson", "utf8");
+
+            // @ts-expect-error workaround
+            const beforeSettings = objectAssignDeep.noMutate({}, settings.getPersistedSettings());
+            // @ts-expect-error workaround
+            const afterSettings = objectAssignDeep.noMutate({}, settings.getPersistedSettings());
+            afterSettings.version = 5;
+
+            expect(settings.getPersistedSettings()).toStrictEqual(beforeSettings);
+
+            settingsMigration.migrateIfNecessary();
+
+            const migratedSettings = settings.getPersistedSettings();
+            expect(migratedSettings).toStrictEqual(afterSettings);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to write state"));
+            expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("is not valid JSON"));
         });
     });
 });


### PR DESCRIPTION
## Design changes

- https://github.com/Koenkk/zigbee-herdsman/issues/1608
- requires https://github.com/Koenkk/zigbee-herdsman/pull/1612/
- Update API to match new features
- Merge Zigbee/MQTT triggered `update` logic into single function for consistency
- Rework OTA support check (from definition) to allow custom file/URL to always go through (`check`/`update`/`schedule`)
- Add from/to file versions to `update` response payload to avoid weirdness with swBuildId/dateCode often unavailable
- Add `latest_source` (URL/filesystem), `latest_release_notes` to OTA state payload
- Allow passing data settings (timings/sizes) per request to override settings
- Tweak the published OTA state based on return of `update` (clear `available` if `update` returned "no image")
- Add ability to `schedule` with custom URL/filesystem
- Add ability to send hex-formatted image to Z2M which will be automatically written to data dir (for use with `update` or `schedule`)
  - Should allow using plain file over MQTT/WS assuming properly formatted upstream (e.g. frontend)
  - _With limitation that MQTT/WS must allow payloads of sufficient size (though most cases should be <1MB)_

Due to MQTT request payloads still allowing simple string for OTA, it duplicates the code a bit for now (marked deprecated for 3.0).

@Koenkk 
- I'm thinking with this one, we might want to bump the settings version so we can trigger a migration to remove all cached OTA states?
- How do you prefer to deal with `null` source/release_notes in `#getEntityPublishPayload`? I'm hesitating between `null` or undefined so it's taken out on stringify.

TODO:
- [x] remove `restart` required from OTA data settings in schema
- [x] change hex writes to `ota` subdir of data dir
- [x] new tests for full coverage
- [x] https://github.com/Koenkk/zigbee-herdsman-converters/pull/11259
- [x] https://github.com/Koenkk/zigbee2mqtt.io/pull/4760