### PR TITLE
fix: transmit power description

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -800,7 +800,7 @@
                     "requiresRestart": true,
                     "minimum": -128,
                     "maximum": 127,
-                    "description": "Transmit power of adapter, only available for Z-Stack (CC253*/CC2652/CC1352) adapters, CC2652 = 5dbm, CC1352 max is = 20dbm (5dbm default)"
+                    "description": "Transmit power of adapter, in dBm (max is often 20, refer to chip specifications)"
                 },
                 "output": {
                     "type": "string",


### PR DESCRIPTION
Thanks @Nerivec for explaining.
So when not setting this option, adapter uses a default value from its firmware?
(in that case I can reword to "Overwrite the default transmit power of the adapter")
I thought Z2M just sets it to 5 when option is not present in config.