### PR TITLE
fix: Home Assistant: Use `temperature_delta` for calibration

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -696,9 +696,8 @@ export class HomeAssistant extends Extension {
                             command_topic: true,
                             command_topic_prefix: endpoint,
                             command_topic_postfix: tempCalibration.property,
-                            device_class: "temperature",
+                            device_class: "temperature_delta",
                             entity_category: "config",
-                            icon: "mdi:math-compass",
                             ...(tempCalibration.unit && {unit_of_measurement: tempCalibration.unit}),
                         },
                     };


### PR DESCRIPTION
About a year ago, HA introduced a new `device_class` specifically for temperature offset/calibration. It's called `temperature_delta` and should be used instead of just `temperature` where appropriate.

This _hopefully_ will improve UX and avoid confusion when creating automations.

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/30702