### PR TITLE
Fix default value of "optimistic" group setting

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -960,7 +960,9 @@
                     "type": "string"
                 },
                 "retain": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "title": "Retain",
+                    "description": "Retain MQTT messages of this group"
                 },
                 "optimistic": {
                     "type": "boolean",

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -855,7 +855,8 @@
                 "retain": {
                     "type": "boolean",
                     "title": "Retain",
-                    "description": "Retain MQTT messages of this device"
+                    "description": "Retain MQTT messages of this device",
+                    "default": false
                 },
                 "disabled": {
                     "type": "boolean",
@@ -962,7 +963,8 @@
                 "retain": {
                     "type": "boolean",
                     "title": "Retain",
-                    "description": "Retain MQTT messages of this group"
+                    "description": "Retain MQTT messages of this group",
+                    "default": false
                 },
                 "optimistic": {
                     "type": "boolean",

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -963,7 +963,10 @@
                     "type": "boolean"
                 },
                 "optimistic": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "title": "Optimistic",
+                    "description": "Publish the expected state of group members after set",
+                    "default": true
                 },
                 "qos": {
                     "type": ["number"],


### PR DESCRIPTION
I noticed **groups** act optimistically by default, but the user interface displays that wrong, cc @Nerivec.
For **devices** it's already correct.

> 1. Add device to group
> 2. Unplug device
> 3. Turn on group
> 4. Device state shows on
> 5. Check group settings, `optimistic` shows as false
> 6. Check `configuration.yaml`, option is not specified 

**I tested this fix and it works fine.** The schema doesn't affect any behavior, right?

Should I also add an explicit `"default": false` to the `retain` option?

Can we also have a **global** `optimistic` flag? 
(So I can have groups and devices default to false, without manually disabling the option for all of them)