### PR TITLE
feat: stop Zigbee2MQTT on MQTT disconnection

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -115,6 +115,11 @@ export class Controller {
                     logger.error("Adapter disconnected, stopping");
                     await this.stop(false, 2);
                 });
+
+                this.eventBus.onMQTTDisconnected(this, async () => {
+                    logger.error("MQTT disconnected, stopping");
+                    await this.stop(false, 3);
+                });
             }
         } catch (error) {
             // skip if aborted by `stop`

--- a/lib/eventBus.ts
+++ b/lib/eventBus.ts
@@ -27,6 +27,7 @@ interface EventBusMap {
     scenesChanged: [data: eventdata.ScenesChanged];
     reconfigure: [data: eventdata.Reconfigure];
     stateChange: [data: eventdata.StateChange];
+    mqttDisconnected: [];
 }
 type EventBusListener<K> = K extends keyof EventBusMap
     ? EventBusMap[K] extends unknown[]
@@ -63,6 +64,13 @@ export default class EventBus {
     }
     public onAdapterDisconnected(key: ListenerKey, callback: () => Promise<void>): void {
         this.on("adapterDisconnected", callback, key);
+    }
+
+    public emitMQTTDisconnected(): void {
+        this.emitter.emit("mqttDisconnected");
+    }
+    public onMQTTDisconnected(key: ListenerKey, callback: () => Promise<void>): void {
+        this.on("mqttDisconnected", callback, key);
     }
 
     public emitPermitJoinChanged(data: eventdata.PermitJoinChanged): void {

--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -142,6 +142,7 @@ export default class Mqtt {
         this.connectionTimer = setInterval(() => {
             if (!this.isConnected()) {
                 logger.error("Not connected to MQTT server!");
+                this.eventBus.emitMQTTDisconnected();
             }
         }, utils.seconds(10));
     }


### PR DESCRIPTION
Currently, when Zigbee2MQTT loses its connection to the MQTT broker, it logs an error but continues to run. This can lead to situations where the bridge remains active but is unable to communicate, requiring manual intervention or external monitoring to trigger a restart.

This PR implements an automatic shutdown mechanism when an MQTT disconnection is detected:
• Added a new mqttDisconnected event to the EventBus.
• The Mqtt class now emits this event if it detects it is no longer connected during its periodic 10-second connection check.
• The Controller listens for this event and initiates a graceful shutdown with exit code 3.

This behavior is consistent with the existing "Adapter disconnected" logic (which exits with code 2). It allows process managers like Docker or systemd to automatically restart Zigbee2MQTT upon connection failure, improving the self-healing capabilities of the bridge.

Changes
• lib/eventBus.ts: Added mqttDisconnected event and corresponding emitter/listener methods.
• lib/mqtt.ts: Updated the connection check interval to emit the mqttDisconnected event when the client is not connected.
• lib/controller.ts: Added a listener for mqttDisconnected to stop the controller and exit with code 3.