### PR TITLE
feat: transaction response API for device set/get commands

### DIFF
--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -10,6 +10,7 @@ import bind from "bind-decorator";
 import expressStaticGzip from "express-static-gzip";
 import finalhandler from "finalhandler";
 import stringify from "json-stable-stringify-without-jsonify";
+import type {IPublishPacket} from "mqtt";
 import WebSocket from "ws";
 
 import data from "../util/data";
@@ -174,7 +175,7 @@ export class Frontend extends Extension {
             if (!isBinary && data) {
                 const message = data.toString();
                 const {topic, payload} = JSON.parse(message);
-                this.mqtt.onMessage(`${this.mqttBaseTopic}/${topic}`, Buffer.from(stringify(payload)));
+                this.mqtt.onMessage(`${this.mqttBaseTopic}/${topic}`, Buffer.from(stringify(payload)), {qos: 0} as IPublishPacket);
             }
         });
 

--- a/lib/extension/frontend.ts
+++ b/lib/extension/frontend.ts
@@ -6,6 +6,7 @@ import {createServer as createSecureServer} from "node:https";
 import type {Socket} from "node:net";
 import {posix} from "node:path";
 import bind from "bind-decorator";
+import type {IPublishPacket} from "mqtt";
 import WebSocket from "ws";
 import data from "../util/data";
 import logger from "../util/logger";
@@ -164,7 +165,7 @@ export class Frontend extends Extension {
             if (!isBinary && data) {
                 const message = data.toString();
                 const {topic, payload} = JSON.parse(message);
-                this.mqtt.onMessage(`${this.mqttBaseTopic}/${topic}`, Buffer.from(stringify(payload)));
+                this.mqtt.onMessage(`${this.mqttBaseTopic}/${topic}`, Buffer.from(stringify(payload)), {qos: 0} as IPublishPacket);
             }
         });
 

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -12,7 +12,7 @@ import Extension from "./extension";
 let topicGetSetRegex: RegExp;
 // Used by `publish.test.ts` to reload regex when changing `mqtt.base_topic`.
 export const loadTopicGetSetRegex = (): void => {
-    topicGetSetRegex = new RegExp(`^${settings.get().mqtt.base_topic}/(?!bridge)(.+?)/(get|set)(?:/(.+))?$`);
+    topicGetSetRegex = new RegExp(`^${settings.get().mqtt.base_topic}/(?!bridge)(.+?)/(request/)?(get|set)(?:/(.+))?$`);
 };
 
 const STATE_VALUES: ReadonlyArray<string> = ["on", "off", "toggle", "open", "close", "stop", "lock", "unlock"];
@@ -23,6 +23,7 @@ interface ParsedTopic {
     endpoint: string | undefined;
     attribute: string;
     type: "get" | "set";
+    isRequest: boolean;
 }
 
 export default class Publish extends Extension {
@@ -49,11 +50,13 @@ export default class Publish extends Extension {
         }
 
         const deviceNameAndEndpoint = match[1];
-        const attribute = match[3];
+        const isRequest = match[2] !== undefined;
+        const type = match[3] as "get" | "set";
+        const attribute = match[4];
 
         // Now parse the device/group name, and endpoint name
         const entity = this.zigbee.resolveEntityAndEndpoint(deviceNameAndEndpoint);
-        return {ID: entity.ID, endpoint: entity.endpointID, type: match[2] as "get" | "set", attribute: attribute};
+        return {ID: entity.ID, endpoint: entity.endpointID, type, attribute, isRequest};
     }
 
     parseMessage(parsedTopic: ParsedTopic, data: eventdata.MQTTMessage): KeyValue | undefined {
@@ -129,6 +132,22 @@ export default class Publish extends Extension {
             return;
         }
 
+        // Extract and strip z2m_transaction before forwarding to converters
+        const z2mTransaction = parsedTopic.isRequest ? message.z2m_transaction : undefined;
+        if (message.z2m_transaction !== undefined) {
+            delete message.z2m_transaction;
+        }
+
+        // Ping: /request/ topic with empty payload after stripping z2m_transaction
+        if (parsedTopic.isRequest && Object.keys(message).length === 0) {
+            const response: KeyValue = {data: {}, status: "ok"};
+            if (z2mTransaction !== undefined) response.z2m_transaction = z2mTransaction;
+            await this.mqtt.publish(`${re.name}/response/${parsedTopic.type}`, stringify(response), {
+                clientOptions: {qos: /* v8 ignore next */ data.qos ?? 0, retain: false},
+            });
+            return;
+        }
+
         const device = re instanceof Device ? re.zh : undefined;
         const entitySettings = re.options;
         const entityState = this.state.get(re);
@@ -172,8 +191,14 @@ export default class Publish extends Extension {
         const endpointNames = re instanceof Device ? re.getEndpointNames() : [];
         const propertyEndpointRegex = new RegExp(`^(.*?)_(${endpointNames.join("|")})$`);
         let scenesChanged = false;
+        const responseData: KeyValue = {};
+        const supersededKeys: string[] = [];
+        const failedKeys: string[] = [];
 
+        // Future: send responses per attribute as each settles, rather than waiting for all.
+        // Currently, multi-attribute requests to sleepy devices block sequentially per attribute.
         for (const entry of entries) {
+            const originalKey = entry[0];
             let key = entry[0];
             const value = entry[1];
             let endpointName = parsedTopic.endpoint;
@@ -279,6 +304,14 @@ export default class Publish extends Extension {
                 logger.error(message);
                 // biome-ignore lint/style/noNonNullAssertion: always Error
                 logger.debug((error as Error).stack!);
+                if (parsedTopic.isRequest) {
+                    ((error as Error).message?.includes("Request superseded") ? supersededKeys : failedKeys).push(originalKey);
+                }
+            }
+
+            // Track result for response (set echoes requested value; get returns status only)
+            if (parsedTopic.isRequest && parsedTopic.type === "set" && !failedKeys.includes(originalKey) && !supersededKeys.includes(originalKey)) {
+                responseData[originalKey] = value;
             }
 
             usedConverters[endpointOrGroupID].push(converter);
@@ -286,6 +319,18 @@ export default class Publish extends Extension {
             if (!scenesChanged && converter.key) {
                 scenesChanged = converter.key.some((k) => SCENE_CONVERTER_KEYS.includes(k));
             }
+        }
+
+        if (parsedTopic.isRequest) {
+            const errorParts: string[] = [];
+            if (supersededKeys.length > 0) errorParts.push(`superseded:${supersededKeys.join(",")}`);
+            if (failedKeys.length > 0) errorParts.push(`failed:${failedKeys.join(",")}`);
+            const response: KeyValue =
+                errorParts.length > 0 ? {data: responseData, status: "error", error: errorParts.join("|")} : {data: responseData, status: "ok"};
+            if (z2mTransaction !== undefined) response.z2m_transaction = z2mTransaction;
+            await this.mqtt.publish(`${re.name}/response/${parsedTopic.type}`, stringify(response), {
+                clientOptions: {qos: /* v8 ignore next */ data.qos ?? 0, retain: false},
+            });
         }
 
         for (const [ID, payload] of Object.entries(toPublish)) {

--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import bind from "bind-decorator";
-import type {IClientOptions, IClientPublishOptions, MqttClient} from "mqtt";
+import type {IClientOptions, IClientPublishOptions, IPublishPacket, MqttClient} from "mqtt";
 import {connectAsync} from "mqtt";
 import type {Zigbee2MQTTAPI} from "./types/api";
 
@@ -179,11 +179,11 @@ export default class Mqtt {
         await this.subscribe(`${settings.get().mqtt.base_topic}/#`);
     }
 
-    @bind public onMessage(topic: string, message: Buffer): void {
+    @bind public onMessage(topic: string, message: Buffer, packet: IPublishPacket): void {
         // Since we subscribe to zigbee2mqtt/# we also receive the message we send ourselves, skip these.
         if (!this.publishedTopics.has(topic)) {
             logger.debug(() => `Received MQTT message on '${topic}' with data '${message.toString()}'`, NS);
-            this.eventBus.emitMQTTMessage({topic, message: message.toString()});
+            this.eventBus.emitMQTTMessage({topic, message: message.toString(), qos: /* v8 ignore next */ packet?.qos ?? 0});
         }
 
         if (this.republishRetainedTimer && topic === `${settings.get().mqtt.base_topic}/bridge/info`) {

--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import bind from "bind-decorator";
-import type {IClientOptions, IClientPublishOptions, MqttClient} from "mqtt";
+import type {IClientOptions, IClientPublishOptions, IPublishPacket, MqttClient} from "mqtt";
 import {connectAsync} from "mqtt";
 import type {Zigbee2MQTTAPI} from "./types/api";
 
@@ -184,11 +184,11 @@ export default class Mqtt {
         await this.subscribe(`${settings.get().mqtt.base_topic}/#`);
     }
 
-    @bind public onMessage(topic: string, message: Buffer): void {
+    @bind public onMessage(topic: string, message: Buffer, packet: IPublishPacket): void {
         // Since we subscribe to zigbee2mqtt/# we also receive the message we send ourselves, skip these.
         if (!this.publishedTopics.has(topic)) {
             logger.debug(() => `Received MQTT message on '${topic}' with data '${message.toString()}'`, NS);
-            this.eventBus.emitMQTTMessage({topic, message: message.toString()});
+            this.eventBus.emitMQTTMessage({topic, message: message.toString(), qos: /* v8 ignore next */ packet?.qos ?? 0});
         }
 
         if (this.republishRetainedTimer && topic === `${settings.get().mqtt.base_topic}/bridge/info`) {

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -47,7 +47,7 @@ declare global {
     namespace eventdata {
         type EntityRenamed = {entity: Device | Group; homeAssisantRename: boolean; from: string; to: string};
         type EntityRemoved = {entity: Device | Group; name: string};
-        type MQTTMessage = {topic: string; message: string};
+        type MQTTMessage = {topic: string; message: string; qos?: 0 | 1 | 2};
         type MQTTMessagePublished = {topic: string; payload: string; options: MqttPublishOptions};
         type StateChange = {
             entity: Device | Group;

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -50,7 +50,7 @@ declare global {
     namespace eventdata {
         type EntityRenamed = {entity: Device | Group; homeAssisantRename: boolean; from: string; to: string};
         type EntityRemoved = {entity: Device | Group; name: string};
-        type MQTTMessage = {topic: string; message: string};
+        type MQTTMessage = {topic: string; message: string; qos?: 0 | 1 | 2};
         type MQTTMessagePublished = {topic: string; payload: string; options: MqttPublishOptions};
         type StateChange = {
             entity: Device | Group;

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -761,7 +761,7 @@ describe("Controller", () => {
         await controller.start();
         mockLogger.debug.mockClear();
         await mockMQTTEvents.message("dummytopic", "dummymessage");
-        expect(spyEventbusEmitMQTTMessage).toHaveBeenCalledWith({topic: "dummytopic", message: "dummymessage"});
+        expect(spyEventbusEmitMQTTMessage).toHaveBeenCalledWith({topic: "dummytopic", message: "dummymessage", qos: 0});
         expect(mockLogger.log).toHaveBeenCalledWith("debug", "Received MQTT message on 'dummytopic' with data 'dummymessage'", LOG_MQTT_NS);
     });
 
@@ -771,7 +771,7 @@ describe("Controller", () => {
         await controller.start();
         mockLogger.debug.mockClear();
         await mockMQTTEvents.message("zigbee2mqtt/skip-this-topic", "skipped");
-        expect(spyEventbusEmitMQTTMessage).toHaveBeenCalledWith({topic: "zigbee2mqtt/skip-this-topic", message: "skipped"});
+        expect(spyEventbusEmitMQTTMessage).toHaveBeenCalledWith({topic: "zigbee2mqtt/skip-this-topic", message: "skipped", qos: 0});
         mockLogger.debug.mockClear();
         await controller.mqtt.publish("skip-this-topic", "", {});
         await mockMQTTEvents.message("zigbee2mqtt/skip-this-topic", "skipped");

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -763,7 +763,7 @@ describe("Controller", () => {
         await controller.start();
         mockLogger.debug.mockClear();
         await mockMQTTEvents.message("dummytopic", "dummymessage");
-        expect(spyEventbusEmitMQTTMessage).toHaveBeenCalledWith({topic: "dummytopic", message: "dummymessage"});
+        expect(spyEventbusEmitMQTTMessage).toHaveBeenCalledWith({topic: "dummytopic", message: "dummymessage", qos: 0});
         expect(mockLogger.log).toHaveBeenCalledWith("debug", "Received MQTT message on 'dummytopic' with data 'dummymessage'", LOG_MQTT_NS);
     });
 
@@ -773,7 +773,7 @@ describe("Controller", () => {
         await controller.start();
         mockLogger.debug.mockClear();
         await mockMQTTEvents.message("zigbee2mqtt/skip-this-topic", "skipped");
-        expect(spyEventbusEmitMQTTMessage).toHaveBeenCalledWith({topic: "zigbee2mqtt/skip-this-topic", message: "skipped"});
+        expect(spyEventbusEmitMQTTMessage).toHaveBeenCalledWith({topic: "zigbee2mqtt/skip-this-topic", message: "skipped", qos: 0});
         mockLogger.debug.mockClear();
         await controller.mqtt.publish("skip-this-topic", "", {});
         await mockMQTTEvents.message("zigbee2mqtt/skip-this-topic", "skipped");


### PR DESCRIPTION
Closes #30679

## What

Adds request/response support for device commands, mirroring the existing bridge pattern ([docs](https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html#zigbee2mqtt-bridge-request)).

- `zigbee2mqtt/FRIENDLY_NAME/request/set` → response on `zigbee2mqtt/FRIENDLY_NAME/response/set`
- `zigbee2mqtt/FRIENDLY_NAME/request/get` → response on `zigbee2mqtt/FRIENDLY_NAME/response/get`
- Existing `/set` and `/get` topics are unchanged — fully backward compatible

## Response shape

### `/response/set` — echoes requested values

Success:
```json
{"data": {"state": "ON", "brightness": 200}, "status": "ok", "z2m_transaction": "my-id"}
```

Error (`error` is human-readable; `error_details` maps each failed attribute to the original error message):
```json
{"data": {}, "status": "error", "error": "Failed to set 'brightness': Request superseded", "error_details": {"brightness": "Request superseded"}, "z2m_transaction": "my-id"}
```

Partial success (attributes that were accepted are still echoed in `data`):
```json
{"data": {"color_temp_startup": 300}, "status": "error", "error": "Failed to set 'brightness': Request superseded", "error_details": {"brightness": "Request superseded"}, "z2m_transaction": "my-id"}
```

`data` echoes the values from the request, not from the device or cache. It confirms what was accepted, not current device state.

### `/response/get` — status only, no data

```json
{"data": {}, "status": "ok", "z2m_transaction": "my-id"}
```

GET responses deliberately omit data values. Actual device values arrive on the state topic (`zigbee2mqtt/FRIENDLY_NAME`), which is the authoritative source. This avoids a race condition where the state cache may not yet be updated when the response is built.

### Common fields

- `z2m_transaction` — optional, echoed back if provided in request
- `error` — human-readable summary, same style as the bridge API
- `error_details` — `{attribute: original error message}` for every failed attribute; original messages are passed through unchanged (e.g. herdsman's `Request superseded` when a newer command replaced a queued one on a sleepy device)
- QoS of response matches request QoS
- `retain: false` (responses are events, not state)
- Ping: send `{"z2m_transaction": "ping1"}` (or `{}`) to `/request/set` → `{"data": {}, "status": "ok"}`

## Why `z2m_transaction` instead of `transaction`

The bridge uses `transaction`. We use `z2m_transaction` because CSM-300ZB has a real device attribute called `transaction` (shinasystem.js). A flat `transaction` field would collide.

## Diff

```
 lib/extension/publish.ts   | +63 (regex, ParsedTopic.isRequest, response logic, per-attribute error tracking)
 lib/mqtt.ts                | +3  (QoS propagation through event system)
 lib/extension/frontend.ts  | +2  (QoS for WebSocket messages)
 lib/types/types.d.ts       | +1  (qos field on MQTTMessage event)
 package.json               | +1  (zigbee-herdsman 9.0.2 → 9.0.6 for superseded error)
 test/extensions/publish.ts | +172 (14 tests covering all response branches)
 test/controller.test.ts    | +2/-2 (update existing tests for qos field)
```

## Test plan

- [x] 14 unit tests covering all response branches (set success, get status-only, errors, partial success, shared-converter keys, ping, groups, QoS, endpoint/attribute topics)
- [x] 834 tests pass, 0 failures
- [x] Biome lint clean
- [x] Manual testing with mains and sleepy devices


## Frontend branches (windfront)

The earlier windfront PR (Nerivec/zigbee2mqtt-windfront#409) was closed as stale while this backend PR awaits review. A windfront PR will be opened once this is merged. Until then, both branches are kept rebased on current windfront `main` and can be used to test against this PR:

- **Minimal (WebSocket plumbing only):** https://github.com/rusty-art/zigbee2mqtt-windfront/tree/main
- **Full implementation (visual feedback — pending/success/error indicators, sleepy-device support, retry on failure):** https://github.com/rusty-art/zigbee2mqtt-windfront/tree/transaction-response-api

### Testing together
- Backend: this PR — publishes structured responses on `<device>/response/set` and `<device>/response/get`
- Frontend: the `transaction-response-api` branch above — consumes responses to show real-time command status

