### PR TITLE
Use frontend.port from configuration.yaml in Onboarding

### DIFF
--- a/lib/util/onboarding.ts
+++ b/lib/util/onboarding.ts
@@ -376,7 +376,8 @@ function generateHtmlError(errors: string): string {
 }
 
 function getServerUrl(): URL {
-    return new URL(process.env.Z2M_ONBOARD_URL ?? "http://0.0.0.0:8080");
+    let port = settings.get().frontend.port ?? "8080";
+    return new URL(process.env.Z2M_ONBOARD_URL ?? `http://0.0.0.0:${port}`);
 }
 
 async function startOnboardingServer(): Promise<boolean> {


### PR DESCRIPTION
Currently in Onboarding there is no way to change the port of the onboarding server.
This change makes use of the port defined for the Frontend server for `startOnboardingServer` and `startFailureServer`.
Personally I dont think it's worth introducing dedicated configuration variables for this, therefore simply reusing frontend port definition, even if frontend may be disabled.