### PR TITLE
fix: improve startup signals behavior

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -117,21 +117,24 @@ export class Controller {
                 });
             }
         } catch (error) {
-            logger.error("Failed to start zigbee-herdsman");
-            logger.error(
-                "Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.html for possible solutions",
-            );
-            logger.error("Exiting...");
-            // biome-ignore lint/style/noNonNullAssertion: always Error
-            logger.error((error as Error).stack!);
+            // skip if aborted by `stop`
+            if (error !== "SIGINT" && error !== "SIGTERM" && error !== "STOPABORT") {
+                logger.error("Failed to start zigbee-herdsman");
+                logger.error(
+                    "Check https://www.zigbee2mqtt.io/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.html for possible solutions",
+                );
+                logger.error("Exiting...");
+                // biome-ignore lint/style/noNonNullAssertion: always Error
+                logger.error((error as Error).stack!);
 
-            /* v8 ignore start */
-            if ((error as Error).message.includes("USB adapter discovery error (No valid USB adapter found)")) {
-                logger.error("If this happens after updating to Zigbee2MQTT 2.0.0, see https://github.com/Koenkk/zigbee2mqtt/discussions/24364");
+                /* v8 ignore start */
+                if ((error as Error).message.includes("USB adapter discovery error (No valid USB adapter found)")) {
+                    logger.error("If this happens after updating to Zigbee2MQTT 2.0.0, see https://github.com/Koenkk/zigbee2mqtt/discussions/24364");
+                }
+                /* v8 ignore stop */
+
+                return await this.exit(1);
             }
-            /* v8 ignore stop */
-
-            return await this.exit(1);
         }
 
         if (abortSignal.aborted) {

--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -28,6 +28,8 @@ import utils from "./util/utils";
 import Zigbee from "./zigbee";
 
 export class Controller {
+    /** Allows canceling in-progress startup sequence if necessary. Signal can be passed to long-running ops as necessary for finer control. */
+    #startAbortController: AbortController | undefined;
     public readonly eventBus: EventBus;
     public readonly zigbee: Zigbee;
     public readonly state: State;
@@ -79,6 +81,9 @@ export class Controller {
     }
 
     async start(): Promise<void> {
+        this.#startAbortController = new AbortController();
+        const abortSignal = this.#startAbortController.signal;
+
         if (settings.get().frontend.enabled) {
             const {Frontend} = await import("./extension/frontend.js");
 
@@ -93,17 +98,24 @@ export class Controller {
 
         this.state.start();
 
+        if (abortSignal.aborted) {
+            logger.info(`Zigbee2MQTT start aborted, reason=${abortSignal.reason}`);
+            return;
+        }
+
         const info = await utils.getZigbee2MQTTVersion();
         logger.info(`Starting Zigbee2MQTT version ${info.version} (commit #${info.commitHash})`);
 
         // Start zigbee
         try {
-            await this.zigbee.start();
+            const started = await this.zigbee.start(abortSignal);
 
-            this.eventBus.onAdapterDisconnected(this, async () => {
-                logger.error("Adapter disconnected, stopping");
-                await this.stop(false, 2);
-            });
+            if (started) {
+                this.eventBus.onAdapterDisconnected(this, async () => {
+                    logger.error("Adapter disconnected, stopping");
+                    await this.stop(false, 2);
+                });
+            }
         } catch (error) {
             logger.error("Failed to start zigbee-herdsman");
             logger.error(
@@ -120,6 +132,11 @@ export class Controller {
             /* v8 ignore stop */
 
             return await this.exit(1);
+        }
+
+        if (abortSignal.aborted) {
+            logger.info(`Zigbee2MQTT start aborted, reason=${abortSignal.reason}`);
+            return;
         }
 
         // Log zigbee clients on startup
@@ -147,9 +164,19 @@ export class Controller {
             return await this.exit(1);
         }
 
+        if (abortSignal.aborted) {
+            logger.info(`Zigbee2MQTT start aborted, reason=${abortSignal.reason}`);
+            return;
+        }
+
         // copy current Set of extensions to ignore possible external extensions added while looping
         for (const extension of new Set(this.extensions)) {
             await this.startExtension(extension);
+
+            if (abortSignal.aborted) {
+                logger.info(`Zigbee2MQTT start aborted, reason=${abortSignal.reason}`);
+                return;
+            }
         }
 
         // Send all cached states.
@@ -157,6 +184,11 @@ export class Controller {
             for (const entity of this.zigbee.devicesAndGroupsIterator()) {
                 if (this.state.exists(entity)) {
                     await this.publishEntityState(entity, this.state.get(entity), "publishCached");
+
+                    if (abortSignal.aborted) {
+                        logger.info(`Zigbee2MQTT start aborted, reason=${abortSignal.reason}`);
+                        return;
+                    }
                 }
             }
         }
@@ -170,6 +202,8 @@ export class Controller {
         this.sdNotify = await initSdNotify();
 
         settings.setOnboarding(false);
+
+        this.#startAbortController = undefined; // gc
     }
 
     @bind async enableDisableExtension(enable: boolean, name: string): Promise<void> {
@@ -287,7 +321,10 @@ export class Controller {
         }
     }
 
-    async stop(restart = false, code = 0): Promise<void> {
+    async stop(restart = false, code = 0, signal: NodeJS.Signals | undefined = undefined): Promise<void> {
+        logger.info(`Stopping Zigbee2MQTT (restart=${restart}, code=${code}, signal=${signal})`);
+
+        this.#startAbortController?.abort(signal ?? "STOPABORT");
         this.sdNotify?.notifyStopping();
 
         let localCode = 0;

--- a/lib/extension/onEvent.ts
+++ b/lib/extension/onEvent.ts
@@ -61,8 +61,11 @@ export default class OnEvent extends Extension {
     override async stop(): Promise<void> {
         await super.stop();
 
-        for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
-            await this.callOnEvent(device, {type: "stop", data: {ieeeAddr: device.ieeeAddr}});
+        // ensure properly started, else this throws undesired errors (e.g. SIGINT during startup)
+        if (this.zigbee.zhController !== undefined) {
+            for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
+                await this.callOnEvent(device, {type: "stop", data: {ieeeAddr: device.ieeeAddr}});
+            }
         }
     }
 

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -51,11 +51,14 @@ class State {
     }
 
     stop(): void {
-        // Remove any invalid states (ie when the device has left the network) when the system is stopped
-        for (const [key] of this.state) {
-            if (typeof key === "string" && key.startsWith("0x") && !this.zigbee.resolveEntity(key)) {
-                // string key = ieeeAddr
-                this.state.delete(key);
+        // ensure properly started, else this throws undesired errors (e.g. SIGINT during startup)
+        if (this.zigbee.zhController !== undefined) {
+            // Remove any invalid states (ie when the device has left the network) when the system is stopped
+            for (const [key] of this.state) {
+                if (typeof key === "string" && key.startsWith("0x") && !this.zigbee.resolveEntity(key)) {
+                    // string key = ieeeAddr
+                    this.state.delete(key);
+                }
             }
         }
 

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -28,7 +28,7 @@ export default class Zigbee {
         return this.#herdsman;
     }
 
-    async start(): Promise<StartResult> {
+    async start(abortSignal: AbortSignal): Promise<boolean> {
         const infoHerdsman = await utils.getDependencyVersion("zigbee-herdsman");
         logger.info(`Starting zigbee-herdsman (${infoHerdsman.version})`);
         const panId = settings.get().advanced.pan_id;
@@ -67,14 +67,23 @@ export default class Zigbee {
         let startResult: StartResult;
         try {
             this.#herdsman = new Controller(herdsmanSettings);
+            // TODO: pass abortSignal
             startResult = await this.#herdsman.start();
         } catch (error) {
             logger.error("Error while starting zigbee-herdsman");
             throw error;
         }
 
+        if (abortSignal.aborted) {
+            return false;
+        }
+
         this.coordinatorIeeeAddr = this.#herdsman.getDevicesByType("Coordinator")[0].ieeeAddr;
-        await this.resolveDevicesDefinitions();
+        await this.resolveDevicesDefinitions(false, abortSignal);
+
+        if (abortSignal.aborted) {
+            return false;
+        }
 
         this.#herdsman.on("adapterDisconnected", () => this.eventBus.emitAdapterDisconnected());
         this.#herdsman.on("lastSeenChanged", (data: ZHEvents.LastSeenChangedPayload) => {
@@ -134,30 +143,49 @@ export default class Zigbee {
         logger.info(`Coordinator firmware version: '${stringify(await this.getCoordinatorVersion())}'`);
         logger.debug(`Zigbee network parameters: ${stringify(await this.#herdsman.getNetworkParameters())}`);
 
-        for (const device of this.devicesIterator(utils.deviceNotCoordinator)) {
-            // If a passlist is used, all other device will be removed from the network.
-            const passlist = settings.get().passlist;
-            const blocklist = settings.get().blocklist;
-            const remove = async (device: Device): Promise<void> => {
-                try {
-                    await device.zh.removeFromNetwork();
-                } catch (error) {
-                    logger.error(`Failed to remove '${device.ieeeAddr}' (${(error as Error).message})`);
-                }
-            };
+        if (abortSignal.aborted) {
+            return false;
+        }
 
-            if (passlist.length > 0) {
+        const remove = async (device: Device): Promise<void> => {
+            try {
+                await device.zh.removeFromNetwork();
+            } catch (error) {
+                logger.error(`Failed to remove '${device.ieeeAddr}' (${(error as Error).message})`);
+            }
+        };
+        // If a passlist is used, all other device will be removed from the network.
+        const passlist = settings.get().passlist;
+
+        if (passlist.length > 0) {
+            for (const device of this.devicesIterator(utils.deviceNotCoordinator)) {
                 if (!passlist.includes(device.ieeeAddr)) {
-                    logger.warning(`Device not on passlist currently connected (${device.ieeeAddr}), removing...`);
+                    logger.warning(`Device not on passlist currently on the network (${device.ieeeAddr}), removing...`);
                     await remove(device);
+
+                    if (abortSignal.aborted) {
+                        return false;
+                    }
                 }
-            } else if (blocklist.includes(device.ieeeAddr)) {
-                logger.warning(`Device on blocklist currently connected (${device.ieeeAddr}), removing...`);
-                await remove(device);
+            }
+        } else {
+            for (const ieee of settings.get().blocklist) {
+                const device = this.resolveDevice(ieee);
+
+                if (device) {
+                    logger.warning(`Device on blocklist currently on the network (${device.ieeeAddr}), removing...`);
+                    await remove(device);
+
+                    if (abortSignal.aborted) {
+                        return false;
+                    }
+                } else {
+                    logger.debug(`Ignoring blocklist device ${ieee}, not currently on the network`);
+                }
             }
         }
 
-        return startResult;
+        return true;
     }
 
     private logDeviceInterview(data: eventdata.DeviceInterview): void {
@@ -224,7 +252,7 @@ export default class Zigbee {
 
     async stop(): Promise<void> {
         logger.info("Stopping zigbee-herdsman...");
-        await this.#herdsman.stop();
+        await this.#herdsman?.stop(); // could be undefined if this is called during startup (abort)
         logger.info("Stopped zigbee-herdsman");
     }
 
@@ -246,9 +274,13 @@ export default class Zigbee {
         await this.#herdsman.permitJoin(time, device?.zh);
     }
 
-    async resolveDevicesDefinitions(ignoreCache = false): Promise<void> {
+    async resolveDevicesDefinitions(ignoreCache = false, abortSignal: AbortSignal | undefined = undefined): Promise<void> {
         for (const device of this.devicesIterator(utils.deviceNotCoordinator)) {
             await device.resolveDefinition(ignoreCache);
+
+            if (abortSignal?.aborted) {
+                return;
+            }
         }
     }
 

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -67,15 +67,10 @@ export default class Zigbee {
         let startResult: StartResult;
         try {
             this.#herdsman = new Controller(herdsmanSettings);
-            // TODO: pass abortSignal
-            startResult = await this.#herdsman.start();
+            startResult = await this.#herdsman.start(abortSignal);
         } catch (error) {
             logger.error("Error while starting zigbee-herdsman");
             throw error;
-        }
-
-        if (abortSignal.aborted) {
-            return false;
         }
 
         this.coordinatorIeeeAddr = this.#herdsman.getDevicesByType("Coordinator")[0].ieeeAddr;

--- a/lib/zigbee.ts
+++ b/lib/zigbee.ts
@@ -173,6 +173,10 @@ export default class Zigbee {
                 const device = this.resolveDevice(ieee);
 
                 if (device) {
+                    if (device.zh.type === "Coordinator") {
+                        continue;
+                    }
+
                     logger.warning(`Device on blocklist currently on the network (${device.ieeeAddr}), removing...`);
                     await remove(device);
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -323,11 +323,13 @@ describe("Controller", () => {
     });
 
     it("Should remove device on blocklist on startup", async () => {
-        settings.set(["blocklist"], [devices.bulb_color.ieeeAddr]);
+        settings.set(["blocklist"], [devices.bulb_color.ieeeAddr, "0x9998889998889990"]);
         await controller.start();
         await flushPromises();
         expect(devices.bulb_color.removeFromNetwork).toHaveBeenCalledTimes(1);
         expect(devices.bulb.removeFromNetwork).toHaveBeenCalledTimes(0);
+        const debugCalls = mockLogger.debug.mock.calls.map((c) => (typeof c[0] === "string" ? c[0] : c[0]()));
+        expect(debugCalls.find((v) => v === "Ignoring blocklist device 0x9998889998889990, not currently on the network")).toBeDefined();
     });
 
     it("Start controller fails", async () => {
@@ -407,6 +409,256 @@ describe("Controller", () => {
         expect(mockUnixDgramSend).toHaveBeenCalledTimes(2);
 
         delete process.env.NOTIFY_SOCKET;
+    });
+
+    describe("aborts during startup", () => {
+        let stateStartSpy: MockInstance<() => void>;
+        let zigbeeStartSpy: MockInstance<() => Promise<boolean>>;
+        let mqttConnectSpy: MockInstance<() => Promise<void>>;
+        let extensionStartSpy: MockInstance<() => Promise<void>>;
+        let publishEntityStateSpy: MockInstance<() => Promise<void>>;
+        let extensionStopSpy: MockInstance<() => Promise<void>>;
+        let mqttDisconnectSpy: MockInstance<() => Promise<void>>;
+        let mqttPublishSpy: MockInstance<() => Promise<void>>;
+
+        beforeEach(() => {
+            stateStartSpy = vi.spyOn(controller.state, "start");
+            zigbeeStartSpy = vi.spyOn(controller.zigbee, "start");
+            mqttConnectSpy = vi.spyOn(controller.mqtt, "connect");
+            const [firstExt] = controller.extensions;
+            extensionStartSpy = vi.spyOn(firstExt, "start");
+            publishEntityStateSpy = vi.spyOn(controller, "publishEntityState");
+            extensionStopSpy = vi.spyOn(firstExt, "stop");
+            mqttDisconnectSpy = vi.spyOn(controller.mqtt, "disconnect");
+            mqttPublishSpy = vi.spyOn(controller.mqtt, "publish");
+
+            mockLogger.info.mockImplementation(console.log);
+            mockLogger.warning.mockImplementation(console.log);
+            mockLogger.error.mockImplementation(console.log);
+        });
+
+        afterEach(() => {
+            // @ts-expect-error prevent dupe `stop` trigger with higher afterEach for easier test debug
+            controller = undefined;
+            stateStartSpy.mockRestore();
+            zigbeeStartSpy.mockRestore();
+            mqttConnectSpy.mockRestore();
+            extensionStartSpy.mockRestore();
+            publishEntityStateSpy.mockRestore();
+            extensionStopSpy.mockRestore();
+            mqttDisconnectSpy.mockRestore();
+            mqttPublishSpy.mockRestore();
+        });
+
+        it("during state start", async () => {
+            stateStartSpy.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(0);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("during zigbee resolve definitions", async () => {
+            const resolveDevicesDefinitionsSpy = vi.spyOn(controller.zigbee, "resolveDevicesDefinitions");
+            resolveDevicesDefinitionsSpy.mockImplementationOnce(async (ignoreCache, abortSignal) => {
+                const device = controller.zigbee.resolveEntity(devices.bulb)! as Device;
+                device.resolveDefinition = vi.fn(async () => {
+                    await controller.stop(undefined, undefined, "SIGINT");
+                });
+
+                return await controller.zigbee.resolveDevicesDefinitions(ignoreCache, abortSignal);
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("during MQTT connect", async () => {
+            mqttConnectSpy.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(1);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("during extension start", async () => {
+            extensionStartSpy.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(1);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(1);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(3);
+        });
+
+        it("during entity state publish", async () => {
+            publishEntityStateSpy.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(1);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(1);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(1);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(13);
+        });
+
+        it("without signal during state start", async () => {
+            stateStartSpy.mockImplementationOnce(async () => {
+                await controller.stop();
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(0);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("without signal during MQTT connect", async () => {
+            mqttConnectSpy.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(1);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("during ZH Controller start", async () => {
+            mockZHController.start.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+
+                return await Promise.resolve("resumed");
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("during ZH Controller getNetworkParameters", async () => {
+            mockZHController.getNetworkParameters.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+
+                return await Promise.resolve({panID: 0x162a, extendedPanID: "0x64c5fd698daf0c00", channel: 15, nwkUpdateID: 0});
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("during ZH Controller passlist", async () => {
+            settings.set(["passlist"], [devices.bulb_color.ieeeAddr]);
+            devices.bulb.removeFromNetwork.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it("during ZH Controller blocklist", async () => {
+            settings.set(["blocklist"], [devices.bulb_color.ieeeAddr]);
+            devices.bulb_color.removeFromNetwork.mockImplementationOnce(async () => {
+                await controller.stop(undefined, undefined, "SIGINT");
+            });
+
+            await controller.start();
+            await flushPromises();
+
+            expect(stateStartSpy).toHaveBeenCalledTimes(1);
+            expect(zigbeeStartSpy).toHaveBeenCalledTimes(1);
+            expect(mqttConnectSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStartSpy).toHaveBeenCalledTimes(0);
+            expect(publishEntityStateSpy).toHaveBeenCalledTimes(0);
+            expect(extensionStopSpy).toHaveBeenCalledTimes(1);
+            expect(mqttDisconnectSpy).toHaveBeenCalledTimes(1);
+            expect(mqttPublishSpy).toHaveBeenCalledTimes(0);
+        });
     });
 
     it("Start controller adapter disconnects", async () => {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -567,7 +567,7 @@ describe("Controller", () => {
 
         it("without signal during MQTT connect", async () => {
             mqttConnectSpy.mockImplementationOnce(async () => {
-                await controller.stop(undefined, undefined, "SIGINT");
+                await controller.stop();
             });
 
             await controller.start();

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -584,8 +584,9 @@ describe("Controller", () => {
         });
 
         it("during ZH Controller start", async () => {
-            mockZHController.start.mockImplementationOnce(async () => {
-                await controller.stop(undefined, undefined, "SIGINT");
+            mockZHController.start.mockImplementationOnce(async (abortSignal) => {
+                void controller.stop(undefined, undefined, "SIGINT");
+                abortSignal?.throwIfAborted();
 
                 return await Promise.resolve("resumed");
             });

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -328,11 +328,12 @@ describe("Controller", () => {
     });
 
     it("Should remove device on blocklist on startup", async () => {
-        settings.set(["blocklist"], [devices.bulb_color.ieeeAddr, "0x9998889998889990"]);
+        settings.set(["blocklist"], [devices.bulb_color.ieeeAddr, "0x9998889998889990", "0x00124b00120144ae"]);
         await controller.start();
         await flushPromises();
         expect(devices.bulb_color.removeFromNetwork).toHaveBeenCalledTimes(1);
         expect(devices.bulb.removeFromNetwork).toHaveBeenCalledTimes(0);
+        expect(devices.coordinator.removeFromNetwork).toHaveBeenCalledTimes(0);
         const debugCalls = mockLogger.debug.mock.calls.map((c) => (typeof c[0] === "string" ? c[0] : c[0]()));
         expect(debugCalls.find((v) => v === "Ignoring blocklist device 0x9998889998889990, not currently on the network")).toBeDefined();
     });

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -54,6 +54,7 @@ const mocksClear = [
 describe("Controller", () => {
     let controller: Controller;
     let mockExit: Mock;
+    let stopAfter = true;
 
     const getZ2MDevice = (zhDevice: string | number | ZhDevice): Device => {
         return controller.zigbee.resolveEntity(zhDevice)! as Device;
@@ -64,6 +65,7 @@ describe("Controller", () => {
     });
 
     beforeEach(() => {
+        stopAfter = true;
         returnDevices.splice(0);
         mockExit = vi.fn();
         data.writeDefaultConfiguration();
@@ -79,7 +81,10 @@ describe("Controller", () => {
     });
 
     afterEach(async () => {
-        await controller?.stop();
+        if (stopAfter) {
+            await controller?.stop();
+        }
+
         await flushPromises();
     });
 
@@ -431,15 +436,10 @@ describe("Controller", () => {
             extensionStopSpy = vi.spyOn(firstExt, "stop");
             mqttDisconnectSpy = vi.spyOn(controller.mqtt, "disconnect");
             mqttPublishSpy = vi.spyOn(controller.mqtt, "publish");
-
-            mockLogger.info.mockImplementation(console.log);
-            mockLogger.warning.mockImplementation(console.log);
-            mockLogger.error.mockImplementation(console.log);
         });
 
         afterEach(() => {
-            // @ts-expect-error prevent dupe `stop` trigger with higher afterEach for easier test debug
-            controller = undefined;
+            stopAfter = false;
             stateStartSpy.mockRestore();
             zigbeeStartSpy.mockRestore();
             mqttConnectSpy.mockRestore();

--- a/test/mocks/mqtt.ts
+++ b/test/mocks/mqtt.ts
@@ -1,5 +1,5 @@
 import type {IClientPublishOptions} from "mqtt";
-
+import {vi} from "vitest";
 import type {EventHandler} from "./utils";
 
 export const events: Record<string, EventHandler> = {};

--- a/test/mocks/zigbeeHerdsman.ts
+++ b/test/mocks/zigbeeHerdsman.ts
@@ -1192,7 +1192,11 @@ export const mockController = {
     on: (type: string, handler: EventHandler): void => {
         events[type] = handler;
     },
-    start: vi.fn((): Promise<AdapterTypes.StartResult> => Promise.resolve("reset")),
+    start: vi.fn(async (abortSignal?: AbortSignal): Promise<AdapterTypes.StartResult> => {
+        abortSignal?.throwIfAborted();
+
+        return await Promise.resolve("reset");
+    }),
     stop: vi.fn(),
     touchlink: {identify: vi.fn(), scan: vi.fn(), factoryReset: vi.fn(), factoryResetFirst: vi.fn()},
     addInstallCode: vi.fn(),


### PR DESCRIPTION
- optimize imports in `index.js`
- add JS typing in `index.js`
- pass possible SIG to Controller `stop`
- add a few guards to prevent undesired errors in "aborted startup" scenario
- optimize passlist/blocklist behavior on startup, no unnecessary looping, move some ops outside of loop
- add "stopping" log in Controller to align behavior (starting, started, stopping, stopped)
  - e.g.: `Stopping Zigbee2MQTT (restart=false, code=0, signal=SIGINT)`
- use AbortController in Controller to abort startup sequence if necessary (mainly to prevent start+stop running concurrently on SIG which creates uncontrolled behaviors)
  - pass abort signal to Zigbee `start` and various nested calls that are possibly "long-running"
  - use return instead of throw to avoid clashing with rest of logic (would have to check error otherwise...)
  - no-op once startup finished

@Koenkk if you see a better way to do this... :stuck_out_tongue: 

CC: @burmistrzak @sjorge @andrei-lazarov if you have some time to review this :wink: 

TODO:
- [x] pass abort signal to ZH (need impl. in ZH)