### PR TITLE
fix: Home Assistant: Change `device_class` of `eco2` to `volatile_organic_compounds_parts`

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -154,7 +154,7 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     },
     distance: {device_class: "distance", state_class: "measurement"},
     duration: {entity_category: "config", icon: "mdi:timer"},
-    eco2: {device_class: "carbon_dioxide", state_class: "measurement"},
+    eco2: {device_class: "volatile_organic_compounds_parts", state_class: "measurement"},
     eco_temperature: {entity_category: "config", icon: "mdi:thermometer"},
     energy: {device_class: "energy", state_class: "total_increasing"},
     external_temperature_input: {device_class: "temperature", icon: "mdi:thermometer"},


### PR DESCRIPTION
In general, eCO2 is simply a TVOC-derived value and should absolutely **not** be treated as CO2 concentration.
This can potentially be dangerous when used in safety-critical automations.

All of these eCO2/TVOC sensors actually can't measure CO2 levels but instead relative TVOC levels expressed as _CO2-equivalent_ calculated by a proprietary algorithm.

More details https://github.com/Koenkk/zigbee-herdsman-converters/pull/11204#issuecomment-3717740841


Related to https://github.com/Koenkk/zigbee-herdsman-converters/pull/11410