### PR TITLE
fix(docs): Clarify units of pause_on_backoff_gt

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -88,7 +88,7 @@
                             "title": "Pause on backoff greater than",
                             "default": 0,
                             "minimum": 0,
-                            "description": "Pause availability pings when backoff reaches over this limit until a new Zigbee message is received from the device. A value of zero disables pausing."
+                            "description": "Pause availability pings when the backoff multiplier reaches over this limit until a new Zigbee message is received from the device. A value of zero disables pausing."
                         }
                     },
                     "required": ["timeout"]


### PR DESCRIPTION
I was a little confused when setting up availability pings: `pause_on_backoff_gt`'s description sounded like it could be seconds or miliseconds from a quick read of the docs. I'm hoping this makes it clearer for the next person.