### PR TITLE
feat: add group entities in discovery config

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1658,6 +1658,32 @@ export class HomeAssistant extends Extension {
             // Set unique_id
             payload.unique_id = `${entity.options.ID}_${config.object_id}_${settings.get().mqtt.base_topic}`;
 
+            // Add group member unique_ids for Home Assistant entity grouping
+            // https://www.home-assistant.io/integrations/mqtt#grouping-entities
+            if (isGroup) {
+                const groupMembers: {name: string; uniqueId: string}[] = [];
+                const mqttBaseTopic = settings.get().mqtt.base_topic;
+
+                for (const member of entity.zh.members) {
+                    const device = this.zigbee.resolveEntity(member.getDevice());
+                    /* v8 ignore next */
+                    if (!device?.isDevice() || !device.definition) continue;
+
+                    const endpointName = device.endpointName(member);
+                    const expectedObjectId = endpointName ? `${config.object_id}_${endpointName}` : config.object_id;
+
+                    for (const dc of this.getConfigs(device)) {
+                        if (dc.type !== config.type || dc.object_id !== expectedObjectId) continue;
+                        groupMembers.push({name: device.name, uniqueId: `${device.options.ID}_${dc.object_id}_${mqttBaseTopic}`});
+                        break;
+                    }
+                }
+
+                if (groupMembers.length > 0) {
+                    payload.group = groupMembers.sort((a, b) => a.name.localeCompare(b.name)).map((m) => m.uniqueId);
+                }
+            }
+
             // Attributes for device registry and origin
             payload.device = devicePayload;
             payload.origin = this.discoveryOrigin;

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import bind from "bind-decorator";
 import stringify from "json-stable-stringify-without-jsonify";
 import type * as zhc from "zigbee-herdsman-converters";
-
+import type {Zh} from "zigbee-herdsman-converters/lib/types";
 import logger from "../util/logger";
 import * as settings from "../util/settings";
 import utils, {assertBinaryExpose, assertEnumExpose, assertNumericExpose, isBinaryExpose, isEnumExpose, isNumericExpose} from "../util/utils";
@@ -18,6 +18,7 @@ interface DiscoveryEntry {
     type: string;
     object_id: string;
     discovery_payload: KeyValue;
+    endpoint?: Zh.Endpoint;
 }
 
 interface Discovered {
@@ -384,7 +385,7 @@ export class HomeAssistant extends Extension {
     private discoveryTopic: string;
     private discoveryRegex: RegExp;
     private discoveryRegexWoTopic = /(.*)\/(.*)\/(.*)\/config/;
-    private deviceConfigLookup = new Map<string, Set<string>>();
+    private groupMemberLookup = new Map<string, string>();
     private statusTopic: string;
     private legacyActionSensor: boolean;
     private experimentalEventEntities: boolean;
@@ -488,21 +489,16 @@ export class HomeAssistant extends Extension {
         return this.discovered[ID];
     }
 
-    private exposeToConfig(
-        exposes: zhc.Expose[],
-        entityType: "device" | "group",
-        allExposes: zhc.Expose[],
-        definition?: zhc.Definition,
-    ): DiscoveryEntry[] {
+    private exposeToConfig(exposes: zhc.Expose[], entity: Device | Group, allExposes: zhc.Expose[]): DiscoveryEntry[] {
         // For groups an array of exposes (of the same type) is passed, this is to determine e.g. what features
         // to use for a bulb (e.g. color_xy/color_temp)
-        assert(entityType === "group" || exposes.length === 1, "Multiple exposes for device not allowed");
+        assert(entity.isGroup() || exposes.length === 1, "Multiple exposes for device not allowed");
         const firstExpose = exposes[0];
-        assert(entityType === "device" || GROUP_SUPPORTED_TYPES.includes(firstExpose.type), `Unsupported expose type ${firstExpose.type} for group`);
+        assert(entity.isDevice() || GROUP_SUPPORTED_TYPES.includes(firstExpose.type), `Unsupported expose type ${firstExpose.type} for group`);
 
         const discoveryEntries: DiscoveryEntry[] = [];
-        const endpoint = entityType === "device" ? exposes[0].endpoint : undefined;
-        const getProperty = (feature: zhc.Feature): string => (entityType === "group" ? featurePropertyWithoutEndpoint(feature) : feature.property);
+        const endpointName = entity.isDevice() ? exposes[0].endpoint : undefined;
+        const getProperty = (feature: zhc.Feature): string => (entity.isGroup() ? featurePropertyWithoutEndpoint(feature) : feature.property);
 
         switch (firstExpose.type) {
             case "light": {
@@ -521,16 +517,16 @@ export class HomeAssistant extends Extension {
 
                 const discoveryEntry: DiscoveryEntry = {
                     type: "light",
-                    object_id: endpoint ? `light_${endpoint}` : "light",
+                    object_id: endpointName ? `light_${endpointName}` : "light",
                     mockProperties: [{property: state.property, value: null}],
                     discovery_payload: {
-                        name: endpoint ? utils.capitalize(endpoint) : null,
+                        name: endpointName ? utils.capitalize(endpointName) : null,
                         brightness: !!hasBrightness,
                         schema: "json",
                         command_topic: true,
                         brightness_scale: 254,
-                        command_topic_prefix: endpoint,
-                        state_topic_postfix: endpoint,
+                        command_topic_prefix: endpointName,
+                        state_topic_postfix: endpointName,
                     },
                 };
 
@@ -583,15 +579,15 @@ export class HomeAssistant extends Extension {
                 const property = getProperty(state);
                 const discoveryEntry: DiscoveryEntry = {
                     type: "switch",
-                    object_id: endpoint ? `switch_${endpoint}` : "switch",
+                    object_id: endpointName ? `switch_${endpointName}` : "switch",
                     mockProperties: [{property: property, value: null}],
                     discovery_payload: {
-                        name: endpoint ? utils.capitalize(endpoint) : null,
+                        name: endpointName ? utils.capitalize(endpointName) : null,
                         payload_off: state.value_off,
                         payload_on: state.value_on,
                         value_template: `{{ value_json.${property} }}`,
                         command_topic: true,
-                        command_topic_prefix: endpoint,
+                        command_topic_prefix: endpointName,
                     },
                 };
 
@@ -622,10 +618,10 @@ export class HomeAssistant extends Extension {
 
                 const discoveryEntry: DiscoveryEntry = {
                     type: "climate",
-                    object_id: endpoint ? `climate_${endpoint}` : "climate",
+                    object_id: endpointName ? `climate_${endpointName}` : "climate",
                     mockProperties: [],
                     discovery_payload: {
-                        name: endpoint ? utils.capitalize(endpoint) : null,
+                        name: endpointName ? utils.capitalize(endpointName) : null,
                         // Static
                         state_topic: false,
                         temperature_unit: "C",
@@ -636,7 +632,7 @@ export class HomeAssistant extends Extension {
                         // Temperature
                         current_temperature_topic: true,
                         current_temperature_template: `{{ value_json.${temperature.property} }}`,
-                        command_topic_prefix: endpoint,
+                        command_topic_prefix: endpointName,
                     },
                 };
 
@@ -705,13 +701,13 @@ export class HomeAssistant extends Extension {
                 if (tempCalibration) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "number",
-                        object_id: endpoint ? `${tempCalibration.name}_${endpoint}` : `${tempCalibration.name}`,
+                        object_id: endpointName ? `${tempCalibration.name}_${endpointName}` : `${tempCalibration.name}`,
                         mockProperties: [{property: tempCalibration.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${tempCalibration.label} ${endpoint}` : tempCalibration.label,
+                            name: endpointName ? `${tempCalibration.label} ${endpointName}` : tempCalibration.label,
                             value_template: `{{ value_json.${tempCalibration.property} }}`,
                             command_topic: true,
-                            command_topic_prefix: endpoint,
+                            command_topic_prefix: endpointName,
                             command_topic_postfix: tempCalibration.property,
                             device_class: "temperature_delta",
                             entity_category: "config",
@@ -730,10 +726,10 @@ export class HomeAssistant extends Extension {
                 const piHeatingDemand = (firstExpose as zhc.Climate).features.filter(isNumericExpose).find((f) => f.name === "pi_heating_demand");
                 if (piHeatingDemand) {
                     const discoveryEntry: Partial<DiscoveryEntry> = {
-                        object_id: endpoint ? `${piHeatingDemand.name}_${endpoint}` : `${piHeatingDemand.name}`,
+                        object_id: endpointName ? `${piHeatingDemand.name}_${endpointName}` : `${piHeatingDemand.name}`,
                         mockProperties: [{property: piHeatingDemand.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${piHeatingDemand.label} ${endpoint}` : piHeatingDemand.label,
+                            name: endpointName ? `${piHeatingDemand.label} ${endpointName}` : piHeatingDemand.label,
                             value_template: `{{ value_json.${piHeatingDemand.property} }}`,
                             ...(piHeatingDemand.unit && {unit_of_measurement: piHeatingDemand.unit}),
                             icon: "mdi:radiator",
@@ -745,7 +741,7 @@ export class HomeAssistant extends Extension {
                     if (piHeatingDemand.access & ACCESS_SET) {
                         discoveryEntry.type = "number";
                         discoveryEntry.discovery_payload.command_topic = true;
-                        discoveryEntry.discovery_payload.command_topic_prefix = endpoint;
+                        discoveryEntry.discovery_payload.command_topic_prefix = endpointName;
                         discoveryEntry.discovery_payload.command_topic_postfix = piHeatingDemand.property;
                         discoveryEntry.discovery_payload.min = piHeatingDemand.value_min;
                         discoveryEntry.discovery_payload.max = piHeatingDemand.value_max;
@@ -761,10 +757,10 @@ export class HomeAssistant extends Extension {
                 if (piCoolingDemand) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "sensor",
-                        object_id: endpoint ? /* v8 ignore next */ `${piCoolingDemand.name}_${endpoint}` : `${piCoolingDemand.name}`,
+                        object_id: endpointName ? /* v8 ignore next */ `${piCoolingDemand.name}_${endpointName}` : `${piCoolingDemand.name}`,
                         mockProperties: [{property: piCoolingDemand.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? /* v8 ignore next */ `${piCoolingDemand.label} ${endpoint}` : piCoolingDemand.label,
+                            name: endpointName ? /* v8 ignore next */ `${piCoolingDemand.label} ${endpointName}` : piCoolingDemand.label,
                             value_template: `{{ value_json.${piCoolingDemand.property} }}`,
                             ...(piCoolingDemand.unit && {unit_of_measurement: piCoolingDemand.unit}),
                             entity_category: "diagnostic",
@@ -783,10 +779,10 @@ export class HomeAssistant extends Extension {
                 if (localTemperature && !temperatureSensor && !localTemperatureSensor) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "sensor",
-                        object_id: endpoint ? `${localTemperature.name}_${endpoint}` : `${localTemperature.name}`,
+                        object_id: endpointName ? `${localTemperature.name}_${endpointName}` : `${localTemperature.name}`,
                         mockProperties: [{property: localTemperature.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${localTemperature.label} ${endpoint}` : localTemperature.label,
+                            name: endpointName ? `${localTemperature.label} ${endpointName}` : localTemperature.label,
                             value_template: `{{ value_json.${localTemperature.property} }}`,
                             ...(localTemperature.unit && {unit_of_measurement: localTemperature.unit}),
                             device_class: "temperature",
@@ -812,18 +808,18 @@ export class HomeAssistant extends Extension {
                 const discoveryEntry: DiscoveryEntry = {
                     type: "lock",
                     /* v8 ignore next */
-                    object_id: endpoint ? `lock_${endpoint}` : "lock",
+                    object_id: endpointName ? `lock_${endpointName}` : "lock",
                     mockProperties: [{property: state.property, value: null}],
                     discovery_payload: {
                         /* v8 ignore next */
-                        name: endpoint ? utils.capitalize(endpoint) : null,
-                        command_topic_prefix: endpoint,
+                        name: endpointName ? utils.capitalize(endpointName) : null,
+                        command_topic_prefix: endpointName,
                         command_topic: true,
                         value_template: `{{ value_json.${state.property} }}`,
                         state_locked: state.value_on,
                         state_unlocked: state.value_off,
                         /* v8 ignore next */
-                        command_topic_postfix: endpoint ? state.property : null,
+                        command_topic_postfix: endpointName ? state.property : null,
                     },
                 };
                 discoveryEntries.push(discoveryEntry);
@@ -848,13 +844,13 @@ export class HomeAssistant extends Extension {
                 const discoveryEntry: DiscoveryEntry = {
                     type: "cover",
                     mockProperties: [{property: state.property, value: null}],
-                    object_id: endpoint ? `cover_${endpoint}` : "cover",
+                    object_id: endpointName ? `cover_${endpointName}` : "cover",
                     discovery_payload: {
-                        name: endpoint ? utils.capitalize(endpoint) : null,
-                        command_topic_prefix: endpoint,
+                        name: endpointName ? utils.capitalize(endpointName) : null,
+                        command_topic_prefix: endpointName,
                         command_topic: true,
                         state_topic: true,
-                        state_topic_postfix: endpoint,
+                        state_topic_postfix: endpointName,
                     },
                 };
 
@@ -917,7 +913,7 @@ export class HomeAssistant extends Extension {
                 break;
             }
             case "fan": {
-                assert(!endpoint, "Endpoint not supported for fan type");
+                assert(!endpointName, "Endpoint not supported for fan type");
                 const discoveryEntry: DiscoveryEntry = {
                     type: "fan",
                     object_id: "fan",
@@ -953,7 +949,7 @@ export class HomeAssistant extends Extension {
                     );
                     let presets = ["on", "auto", "smart"].filter((s) => modeEmulatedSpeed.values.includes(s));
 
-                    if (definition?.model === "99432") {
+                    if (entity.isDevice() && entity.definition?.model === "99432") {
                         // The Hampton Bay 99432 fan implements 4 speeds using the ZCL
                         // hvacFanCtrl values `low`, `medium`, `high`, and `on`, and
                         // 1 preset called "Comfort Breeze" using the ZCL value `smart`.
@@ -1015,9 +1011,9 @@ export class HomeAssistant extends Extension {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "switch",
                         mockProperties: [{property: firstExpose.property, value: null}],
-                        object_id: endpoint ? `switch_${firstExpose.name}_${endpoint}` : `switch_${firstExpose.name}`,
+                        object_id: endpointName ? `switch_${firstExpose.name}_${endpointName}` : `switch_${firstExpose.name}`,
                         discovery_payload: {
-                            name: endpoint ? /* v8 ignore next */ `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                            name: endpointName ? /* v8 ignore next */ `${firstExpose.label} ${endpointName}` : firstExpose.label,
                             value_template:
                                 typeof firstExpose.value_on === "boolean"
                                     ? `{% if value_json.${firstExpose.property} %}true{% else %}false{% endif %}`
@@ -1025,7 +1021,7 @@ export class HomeAssistant extends Extension {
                             payload_on: firstExpose.value_on.toString(),
                             payload_off: firstExpose.value_off.toString(),
                             command_topic: true,
-                            command_topic_prefix: endpoint,
+                            command_topic_prefix: endpointName,
                             command_topic_postfix: firstExpose.property,
                             ...(BINARY_DISCOVERY_LOOKUP[firstExpose.name] || {}),
                         },
@@ -1035,10 +1031,10 @@ export class HomeAssistant extends Extension {
                 } else {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "binary_sensor",
-                        object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
+                        object_id: endpointName ? `${firstExpose.name}_${endpointName}` : `${firstExpose.name}`,
                         mockProperties: [{property: firstExpose.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? /* v8 ignore next */ `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                            name: endpointName ? /* v8 ignore next */ `${firstExpose.label} ${endpointName}` : firstExpose.label,
                             value_template: `{{ value_json.${firstExpose.property} }}`,
                             payload_on: firstExpose.value_on,
                             payload_off: firstExpose.value_off,
@@ -1060,13 +1056,13 @@ export class HomeAssistant extends Extension {
                 if (allowsSet) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "number",
-                        object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
+                        object_id: endpointName ? `${firstExpose.name}_${endpointName}` : `${firstExpose.name}`,
                         mockProperties: [{property: firstExpose.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                            name: endpointName ? `${firstExpose.label} ${endpointName}` : firstExpose.label,
                             value_template: `{{ value_json.${firstExpose.property} }}`,
                             command_topic: true,
-                            command_topic_prefix: endpoint,
+                            command_topic_prefix: endpointName,
                             command_topic_postfix: firstExpose.property,
                             ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
                             ...(firstExpose.value_step && {step: firstExpose.value_step}),
@@ -1111,10 +1107,10 @@ export class HomeAssistant extends Extension {
 
                 const discoveryEntry: DiscoveryEntry = {
                     type: "sensor",
-                    object_id: endpoint ? `${firstExpose.name}_${endpoint}` : `${firstExpose.name}`,
+                    object_id: endpointName ? `${firstExpose.name}_${endpointName}` : `${firstExpose.name}`,
                     mockProperties: [{property: firstExpose.property, value: null}],
                     discovery_payload: {
-                        name: endpoint ? `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                        name: endpointName ? `${firstExpose.label} ${endpointName}` : firstExpose.label,
                         value_template: `{{ value_json.${firstExpose.property} }}`,
                         enabled_by_default: !allowsSet,
                         ...(firstExpose.unit && {unit_of_measurement: firstExpose.unit}),
@@ -1156,7 +1152,7 @@ export class HomeAssistant extends Extension {
                             object_id: firstExpose.property,
                             mockProperties: [],
                             discovery_payload: {
-                                name: endpoint ? /* v8 ignore next */ `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                                name: endpointName ? /* v8 ignore next */ `${firstExpose.label} ${endpointName}` : firstExpose.label,
                                 state_topic: true,
                                 event_types: this.prepareActionEventTypes(firstExpose.values),
                                 value_template: this.actionValueTemplate,
@@ -1180,9 +1176,9 @@ export class HomeAssistant extends Extension {
                         object_id: firstExpose.property,
                         mockProperties: [{property: firstExpose.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? /* v8 ignore next */ `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                            name: endpointName ? /* v8 ignore next */ `${firstExpose.label} ${endpointName}` : firstExpose.label,
                             state_topic: false,
-                            command_topic_prefix: endpoint,
+                            command_topic_prefix: endpointName,
                             command_topic: true,
                             command_topic_postfix: firstExpose.property,
                             payload_press: firstExpose.values[0].toString(),
@@ -1201,10 +1197,10 @@ export class HomeAssistant extends Extension {
                         object_id: firstExpose.property,
                         mockProperties: [{property: firstExpose.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                            name: endpointName ? `${firstExpose.label} ${endpointName}` : firstExpose.label,
                             value_template: valueTemplate,
                             state_topic: !!(firstExpose.access & ACCESS_STATE),
-                            command_topic_prefix: endpoint,
+                            command_topic_prefix: endpointName,
                             command_topic: true,
                             command_topic_postfix: firstExpose.property,
                             options: firstExpose.values.map((v) => v.toString()),
@@ -1223,7 +1219,7 @@ export class HomeAssistant extends Extension {
                         object_id: firstExpose.property,
                         mockProperties: [{property: firstExpose.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${firstExpose.label} ${endpoint}` : firstExpose.label,
+                            name: endpointName ? `${firstExpose.label} ${endpointName}` : firstExpose.label,
                             value_template: valueTemplate,
                             ...ENUM_DISCOVERY_LOOKUP[firstExpose.name],
                         },
@@ -1245,12 +1241,12 @@ export class HomeAssistant extends Extension {
 
                     const discoveryEntry: DiscoveryEntry = {
                         type: "siren",
-                        object_id: endpoint ? /* v8 ignore next */ `siren_${endpoint}` : "siren",
+                        object_id: endpointName ? /* v8 ignore next */ `siren_${endpointName}` : "siren",
                         mockProperties: [{property: warningExpose.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? /* v8 ignore next */ utils.capitalize(endpoint) : null,
+                            name: endpointName ? /* v8 ignore next */ utils.capitalize(endpointName) : null,
                             command_topic: true,
-                            command_topic_prefix: endpoint,
+                            command_topic_prefix: endpointName,
                             state_topic: false,
                             optimistic: true,
                         },
@@ -1296,10 +1292,10 @@ export class HomeAssistant extends Extension {
                         object_id: firstExposeTyped.property,
                         mockProperties: [{property: firstExposeTyped.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${firstExposeTyped.label} ${endpoint}` : firstExposeTyped.label,
+                            name: endpointName ? `${firstExposeTyped.label} ${endpointName}` : firstExposeTyped.label,
                             state_topic: firstExposeTyped.access & ACCESS_STATE,
                             value_template: `{{ value_json.${firstExposeTyped.property} }}`,
-                            command_topic_prefix: endpoint,
+                            command_topic_prefix: endpointName,
                             command_topic: true,
                             command_topic_postfix: firstExposeTyped.property,
                             ...LIST_DISCOVERY_LOOKUP[firstExposeTyped.name],
@@ -1313,7 +1309,7 @@ export class HomeAssistant extends Extension {
                         object_id: firstExposeTyped.property,
                         mockProperties: [{property: firstExposeTyped.property, value: null}],
                         discovery_payload: {
-                            name: endpoint ? `${firstExposeTyped.label} ${endpoint}` : firstExposeTyped.label,
+                            name: endpointName ? `${firstExposeTyped.label} ${endpointName}` : firstExposeTyped.label,
                             // Truncate text if it's too long
                             // https://github.com/Koenkk/zigbee2mqtt/issues/23199
                             value_template: `{{ value_json.${firstExposeTyped.property} | default('',True) | string | truncate(254, True, '', 0) }}`,
@@ -1350,6 +1346,8 @@ export class HomeAssistant extends Extension {
             if (entry.discovery_payload.device_class) {
                 delete entry.discovery_payload.name;
             }
+
+            entry.endpoint = entity.isDevice() ? entity.endpoint(endpointName) : undefined;
         }
 
         return discoveryEntries;
@@ -1364,7 +1362,6 @@ export class HomeAssistant extends Extension {
         }
 
         delete this.discovered[data.entity.ID];
-        this.deviceConfigLookup.delete(`${data.entity.ID}`);
     }
 
     @bind async onGroupMembersChanged(data: eventdata.GroupMembersChanged): Promise<void> {
@@ -1476,7 +1473,7 @@ export class HomeAssistant extends Extension {
         if (isDevice) {
             const exposes = entity.exposes(); // avoid calling it hundred of times/s
             for (const expose of exposes) {
-                configs.push(...this.exposeToConfig([expose], "device", exposes, entity.definition));
+                configs.push(...this.exposeToConfig([expose], entity, exposes));
             }
         } else if (isGroup) {
             // group
@@ -1505,7 +1502,7 @@ export class HomeAssistant extends Extension {
             }
 
             configs = ([] as DiscoveryEntry[]).concat(
-                ...Object.values(exposesByType).map((exposes) => this.exposeToConfig(exposes, "group", allExposes)),
+                ...Object.values(exposesByType).map((exposes) => this.exposeToConfig(exposes, entity, allExposes)),
             );
         } else {
             // Discover bridge config.
@@ -1612,17 +1609,7 @@ export class HomeAssistant extends Extension {
         const lastDiscoveredTopics = Object.keys(discovered.messages);
         const newDiscoveredTopics = new Set<string>();
 
-        const configs = this.getConfigs(entity);
-
-        if (isDevice) {
-            const configSet = new Set<string>();
-            for (const c of configs) {
-                configSet.add(`${c.type}:${c.object_id}`);
-            }
-            this.deviceConfigLookup.set(`${entity.options.ID}`, configSet);
-        }
-
-        for (const config of configs) {
+        for (const config of this.getConfigs(entity)) {
             const payload = {...config.discovery_payload};
             const baseTopic = `${settings.get().mqtt.base_topic}/${entity.name}`;
             let stateTopic = baseTopic;
@@ -1668,30 +1655,29 @@ export class HomeAssistant extends Extension {
             payload.default_entity_id = `${config.type}.${payload.object_id}`;
 
             // Set unique_id
-            payload.unique_id = `${entity.options.ID}_${config.object_id}_${settings.get().mqtt.base_topic}`;
+            const uniqueId = `${entity.options.ID}_${config.object_id}_${settings.get().mqtt.base_topic}`;
+            payload.unique_id = uniqueId;
+
+            if (config.endpoint) {
+                assert(entity.isDevice());
+                const key = `${config.endpoint.deviceIeeeAddress}_${config.endpoint.ID}_${config.type}`;
+                this.groupMemberLookup.set(key, uniqueId);
+            }
 
             // Add group member unique_ids for Home Assistant entity grouping
             // https://www.home-assistant.io/integrations/mqtt#grouping-entities
             if (isGroup) {
-                const groupMembers: {name: string; uniqueId: string}[] = [];
-                const mqttBaseTopic = settings.get().mqtt.base_topic;
-
-                for (const member of entity.zh.members) {
-                    const device = this.zigbee.resolveEntity(member.getDevice());
-                    /* v8 ignore next */
-                    if (!device?.isDevice() || !device.definition) continue;
-
-                    const endpointName = device.endpointName(member);
-                    const expectedObjectId = endpointName ? `${config.object_id}_${endpointName}` : config.object_id;
-                    const deviceConfigs = this.deviceConfigLookup.get(`${device.options.ID}`);
-
-                    if (deviceConfigs?.has(`${config.type}:${expectedObjectId}`)) {
-                        groupMembers.push({name: device.name, uniqueId: `${device.options.ID}_${expectedObjectId}_${mqttBaseTopic}`});
+                const memberIds: string[] = [];
+                for (const endpoint of entity.zh.members) {
+                    const memberKey = `${endpoint.deviceIeeeAddress}_${endpoint.ID}_${config.type}`;
+                    const memberUniqueId = this.groupMemberLookup.get(memberKey);
+                    if (memberUniqueId) {
+                        memberIds.push(memberUniqueId);
                     }
                 }
 
-                if (groupMembers.length > 0) {
-                    payload.group = groupMembers.sort((a, b) => a.name.localeCompare(b.name)).map((m) => m.uniqueId);
+                if (memberIds.length > 0) {
+                    payload.group = memberIds;
                 }
             }
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -384,6 +384,7 @@ export class HomeAssistant extends Extension {
     private discoveryTopic: string;
     private discoveryRegex: RegExp;
     private discoveryRegexWoTopic = /(.*)\/(.*)\/(.*)\/config/;
+    private deviceConfigLookup = new Map<string, Set<string>>();
     private statusTopic: string;
     private legacyActionSensor: boolean;
     private experimentalEventEntities: boolean;
@@ -1363,6 +1364,7 @@ export class HomeAssistant extends Extension {
         }
 
         delete this.discovered[data.entity.ID];
+        this.deviceConfigLookup.delete(`${data.entity.ID}`);
     }
 
     @bind async onGroupMembersChanged(data: eventdata.GroupMembersChanged): Promise<void> {
@@ -1610,7 +1612,17 @@ export class HomeAssistant extends Extension {
         const lastDiscoveredTopics = Object.keys(discovered.messages);
         const newDiscoveredTopics = new Set<string>();
 
-        for (const config of this.getConfigs(entity)) {
+        const configs = this.getConfigs(entity);
+
+        if (isDevice) {
+            const configSet = new Set<string>();
+            for (const c of configs) {
+                configSet.add(`${c.type}:${c.object_id}`);
+            }
+            this.deviceConfigLookup.set(`${entity.options.ID}`, configSet);
+        }
+
+        for (const config of configs) {
             const payload = {...config.discovery_payload};
             const baseTopic = `${settings.get().mqtt.base_topic}/${entity.name}`;
             let stateTopic = baseTopic;
@@ -1671,11 +1683,10 @@ export class HomeAssistant extends Extension {
 
                     const endpointName = device.endpointName(member);
                     const expectedObjectId = endpointName ? `${config.object_id}_${endpointName}` : config.object_id;
+                    const deviceConfigs = this.deviceConfigLookup.get(`${device.options.ID}`);
 
-                    for (const dc of this.getConfigs(device)) {
-                        if (dc.type !== config.type || dc.object_id !== expectedObjectId) continue;
-                        groupMembers.push({name: device.name, uniqueId: `${device.options.ID}_${dc.object_id}_${mqttBaseTopic}`});
-                        break;
+                    if (deviceConfigs?.has(`${config.type}:${expectedObjectId}`)) {
+                        groupMembers.push({name: device.name, uniqueId: `${device.options.ID}_${expectedObjectId}_${mqttBaseTopic}`});
                     }
                 }
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -461,10 +461,15 @@ export class HomeAssistant extends Extension {
         const discoverWait = 5;
         // Discover with `published = false`, this will populate `this.discovered` without publishing the discoveries.
         // This is needed for clearing outdated entries in `this.onMQTTMessage()`
+        // Discover devices before groups to populate `this.groupMemberLookup` for group discovery.
         await this.discover(this.bridge, false);
 
-        for (const e of this.zigbee.devicesAndGroupsIterator(utils.deviceNotCoordinator)) {
-            await this.discover(e, false);
+        for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
+            await this.discover(device, false);
+        }
+
+        for (const group of this.zigbee.groupsIterator()) {
+            await this.discover(group, false);
         }
 
         logger.debug(`Discovering entities to Home Assistant in ${discoverWait}s`);
@@ -1660,11 +1665,13 @@ export class HomeAssistant extends Extension {
 
             if (config.endpoint) {
                 assert(entity.isDevice());
-                const key = `${config.endpoint.deviceIeeeAddress}_${config.endpoint.ID}_${config.type}`;
-                this.groupMemberLookup.set(key, uniqueId);
+                const memberKey = `${config.endpoint.deviceIeeeAddress}_${config.endpoint.ID}_${config.type}`;
+                this.groupMemberLookup.set(memberKey, uniqueId);
             }
 
             // Add group member unique_ids for Home Assistant entity grouping
+            // This assumes that `discover()` already has been called for all devices, since it depends on the
+            // `groupMemberLookup` being populated.
             // https://www.home-assistant.io/integrations/mqtt#grouping-entities
             if (isGroup) {
                 const memberIds: string[] = [];

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -170,6 +170,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group",
             default_entity_id: "light.ha_discovery_group",
             unique_id: "9_light_zigbee2mqtt",
+            group: ["0x000b57fffec6a5b7_light_zigbee2mqtt", "0x000b57fffec6a5b4_light_zigbee2mqtt"],
             origin: origin,
         };
 
@@ -225,6 +226,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group",
             default_entity_id: "switch.ha_discovery_group",
             unique_id: "9_switch_zigbee2mqtt",
+            group: ["0x0017880104e45542_switch_right_zigbee2mqtt"],
             origin: origin,
             value_template: "{{ value_json.state }}",
         };
@@ -1972,6 +1974,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group_new",
             default_entity_id: "light.ha_discovery_group_new",
             unique_id: "9_light_zigbee2mqtt",
+            group: ["0x000b57fffec6a5b7_light_zigbee2mqtt", "0x000b57fffec6a5b4_light_zigbee2mqtt"],
             origin: origin,
         };
 
@@ -2441,6 +2444,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group",
             default_entity_id: "light.ha_discovery_group",
             unique_id: "9_light_zigbee2mqtt",
+            group: ["0x000b57fffec6a5b7_light_zigbee2mqtt", "0x000b57fffec6a5b4_light_zigbee2mqtt"],
             origin: origin,
         };
 
@@ -2486,6 +2490,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group",
             default_entity_id: "light.ha_discovery_group",
             unique_id: "9_light_zigbee2mqtt",
+            group: ["0x000b57fffec6a5b7_light_zigbee2mqtt", "0x000b57fffec6a5b4_light_zigbee2mqtt"],
             origin: origin,
         };
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -103,6 +103,7 @@ describe("Extension: HomeAssistant", () => {
                 definition: d,
                 isDevice: (): boolean => true,
                 isGroup: (): boolean => false,
+                endpoint: () => undefined,
                 options: {},
                 exposes: (): unknown[] => exposes,
                 zh: {endpoints: []},
@@ -124,7 +125,7 @@ describe("Extension: HomeAssistant", () => {
             }
         }
 
-        expect(duplicated).toHaveLength(0);
+        expect(duplicated).toStrictEqual([]);
     });
 
     it("Should discover devices and groups", async () => {
@@ -170,7 +171,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group",
             default_entity_id: "light.ha_discovery_group",
             unique_id: "9_light_zigbee2mqtt",
-            group: ["0x000b57fffec6a5b7_light_zigbee2mqtt", "0x000b57fffec6a5b4_light_zigbee2mqtt"],
+            group: ["0x000b57fffec6a5b4_light_zigbee2mqtt", "0x000b57fffec6a5b7_light_zigbee2mqtt"],
             origin: origin,
         };
 
@@ -1974,7 +1975,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group_new",
             default_entity_id: "light.ha_discovery_group_new",
             unique_id: "9_light_zigbee2mqtt",
-            group: ["0x000b57fffec6a5b7_light_zigbee2mqtt", "0x000b57fffec6a5b4_light_zigbee2mqtt"],
+            group: ["0x000b57fffec6a5b4_light_zigbee2mqtt", "0x000b57fffec6a5b7_light_zigbee2mqtt"],
             origin: origin,
         };
 
@@ -2444,7 +2445,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group",
             default_entity_id: "light.ha_discovery_group",
             unique_id: "9_light_zigbee2mqtt",
-            group: ["0x000b57fffec6a5b7_light_zigbee2mqtt", "0x000b57fffec6a5b4_light_zigbee2mqtt"],
+            group: ["0x000b57fffec6a5b4_light_zigbee2mqtt", "0x000b57fffec6a5b7_light_zigbee2mqtt"],
             origin: origin,
         };
 
@@ -2490,7 +2491,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group",
             default_entity_id: "light.ha_discovery_group",
             unique_id: "9_light_zigbee2mqtt",
-            group: ["0x000b57fffec6a5b7_light_zigbee2mqtt", "0x000b57fffec6a5b4_light_zigbee2mqtt"],
+            group: ["0x000b57fffec6a5b4_light_zigbee2mqtt", "0x000b57fffec6a5b7_light_zigbee2mqtt"],
             origin: origin,
         };
 


### PR DESCRIPTION
This PR implements feature https://github.com/koenkk/zigbee2mqtt/issues/28512.
It requires Home Assistant >2026.4 for MQTT grouping (https://github.com/home-assistant/core/pull/152270).

Screenshot:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/e4935c66-f1c6-4089-8df9-6c99aabc8016" />

Note that the member entities must be already configured before the member entities will become visible in the UI at the moment a group entity is loaded. So basically you need the reload your MQTT integration after having this in Zigbee2MQTT.