### PR TITLE
feat: Home Assistant: Discover temperature sensor for thermostats

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -760,7 +760,9 @@ export class HomeAssistant extends Extension {
                 }
 
                 const temperatureSensor = allExposes?.filter(isNumericExpose).find((e) => e.name === "temperature" && e.access & ACCESS_STATE);
-                const localTemperatureSensor = allExposes?.filter(isNumericExpose).find((e) => e.name === "local_temperature" && e.access & ACCESS_STATE);
+                const localTemperatureSensor = allExposes
+                    ?.filter(isNumericExpose)
+                    .find((e) => e.name === "local_temperature" && e.access & ACCESS_STATE);
                 if (temperature && !temperatureSensor && !localTemperatureSensor) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "sensor",
@@ -769,9 +771,9 @@ export class HomeAssistant extends Extension {
                         discovery_payload: {
                             name: endpoint ? `${temperature.label} ${endpoint}` : temperature.label,
                             value_template: `{{ value_json.${temperature.property} }}`,
+                            ...(temperature.unit && {unit_of_measurement: temperature.unit}),
                             device_class: "temperature",
                             state_class: "measurement",
-                            ...(temperature.unit && {unit_of_measurement: temperature.unit}),
                         },
                     };
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -759,19 +759,20 @@ export class HomeAssistant extends Extension {
                     discoveryEntries.push(discoveryEntry);
                 }
 
+                const localTemperature = (firstExpose as zhc.Climate).features.filter(isNumericExpose).find((f) => f.name === "local_temperature");
                 const temperatureSensor = allExposes?.filter(isNumericExpose).find((e) => e.name === "temperature" && e.access & ACCESS_STATE);
                 const localTemperatureSensor = allExposes
                     ?.filter(isNumericExpose)
                     .find((e) => e.name === "local_temperature" && e.access & ACCESS_STATE);
-                if (temperature && !temperatureSensor && !localTemperatureSensor) {
+                if (localTemperature && !temperatureSensor && !localTemperatureSensor) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "sensor",
-                        object_id: endpoint ? `${temperature.name}_${endpoint}` : `${temperature.name}`,
-                        mockProperties: [{property: temperature.property, value: null}],
+                        object_id: endpoint ? `${localTemperature.name}_${endpoint}` : `${localTemperature.name}`,
+                        mockProperties: [{property: localTemperature.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${temperature.label} ${endpoint}` : temperature.label,
-                            value_template: `{{ value_json.${temperature.property} }}`,
-                            ...(temperature.unit && {unit_of_measurement: temperature.unit}),
+                            name: endpoint ? `${localTemperature.label} ${endpoint}` : localTemperature.label,
+                            value_template: `{{ value_json.${localTemperature.property} }}`,
+                            ...(localTemperature.unit && {unit_of_measurement: localTemperature.unit}),
                             device_class: "temperature",
                             state_class: "measurement",
                         },

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -759,6 +759,25 @@ export class HomeAssistant extends Extension {
                     discoveryEntries.push(discoveryEntry);
                 }
 
+                const temperatureSensor = allExposes?.filter(isNumericExpose).find((e) => e.name === "temperature" && e.access & ACCESS_STATE);
+                const localTemperatureSensor = allExposes?.filter(isNumericExpose).find((e) => e.name === "local_temperature" && e.access & ACCESS_STATE);
+                if (temperature && !temperatureSensor && !localTemperatureSensor) {
+                    const discoveryEntry: DiscoveryEntry = {
+                        type: "sensor",
+                        object_id: endpoint ? `${temperature.name}_${endpoint}` : `${temperature.name}`,
+                        mockProperties: [{property: temperature.property, value: null}],
+                        discovery_payload: {
+                            name: endpoint ? `${temperature.label} ${endpoint}` : temperature.label,
+                            value_template: `{{ value_json.${temperature.property} }}`,
+                            device_class: "temperature",
+                            state_class: "measurement",
+                            ...(temperature.unit && {unit_of_measurement: temperature.unit}),
+                        },
+                    };
+
+                    discoveryEntries.push(discoveryEntry);
+                }
+
                 const currentHumidity = allExposes?.filter(isNumericExpose).find((e) => e.name === "humidity" && e.access & ACCESS_STATE);
                 if (currentHumidity) {
                     discoveryEntry.discovery_payload.current_humidity_template = `{{ value_json.${currentHumidity.property} }}`;

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1268,7 +1268,6 @@ describe("Extension: HomeAssistant", () => {
             unique_id: "0x18fc2600000d7ae3_local_temperature_zigbee2mqtt",
             unit_of_measurement: "°C",
             value_template: "{{ value_json.local_temperature }}",
-            unique_id: "0x18fc2600000d7ae3_climate_zigbee2mqtt",
         };
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("homeassistant/sensor/0x18fc2600000d7ae3/local_temperature/config", stringify(payload), {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1248,6 +1248,35 @@ describe("Extension: HomeAssistant", () => {
         });
     });
 
+    it("Should discover seperate temperature sensor for thermostat", () => {
+        const payload = {
+            availability: [{topic: "zigbee2mqtt/bridge/state", value_template: "{{ value_json.state }}"}],
+            default_entity_id: "sensor.bosch_rm230z_local_temperature",
+            device: {
+                identifiers: ["zigbee2mqtt_0x18fc2600000d7ae3"],
+                manufacturer: "Bosch",
+                model: "Room thermostat II 230V",
+                model_id: "BTH-RM230Z",
+                name: "bosch_rm230z",
+                via_device: "zigbee2mqtt_bridge_0x00124b00120144ae",
+            },
+            device_class: "temperature",
+            object_id: "bosch_rm230z_local_temperature",
+            origin,
+            state_class: "measurement",
+            state_topic: "zigbee2mqtt/bosch_rm230z",
+            unique_id: "0x18fc2600000d7ae3_local_temperature_zigbee2mqtt",
+            unit_of_measurement: "°C",
+            value_template: "{{ value_json.local_temperature }}",
+            unique_id: "0x18fc2600000d7ae3_climate_zigbee2mqtt",
+        };
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("homeassistant/sensor/0x18fc2600000d7ae3/local_temperature/config", stringify(payload), {
+            qos: 1,
+            retain: true,
+        });
+    });
+
     it("Should discover devices with cover_position", () => {
         let payload;
 


### PR DESCRIPTION
According to the [HA folks](https://github.com/home-assistant/frontend/discussions/24948#discussioncomment-12844085), it's current best practice to expose/discover an additional temperature sensor for each thermostat because the `current_temperature` attribute of `climate` entities is **not** kept for long-term statistics.

By implementing this using the `homeassistant.ts` extension, we avoid exposing _fake_ sensors to other ecosystems while still improving the UX for HA users. 😊

Fixes https://github.com/Koenkk/zigbee2mqtt/issues/29686