### PR TITLE
Fix path traversal vulnerabilities

### DIFF
--- a/lib/extension/externalJS.ts
+++ b/lib/extension/externalJS.ts
@@ -13,6 +13,7 @@ import Extension from "./extension";
 
 const SUPPORTED_OPERATIONS = ["save", "remove"];
 const TMP_PREFIX = ".tmp-ed42d4f2-";
+const ALLOWED_EXTENSIONS = new Set([".js", ".cjs", ".mjs"]);
 
 export default abstract class ExternalJSExtension<M> extends Extension {
     protected folderName: string;
@@ -89,11 +90,17 @@ export default abstract class ExternalJSExtension<M> extends Extension {
     }
 
     private getFilePath(name: string, mkBasePath = false): string {
+        const target = utils.resolveSafeChildPath(this.basePath, name);
+
+        if (!ALLOWED_EXTENSIONS.has(path.extname(name).toLowerCase())) {
+            throw new Error(`Invalid file name '${name}'`);
+        }
+
         if (mkBasePath && !fs.existsSync(this.basePath)) {
             fs.mkdirSync(this.basePath, {recursive: true});
         }
 
-        return path.join(this.basePath, name);
+        return target;
     }
 
     protected getFileCode(name: string): string {

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -31,17 +31,12 @@ export interface UpdatePayload {
  * Write to `dataDir` and return created path
  */
 function writeFirmwareHexToDataDir(hex: string, fileName: string | undefined, deviceIeee: string): string {
-    if (!fileName) {
-        fileName = `${deviceIeee}_${Date.now()}`;
-    }
-
     const baseDir = dataDir.joinPath("ota");
+    const filePath = fileName ? utils.resolveSafeChildPath(baseDir, fileName) : join(baseDir, `${deviceIeee}_${Date.now()}`);
 
     if (!existsSync(baseDir)) {
         mkdirSync(baseDir, {recursive: true});
     }
-
-    const filePath = join(baseDir, fileName);
 
     writeFileSync(filePath, Buffer.from(hex, "hex"));
 
@@ -340,8 +335,13 @@ export default class OTAUpdate extends Extension {
                         if (payload.hex) {
                             assert(payload.hex.data);
 
-                            // write to `dataDir` and pass created path as source URL
-                            source.url = writeFirmwareHexToDataDir(payload.hex.data, payload.hex.file_name, device.ieeeAddr);
+                            try {
+                                // write to `dataDir` and pass created path as source URL
+                                source.url = writeFirmwareHexToDataDir(payload.hex.data, payload.hex.file_name, device.ieeeAddr);
+                            } catch (e) {
+                                error = (e as Error).message;
+                                break;
+                            }
                         } else if (payload.url) {
                             source.url = payload.url;
                         } else if (!device.definition?.ota) {
@@ -411,8 +411,13 @@ export default class OTAUpdate extends Extension {
                         if (payload.hex) {
                             assert(payload.hex.data);
 
-                            // write to `dataDir` and pass created path as source URL
-                            source.url = writeFirmwareHexToDataDir(payload.hex.data, payload.hex.file_name, device.ieeeAddr);
+                            try {
+                                // write to `dataDir` and pass created path as source URL
+                                source.url = writeFirmwareHexToDataDir(payload.hex.data, payload.hex.file_name, device.ieeeAddr);
+                            } catch (e) {
+                                error = (e as Error).message;
+                                break;
+                            }
                         } else if (payload.url) {
                             source.url = payload.url;
                         } else if (!device.definition?.ota) {
@@ -435,8 +440,14 @@ export default class OTAUpdate extends Extension {
                 }
 
                 case "unschedule": {
-                    if (device.zh.scheduledOta?.url?.startsWith(dataDir.joinPath("ota"))) {
-                        rmSync(device.zh.scheduledOta.url, {force: true});
+                    const url = device.zh.scheduledOta?.url;
+
+                    if (url) {
+                        try {
+                            rmSync(utils.resolveSafeChildPath(dataDir.joinPath("ota"), url), {force: true});
+                        } catch {
+                            // not a safe child of OTA dir (remote URL or traversal) — skip
+                        }
                     }
 
                     device.zh.unscheduleOta();

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -10,7 +10,15 @@ import type {Zigbee2MQTTAPI, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints, 
 
 import data from "./data";
 
-const BASE64_IMAGE_REGEX = /data:image\/(?<extension>.+);base64,(?<data>.+)/;
+const ICON_MIME_EXT: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+    "image/bmp": "bmp",
+};
+const BASE64_IMAGE_REGEX = /^data:(?<mime>[^;]+);base64,(?<data>.+)$/;
 
 export const DEFAULT_BIND_GROUP_ID = 901;
 
@@ -375,14 +383,19 @@ function deviceNotCoordinator(device: zh.Device): boolean {
 }
 
 function matchBase64File(value: string | undefined): {extension: string; data: string} | false {
-    if (value !== undefined) {
-        const match = value.match(BASE64_IMAGE_REGEX);
-        if (match) {
-            assert(match.groups?.extension && match.groups?.data);
-            return {extension: match.groups.extension, data: match.groups.data};
-        }
+    if (value === undefined) return false;
+
+    const match = value.match(BASE64_IMAGE_REGEX);
+    if (!match) return false;
+
+    assert(match.groups?.mime && match.groups?.data);
+    const extension = ICON_MIME_EXT[match.groups.mime];
+
+    if (!extension) {
+        throw new Error(`Unsupported icon mime type '${match.groups.mime}'`);
     }
-    return false;
+
+    return {extension, data: match.groups.data};
 }
 
 function saveBase64DeviceIcon(base64Match: {extension: string; data: string}): string {

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -398,6 +398,20 @@ function matchBase64File(value: string | undefined): {extension: string; data: s
     return {extension, data: match.groups.data};
 }
 
+// Resolve `name` against `base` and assert the result is a direct child of `base`.
+// Throws otherwise. Relies on Node's path normalization to handle traversal,
+// absolute paths, null bytes, unicode, and OS-specific quirks uniformly.
+function resolveSafeChildPath(base: string, name: string): string {
+    const baseAbs = path.resolve(base);
+    const target = path.resolve(baseAbs, name);
+
+    if (path.dirname(target) !== baseAbs) {
+        throw new Error(`Invalid file name '${name}'`);
+    }
+
+    return target;
+}
+
 function saveBase64DeviceIcon(base64Match: {extension: string; data: string}): string {
     const md5Hash = crypto.createHash("md5").update(base64Match.data).digest("hex");
     const fileSettings = `device_icons/${md5Hash}.${base64Match.extension}`;
@@ -413,6 +427,7 @@ const noop = (): void => {};
 export default {
     matchBase64File,
     saveBase64DeviceIcon,
+    resolveSafeChildPath,
     capitalize,
     getZigbee2MQTTVersion,
     getDependencyVersion,

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -3392,6 +3392,20 @@ describe("Extension: Bridge", () => {
         );
     });
 
+    it("Should reject icon data URI with disallowed mime type", async () => {
+        mockMQTTPublishAsync.mockClear();
+        const malicious = "data:image/exe;base64,QUFB";
+        mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/options", stringify({options: {icon: malicious}, id: "bulb"}));
+        await flushPromises();
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
+            "zigbee2mqtt/bridge/response/device/options",
+            expect.stringContaining("Unsupported icon mime type 'image/exe'"),
+            {},
+        );
+        expect(settings.getDevice("bulb").icon).toBeUndefined();
+    });
+
     it("Should allow to remove device option", async () => {
         mockMQTTPublishAsync.mockClear();
         settings.set(["devices", "0x000b57fffec6a5b2", "qos"], 1);

--- a/test/extensions/externalConverters.test.ts
+++ b/test/extensions/externalConverters.test.ts
@@ -608,5 +608,28 @@ describe("Extension: ExternalConverters", () => {
                 {},
             );
         });
+
+        it.each([
+            ["../escape.js", 10],
+            ["foo/bar.js", 11],
+            ["foo.txt", 12],
+            ["..", 13],
+            ["/etc/passwd", 14],
+        ])("rejects save with traversal or non-JS name '%s'", async (badName, transaction) => {
+            await resetExtension();
+            for (const mock of mocksClear) mock.mockClear();
+
+            await (controller.getExtension("ExternalConverters")! as ExternalConverters).onMQTTMessage({
+                topic: "zigbee2mqtt/bridge/request/converter/save",
+                message: {name: badName, code: "module.exports = {};", transaction},
+            });
+
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
+                "zigbee2mqtt/bridge/response/converter/save",
+                expect.stringContaining(`Invalid file name '${badName}'`),
+                {},
+            );
+            expect(writeFileSyncSpy).not.toHaveBeenCalledWith(expect.stringContaining(badName), expect.anything(), expect.anything());
+        });
     });
 });

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -8,7 +8,7 @@ import {flushPromises} from "../mocks/utils";
 import {devices, events as mockZHEvents} from "../mocks/zigbeeHerdsman";
 
 import {join} from "node:path";
-import {existsSync, readFileSync, rmSync} from "node:fs";
+import {existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import stringify from "json-stable-stringify-without-jsonify";
 import {Controller} from "../../lib/controller";
 import OTAUpdate from "../../lib/extension/otaUpdate";
@@ -407,6 +407,31 @@ describe("Extension: OTAUpdate", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bridge/devices", expect.any(String), {retain: true});
         expect(existsSync(saveFilePath)).toStrictEqual(true);
         expect(readFileSync(saveFilePath)).toStrictEqual(Buffer.from([0x01, 0x02, 0x03]));
+    });
+
+    it.each([
+        ["..", "update"],
+        [".", "update"],
+        ["../escape.hex", "update"],
+        ["..", "schedule"],
+        ["../escape.hex", "schedule"],
+    ])("rejects %s file_name on %s", async (badName, op) => {
+        const otaDir = join(data.mockDir, "ota");
+        const before = existsSync(otaDir) ? readdirSync(otaDir) : [];
+
+        mockMQTTEvents.message(
+            `zigbee2mqtt/bridge/request/device/ota_update/${op}`,
+            stringify({id: "bulb", hex: {data: "010203", file_name: badName}}),
+        );
+        await flushPromises();
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
+            `zigbee2mqtt/bridge/response/device/ota_update/${op}`,
+            expect.stringContaining(`Invalid file name '${badName}'`),
+            {},
+        );
+        const after = existsSync(otaDir) ? readdirSync(otaDir) : [];
+        expect(after).toStrictEqual(before);
     });
 
     it("updates with override data settings", async () => {
@@ -1210,6 +1235,27 @@ describe("Extension: OTAUpdate", () => {
             {},
         );
         expect(devices.bulb.scheduledOta).toStrictEqual(undefined);
+    });
+
+    it("does not rmSync outside ota dir on unschedule with traversal url", async () => {
+        const otaDir = join(data.mockDir, "ota");
+        mkdirSync(otaDir, {recursive: true});
+        const sentinelFile = join(data.mockDir, "canary.txt");
+        writeFileSync(sentinelFile, "do-not-delete");
+
+        // schedule with a payload.url that escapes the ota dir via traversal
+        const traversalUrl = join(otaDir, "..", "canary.txt");
+        mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/ota_update/schedule", stringify({id: "bulb", url: traversalUrl}));
+        await flushPromises();
+        expect(devices.bulb.scheduledOta).toStrictEqual({url: traversalUrl, downgrade: false});
+
+        mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/ota_update/unschedule", stringify({id: "bulb"}));
+        await flushPromises();
+
+        expect(existsSync(sentinelFile)).toStrictEqual(true);
+        expect(devices.bulb.scheduledOta).toStrictEqual(undefined);
+
+        rmSync(sentinelFile);
     });
 
     it("responds with NO_IMAGE_AVAILABLE when not supporting OTA", async () => {


### PR DESCRIPTION
These vulnerabilities let you access (read/write/delete) arbitrary files that the user running z2m has access to, provided you have access to MQTT directly or alternatively an unauthenticated frontend.

Each commit has more details about the issue it addresses.