### PR TITLE
feat: Home Assistant: add siren entity for IAS warning devices

### DIFF
--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -944,6 +944,45 @@ describe("Extension: HomeAssistant", () => {
         });
     });
 
+    it("Should discover siren (HS2WD-E)", () => {
+        const payload = {
+            available_tones: ["emergency"],
+            support_duration: true,
+            optimistic: true,
+            command_topic: "zigbee2mqtt/siren/set",
+            command_template:
+                '{"warning": {"mode": "{{ tone | default(\'emergency\') }}", ' +
+                '"level": "' +
+                "{% if volume_level is defined %}" +
+                "{% if volume_level | float <= 0.25 %}low" +
+                "{% elif volume_level | float <= 0.5 %}medium" +
+                "{% elif volume_level | float <= 0.75 %}high" +
+                "{% else %}very_high{% endif %}" +
+                '{% else %}medium{% endif %}", ' +
+                '"duration": {{ duration | default(10) }}}}',
+            command_off_template: '{"warning": {"mode": "stop"}}',
+            name: null,
+            object_id: "siren",
+            default_entity_id: "siren.siren",
+            unique_id: "0x0017880104e45549_siren_zigbee2mqtt",
+            origin: origin,
+            device: {
+                identifiers: ["zigbee2mqtt_0x0017880104e45549"],
+                name: "siren",
+                model: "Smart siren",
+                model_id: "HS2WD-E",
+                manufacturer: "Heiman",
+                via_device: "zigbee2mqtt_bridge_0x00124b00120144ae",
+            },
+            availability: [{topic: "zigbee2mqtt/bridge/state", value_template: "{{ value_json.state }}"}],
+        };
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("homeassistant/siren/0x0017880104e45549/siren/config", stringify(payload), {
+            retain: true,
+            qos: 1,
+        });
+    });
+
     it("Should discover devices with speed-controlled fan", () => {
         const payload = {
             state_topic: "zigbee2mqtt/fanbee",


### PR DESCRIPTION
Closes #28142

## What's the problem?

IAS Warning Devices (e.g. SIRZB-110, SIRZB-111, HS2WD-E) are completely invisible in Home Assistant — they show up in Z2M but you can't do anything with them in HA other than manually sending MQTT messages.

## What does this PR do?

Since the `warning` composite expose isn't handled by the HA extension, I went with creating a new siren entity that gets auto-discovered by HA. This way, the warning settings (tone, volume, duration) are accessible in HA and not just in Z2M.

- **Tones**: Extracted from the `mode` enum feature (excluding `stop`)
- **Volume**: HA float (0–1) mapped via Jinja2 template to Z2M levels (`low` / `medium` / `high` / `very_high`)
- **Duration**: Passed through directly (seconds)
- **Optimistic**: `true` — warning is write-only, no state feedback from the device
- **Turn off**: Sends `{"warning": {"mode": "stop"}}`

## Testing

- [x] Added siren discovery test for HS2WD-E mock device
- [x] Full test suite passes with 100% code coverage
- [x] Lint/format clean, build succeeds
- [x] Manually tested end-to-end on a real SIRZB-111 by injecting the built `homeassistant.js` into a running Z2M add-on instance. Siren entity appeared in HA and was controllable via `siren.turn_on` / `siren.turn_off` with tone, volume, and duration parameters.

With this change, you can control the siren like this in HA automations:
```yaml
actions:
  - action: siren.turn_on
    data:
      tone: burglar
      volume_level: 1
      duration: "3"
    target:
      entity_id: siren.sirene_name
```

If something doesn't fit the project's standards or if you like that I change something — just let me know, happy to adjust!