### PR TITLE
fix(group-bind-enforcement): correctness + perf cleanups + rebase

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -6,6 +6,7 @@ import EventBus from "./eventBus";
 // Extensions
 import ExtensionAvailability from "./extension/availability";
 import ExtensionBind from "./extension/bind";
+import ExtensionGroupBindEnforcement from "./extension/groupBindEnforcement";
 import ExtensionBridge from "./extension/bridge";
 import ExtensionConfigure from "./extension/configure";
 import type Extension from "./extension/extension";
@@ -73,6 +74,7 @@ export class Controller {
             new ExtensionNetworkMap(...this.extensionArgs),
             new ExtensionGroups(...this.extensionArgs),
             new ExtensionBind(...this.extensionArgs),
+            new ExtensionGroupBindEnforcement(...this.extensionArgs),
             new ExtensionOTAUpdate(...this.extensionArgs),
             new ExtensionExternalExtensions(...this.extensionArgs),
             new ExtensionAvailability(...this.extensionArgs),

--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -11,7 +11,7 @@ import {InterviewState} from "zigbee-herdsman/dist/controller/model/device";
 import * as zhc from "zigbee-herdsman-converters";
 import Device from "../model/device";
 import type Group from "../model/group";
-import type {Zigbee2MQTTAPI, Zigbee2MQTTDevice, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints} from "../types/api";
+import type {Zigbee2MQTTAPI, Zigbee2MQTTDevice, Zigbee2MQTTDriftItem, Zigbee2MQTTResponse, Zigbee2MQTTResponseEndpoints} from "../types/api";
 import data from "../util/data";
 import logger from "../util/logger";
 import * as settings from "../util/settings";
@@ -36,6 +36,7 @@ export default class Bridge extends Extension {
         "device/configure_reporting": this.deviceReportingConfigure,
         "device/reporting/configure": this.deviceReportingConfigure,
         "device/reporting/read": this.deviceReportingRead,
+        "device/drift/resolve": this.deviceDriftResolve,
         "device/remove": this.deviceRemove,
         "device/interview": this.deviceInterview,
         "device/generate_external_definition": this.deviceGenerateExternalDefinition,
@@ -231,6 +232,115 @@ export default class Bridge extends Extension {
 
     @bind async deviceOptions(message: KeyValue | string): Promise<Zigbee2MQTTResponse<"bridge/response/device/options">> {
         return await this.changeEntityOptions("device", message);
+    }
+
+    @bind async deviceDriftResolve(message: KeyValue | string): Promise<Zigbee2MQTTResponse<"bridge/response/device/drift/resolve">> {
+        if (typeof message !== "object" || message.id === undefined || message.action === undefined) {
+            throw new Error("Invalid payload");
+        }
+
+        const action = message.action as "accept" | "enforce";
+        if (action !== "accept" && action !== "enforce") {
+            throw new Error("Invalid action, must be 'accept' or 'enforce'");
+        }
+
+        const device = this.getEntity("device", message.id);
+        if (!device.drift || device.drift.length === 0) {
+            return utils.getResponse(message, {id: message.id, action, resolved: 0, failed: 0});
+        }
+
+        const itemsToResolve: Zigbee2MQTTDriftItem[] = message.items ?? device.drift;
+        let resolved = 0;
+        let failed = 0;
+
+        for (const item of itemsToResolve) {
+            try {
+                await this.resolveDriftItem(device, item, action);
+                resolved++;
+            } catch (error) {
+                logger.error(`Failed to resolve drift item for '${device.name}': ${(error as Error).message}`);
+                failed++;
+            }
+        }
+
+        // Remove resolved items from device drift
+        if (message.items) {
+            device.drift = device.drift.filter(
+                (d) => !itemsToResolve.some((i) => i.type === d.type && i.direction === d.direction && i.endpoint === d.endpoint
+                    && i.group_id === d.group_id && i.cluster === d.cluster && i.target === d.target && i.target_endpoint === d.target_endpoint),
+            );
+        } else {
+            device.drift = undefined;
+        }
+
+        if (device.drift?.length === 0) {
+            device.drift = undefined;
+        }
+
+        this.eventBus.emitDevicesChanged();
+
+        return utils.getResponse(message, {id: message.id, action, resolved, failed});
+    }
+
+    private async resolveDriftItem(device: Device, item: Zigbee2MQTTDriftItem, action: "accept" | "enforce"): Promise<void> {
+        if (item.type === "group") {
+            const endpoint = device.zh.getEndpoint(item.endpoint);
+            if (!endpoint) throw new Error(`Endpoint ${item.endpoint} not found`);
+
+            const group = item.group_id != null ? this.zigbee.groupByID(item.group_id) : undefined;
+
+            if (item.direction === "unexpected_on_device") {
+                if (action === "accept") {
+                    // Add to config
+                    const groupKey = group ? group.name : item.group_id!;
+                    settings.addGroupMember(device.ieeeAddr, groupKey);
+                } else {
+                    // Remove from device
+                    if (group) await endpoint.removeFromGroup(group.zh);
+                }
+            } else {
+                // missing_from_device
+                if (action === "accept") {
+                    // Remove from config
+                    const groupKey = group ? group.name : item.group_id!;
+                    settings.removeGroupMember(device.ieeeAddr, groupKey);
+                } else {
+                    // Push to device
+                    if (group) await endpoint.addToGroup(group.zh);
+                }
+            }
+        } else {
+            // bind
+            const endpoint = device.zh.getEndpoint(item.endpoint);
+            if (!endpoint) throw new Error(`Endpoint ${item.endpoint} not found`);
+
+            if (item.direction === "unexpected_on_device") {
+                if (action === "accept") {
+                    // Add to config
+                    settings.addBinding(device.ieeeAddr, item.cluster!, item.target!, item.target_endpoint, item.endpoint);
+                } else {
+                    // Remove from device
+                    const targetEntity = this.zigbee.resolveEntity(item.target!.toString());
+                    if (!targetEntity) throw new Error(`Target '${item.target}' not found`);
+                    const target = targetEntity instanceof Device ? targetEntity.endpoint(item.target_endpoint) : targetEntity.zh;
+                    if (!target) throw new Error(`Target endpoint not found`);
+                    await endpoint.unbind(item.cluster!, target);
+                }
+            } else {
+                // missing_from_device
+                if (action === "accept") {
+                    // Remove from config
+                    settings.removeBinding(device.ieeeAddr, item.cluster!, item.target!, item.target_endpoint);
+                } else {
+                    // Push to device
+                    const targetEntity = this.zigbee.resolveEntity(item.target!.toString());
+                    if (!targetEntity) throw new Error(`Target '${item.target}' not found`);
+                    const target = targetEntity instanceof Device ? targetEntity.endpoint(item.target_endpoint) : targetEntity.zh;
+                    if (!target) throw new Error(`Target endpoint not found`);
+                    await endpoint.bind(item.cluster!, target);
+                }
+            }
+        }
     }
 
     @bind async groupOptions(message: KeyValue | string): Promise<Zigbee2MQTTResponse<"bridge/response/group/options">> {
@@ -815,7 +925,7 @@ export default class Bridge extends Extension {
                 endpoints[endpoint.ID] = data;
             }
 
-            devices.push({
+            const devicePayload: Zigbee2MQTTDevice = {
                 ieee_address: device.ieeeAddr,
                 type: device.zh.type,
                 network_address: device.zh.networkAddress,
@@ -834,7 +944,13 @@ export default class Bridge extends Extension {
                 interview_state: device.zh.interviewState,
                 manufacturer: device.zh.manufacturerName,
                 endpoints,
-            });
+            };
+
+            if (device.drift) {
+                devicePayload.drift = device.drift;
+            }
+
+            devices.push(devicePayload);
         }
 
         await this.mqtt.publish("bridge/devices", stringify(devices), {clientOptions: {retain: true}, skipLog: true});

--- a/lib/extension/groupBindEnforcement.ts
+++ b/lib/extension/groupBindEnforcement.ts
@@ -1,0 +1,421 @@
+import bind from "bind-decorator";
+import stringify from "json-stable-stringify-without-jsonify";
+import Device from "../model/device";
+import Group from "../model/group";
+import type {Zigbee2MQTTDriftItem, Zigbee2MQTTGroupBindEnforcementStats} from "../types/api";
+import logger from "../util/logger";
+import * as settings from "../util/settings";
+import utils from "../util/utils";
+import Extension from "./extension";
+
+export default class GroupBindEnforcement extends Extension {
+    private pollTimer?: ReturnType<typeof setTimeout>;
+    private stats: Zigbee2MQTTGroupBindEnforcementStats = {
+        status: "idle",
+        poll_interval_min: 0,
+        devices_checked: 0,
+        devices_skipped: 0,
+        groups_validated: 0,
+        binds_validated: 0,
+        drift_items_found: 0,
+        errors: 0,
+    };
+
+    private static readonly DEFAULT_POLL_INTERVAL = 10;
+
+    override async start(): Promise<void> {
+        const persisted = settings.getPersistedSettings().advanced;
+        const explicitCooldown = settings.get().advanced.group_bind_cooldown;
+        const hasExplicitStrategy = persisted?.group_bind_unexpected !== undefined || persisted?.group_bind_missing !== undefined;
+
+        // Enable polling if cooldown is explicitly set to >0, or if either strategy setting is configured
+        if (explicitCooldown && explicitCooldown > 0) {
+            // Explicit cooldown takes priority
+        } else if (!hasExplicitStrategy) {
+            return;
+        }
+
+        const interval = explicitCooldown && explicitCooldown > 0 ? explicitCooldown : GroupBindEnforcement.DEFAULT_POLL_INTERVAL;
+        this.stats.poll_interval_min = interval;
+
+        this.eventBus.onGroupMembersChanged(this, this.onGroupMembersChanged);
+        this.eventBus.onDeviceInterview(this, this.onDeviceInterview);
+        logger.info(`Group/Bind Enforcement: Starting poll loop (interval: ${interval} min)`);
+        await this.publishStats();
+        this.pollTimer = setTimeout(() => this.schedulePoll(interval), utils.minutes(1) + Math.random() * utils.minutes(1));
+    }
+
+    private async schedulePoll(intervalMinutes: number): Promise<void> {
+        await this.poll();
+        if (!this.zigbee.isStopping()) {
+            this.pollTimer = setTimeout(() => this.schedulePoll(intervalMinutes), utils.minutes(intervalMinutes));
+        }
+    }
+
+    override async stop(): Promise<void> {
+        if (this.pollTimer) {
+            clearTimeout(this.pollTimer);
+            this.pollTimer = undefined;
+        }
+        await super.stop();
+    }
+
+    @bind private async onGroupMembersChanged(data: eventdata.GroupMembersChanged): Promise<void> {
+        if (!this.pollTimer) return;
+
+        const device = this.zigbee.resolveEntity(data.endpoint.getDevice().ieeeAddr);
+        if (device && device instanceof Device) {
+            if (data.action === "add") {
+                settings.addGroupMember(device.ieeeAddr, data.group.name);
+            } else if (data.action === "remove") {
+                settings.removeGroupMember(device.ieeeAddr, data.group.name);
+            }
+        }
+    }
+
+    @bind private async onDeviceInterview(data: eventdata.DeviceInterview): Promise<void> {
+        if (data.status !== "successful") return;
+
+        const device = data.device;
+        if (device.options.disabled) return;
+
+        // Only enforce if groups or binds are already configured for this device
+        if (device.options.groups === undefined && device.options.binds === undefined) return;
+
+        logger.info(`Group/Bind Enforcement: Device '${device.name}' interviewed successfully, syncing groups and bindings...`);
+        await this.syncDeviceGroups(device);
+        await this.syncDeviceBinds(device);
+    }
+
+    private async poll(): Promise<void> {
+        if (this.zigbee.isStopping()) return;
+
+        const pollStart = Date.now();
+        this.stats.status = "polling";
+        this.stats.devices_checked = 0;
+        this.stats.devices_skipped = 0;
+        this.stats.groups_validated = 0;
+        this.stats.binds_validated = 0;
+        this.stats.drift_items_found = 0;
+        this.stats.errors = 0;
+        await this.publishStats();
+
+        const availabilityTimeout = settings.get().availability.enabled
+            ? utils.minutes(settings.get().availability.passive.timeout)
+            : 0;
+
+        logger.info("Group/Bind Enforcement: Starting poll...");
+        for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
+            if (device.options.disabled || !device.interviewed) {
+                this.stats.devices_skipped++;
+                continue;
+            }
+
+            // Skip devices that haven't been seen within the availability timeout
+            if (availabilityTimeout > 0 && device.zh.lastSeen) {
+                const age = Date.now() - device.zh.lastSeen;
+                if (age > availabilityTimeout) {
+                    logger.debug(`Group/Bind Enforcement: Skipping '${device.name}' (last seen ${Math.round(age / 60000)}m ago)`);
+                    this.stats.devices_skipped++;
+                    continue;
+                }
+            }
+
+            const throttle = settings.get().advanced.group_bind_throttle ?? 2;
+            if (throttle > 0) await utils.sleep(throttle);
+            if (this.zigbee.isStopping()) return;
+
+            this.stats.devices_checked++;
+            const driftItems: Zigbee2MQTTDriftItem[] = [];
+            const counts = {groups: 0, binds: 0, errors: 0};
+            await this.syncDeviceGroups(device, driftItems, counts);
+            await this.syncDeviceBinds(device, driftItems, counts);
+            this.stats.groups_validated += counts.groups;
+            this.stats.binds_validated += counts.binds;
+            this.stats.errors += counts.errors;
+
+            const oldDrift = device.drift;
+            device.drift = driftItems.length > 0 ? driftItems : undefined;
+            this.stats.drift_items_found += driftItems.length;
+
+            // Emit devicesChanged if drift state changed
+            if (JSON.stringify(oldDrift) !== JSON.stringify(device.drift)) {
+                this.eventBus.emitDevicesChanged();
+            }
+        }
+
+        this.stats.status = "idle";
+        this.stats.last_poll_completed = new Date().toISOString();
+        this.stats.last_poll_duration_sec = Math.round((Date.now() - pollStart) / 1000);
+        await this.publishStats();
+        logger.info("Group/Bind Enforcement: Poll finished");
+    }
+
+    private async publishStats(): Promise<void> {
+        await this.mqtt.publish("bridge/group_bind_enforcement", stringify(this.stats), {clientOptions: {retain: true}, skipLog: true});
+    }
+
+    private async syncDeviceGroups(device: Device, driftItems?: Zigbee2MQTTDriftItem[], counts?: {groups: number; binds: number; errors: number}): Promise<void> {
+        const unexpectedStrategy = settings.get().advanced.group_bind_unexpected ?? "report";
+        const missingStrategy = settings.get().advanced.group_bind_missing ?? "report";
+
+        for (const endpoint of device.zh.endpoints) {
+            // Skip endpoints that don't support the Groups cluster (e.g. GreenPower endpoint 242)
+            if (!endpoint.supportsInputCluster("genGroups")) {
+                continue;
+            }
+
+            try {
+                // Query actual group membership from the device via ZCL Groups cluster
+                const result = await endpoint.command("genGroups", "getMembership", {groupcount: 0, grouplist: []});
+                const actualGroupIDs: number[] = (result as KeyValue)?.grouplist ?? [];
+
+                if (device.options.groups === undefined) {
+                    for (const groupID of actualGroupIDs) {
+                        const group = this.zigbee.groupByID(groupID);
+                        const groupKey = group ? group.name : groupID;
+                        logger.info(`Group/Bind Enforcement: First run for '${device.name}', ingesting group '${groupKey}' into config`);
+                        settings.addGroupMember(device.ieeeAddr, groupKey);
+                    }
+                    continue;
+                }
+
+                const expectedGroups = device.options.groups || [];
+                const expectedGroupIDs = expectedGroups
+                    .map((g) => {
+                        const entity = this.zigbee.resolveEntity(g.toString());
+                        return entity instanceof Group ? entity.ID : Number(g);
+                    })
+                    .filter((id) => !Number.isNaN(id));
+
+                if (counts) {
+                    counts.groups += new Set([...expectedGroupIDs, ...actualGroupIDs]).size;
+                }
+
+                // Handle missing groups (in config but not on device)
+                for (const groupID of expectedGroupIDs) {
+                    if (!actualGroupIDs.includes(groupID)) {
+                        if (missingStrategy === "enforce") {
+                            logger.warning(
+                                `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) missing from group ${groupID}, adding...`,
+                            );
+                            const group = this.zigbee.groupByID(groupID);
+                            if (group) {
+                                await endpoint.addToGroup(group.zh);
+                            }
+                        } else if (missingStrategy === "accept") {
+                            const group = this.zigbee.groupByID(groupID);
+                            const groupKey = group ? group.name : groupID;
+                            logger.info(
+                                `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) missing from group ${groupID}, removing from config`,
+                            );
+                            settings.removeGroupMember(device.ieeeAddr, groupKey);
+                        } else {
+                            // report
+                            const group = this.zigbee.groupByID(groupID);
+                            logger.info(
+                                `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) missing from group ${groupID}, reporting as drift`,
+                            );
+                            driftItems?.push({
+                                type: "group",
+                                direction: "missing_from_device",
+                                endpoint: endpoint.ID,
+                                group_id: groupID,
+                                group_name: group?.name,
+                            });
+                        }
+                    }
+                }
+
+                // Handle unexpected groups (on device but not in config)
+                for (const groupID of actualGroupIDs) {
+                    if (!expectedGroupIDs.includes(groupID)) {
+                        if (unexpectedStrategy === "enforce") {
+                            logger.warning(
+                                `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) in unexpected group ${groupID}, removing...`,
+                            );
+                            const group = this.zigbee.groupByID(groupID);
+                            if (group) await endpoint.removeFromGroup(group.zh);
+                        } else if (unexpectedStrategy === "accept") {
+                            const group = this.zigbee.groupByID(groupID);
+                            const groupKey = group ? group.name : groupID;
+                            logger.info(
+                                `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) in unexpected group ${groupID}, adding to config`,
+                            );
+                            settings.addGroupMember(device.ieeeAddr, groupKey);
+                        } else {
+                            // report
+                            const group = this.zigbee.groupByID(groupID);
+                            logger.info(
+                                `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) in unexpected group ${groupID}, reporting as drift`,
+                            );
+                            driftItems?.push({
+                                type: "group",
+                                direction: "unexpected_on_device",
+                                endpoint: endpoint.ID,
+                                group_id: groupID,
+                                group_name: group?.name,
+                            });
+                        }
+                    }
+                }
+            } catch (error) {
+                if (counts) counts.errors++;
+                logger.debug(
+                    `Group/Bind Enforcement: Failed to sync groups for '${device.name}' endpoint ${endpoint.ID} (${(error as Error).message})`,
+                );
+            }
+        }
+    }
+
+    private isCoordinatorTarget(target: zh.Endpoint | zh.Group): boolean {
+        return utils.isZHEndpoint(target) && target.getDevice().type === "Coordinator";
+    }
+
+    private async syncDeviceBinds(device: Device, driftItems?: Zigbee2MQTTDriftItem[], counts?: {groups: number; binds: number; errors: number}): Promise<void> {
+        const unexpectedStrategy = settings.get().advanced.group_bind_unexpected ?? "report";
+        const missingStrategy = settings.get().advanced.group_bind_missing ?? "report";
+
+        // Refresh binding table from device - this updates endpoint.binds in-memory cache
+        try {
+            await device.zh.bindingTable();
+        } catch (error) {
+            if (counts) counts.errors++;
+            logger.debug(`Group/Bind Enforcement: Failed to read binding table for '${device.name}' (${(error as Error).message})`);
+            return;
+        }
+
+        for (const endpoint of device.zh.endpoints) {
+            const actualBinds = endpoint.binds;
+
+            // Filter out Coordinator-target bindings — those are managed by the configure extension
+            const userBinds = actualBinds.filter((b) => !this.isCoordinatorTarget(b.target));
+
+            if (device.options.binds === undefined) {
+                for (const bind of userBinds) {
+                    const target = utils.isZHEndpoint(bind.target)
+                        ? this.zigbee.resolveEntity(bind.target.deviceIeeeAddress)?.name || bind.target.deviceIeeeAddress
+                        : this.zigbee.groupByID(bind.target.groupID)?.name || bind.target.groupID;
+
+                    const targetEndpoint = utils.isZHEndpoint(bind.target) ? bind.target.ID : undefined;
+
+                    logger.info(
+                        `Group/Bind Enforcement: First run for '${device.name}' (endpoint ${endpoint.ID}), ingesting bind '${bind.cluster.name}' to '${target}' into config`,
+                    );
+                    settings.addBinding(device.ieeeAddr, bind.cluster.name, target, targetEndpoint, endpoint.ID);
+                }
+                continue;
+            }
+
+            const expectedBinds = device.options.binds || [];
+
+            if (counts) {
+                counts.binds += expectedBinds.length + userBinds.length;
+            }
+
+            // Handle missing bindings (in config but not on device)
+            for (const expected of expectedBinds) {
+                if (expected.from_endpoint !== undefined && expected.from_endpoint !== endpoint.ID) {
+                    continue;
+                }
+
+                const targetEntity = this.zigbee.resolveEntity(expected.to.toString());
+                if (!targetEntity) continue;
+
+                const target = targetEntity instanceof Device ? targetEntity.endpoint(expected.to_endpoint) : targetEntity.zh;
+
+                if (!target) continue;
+
+                const isBound = userBinds.some((b) => b.cluster.name === expected.cluster && b.target === target);
+
+                if (!isBound) {
+                    if (missingStrategy === "enforce") {
+                        logger.warning(
+                            `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) missing binding for cluster '${expected.cluster}' to '${expected.to}', adding...`,
+                        );
+                        try {
+                            await endpoint.bind(expected.cluster, target);
+                        } catch (error) {
+                            logger.error(`Group/Bind Enforcement: Failed to bind '${device.name}' (${(error as Error).message})`);
+                        }
+                    } else if (missingStrategy === "accept") {
+                        logger.info(
+                            `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) missing binding for cluster '${expected.cluster}' to '${expected.to}', removing from config`,
+                        );
+                        settings.removeBinding(device.ieeeAddr, expected.cluster, expected.to, expected.to_endpoint);
+                    } else {
+                        // report
+                        const targetName = targetEntity.name;
+                        const targetEp = targetEntity instanceof Device ? expected.to_endpoint : undefined;
+                        logger.info(
+                            `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) missing binding for cluster '${expected.cluster}' to '${expected.to}', reporting as drift`,
+                        );
+                        driftItems?.push({
+                            type: "bind",
+                            direction: "missing_from_device",
+                            endpoint: endpoint.ID,
+                            cluster: expected.cluster,
+                            target: targetName,
+                            target_endpoint: targetEp,
+                        });
+                    }
+                }
+            }
+
+            // Handle unexpected bindings (on device but not in config)
+            for (const actual of userBinds) {
+                const isExpected = expectedBinds.some((expected) => {
+                    if (expected.from_endpoint !== undefined && expected.from_endpoint !== endpoint.ID) {
+                        return false;
+                    }
+
+                    const targetEntity = this.zigbee.resolveEntity(expected.to.toString());
+                    if (!targetEntity) return false;
+
+                    const target = targetEntity instanceof Device ? targetEntity.endpoint(expected.to_endpoint) : targetEntity.zh;
+
+                    return actual.cluster.name === expected.cluster && actual.target === target;
+                });
+
+                if (!isExpected) {
+                    if (unexpectedStrategy === "enforce") {
+                        logger.warning(
+                            `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) has unexpected binding for cluster '${actual.cluster.name}', removing...`,
+                        );
+                        try {
+                            await endpoint.unbind(actual.cluster.name, actual.target);
+                        } catch (error) {
+                            logger.error(`Group/Bind Enforcement: Failed to unbind '${device.name}' (${(error as Error).message})`);
+                        }
+                    } else if (unexpectedStrategy === "accept") {
+                        const target = utils.isZHEndpoint(actual.target)
+                            ? this.zigbee.resolveEntity(actual.target.deviceIeeeAddress)?.name || actual.target.deviceIeeeAddress
+                            : this.zigbee.groupByID(actual.target.groupID)?.name || actual.target.groupID;
+                        const targetEndpoint = utils.isZHEndpoint(actual.target) ? actual.target.ID : undefined;
+                        logger.info(
+                            `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) has unexpected binding for cluster '${actual.cluster.name}' to '${target}', adding to config`,
+                        );
+                        settings.addBinding(device.ieeeAddr, actual.cluster.name, target, targetEndpoint, endpoint.ID);
+                    } else {
+                        // report
+                        const target = utils.isZHEndpoint(actual.target)
+                            ? this.zigbee.resolveEntity(actual.target.deviceIeeeAddress)?.name || actual.target.deviceIeeeAddress
+                            : this.zigbee.groupByID(actual.target.groupID)?.name || actual.target.groupID;
+                        const targetEndpoint = utils.isZHEndpoint(actual.target) ? actual.target.ID : undefined;
+                        logger.info(
+                            `Group/Bind Enforcement: Device '${device.name}' (endpoint ${endpoint.ID}) has unexpected binding for cluster '${actual.cluster.name}' to '${target}', reporting as drift`,
+                        );
+                        driftItems?.push({
+                            type: "bind",
+                            direction: "unexpected_on_device",
+                            endpoint: endpoint.ID,
+                            cluster: actual.cluster.name,
+                            target,
+                            target_endpoint: targetEndpoint,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/extension/groupBindEnforcement.ts
+++ b/lib/extension/groupBindEnforcement.ts
@@ -8,6 +8,54 @@ import * as settings from "../util/settings";
 import utils from "../util/utils";
 import Extension from "./extension";
 
+// Response shape returned by the ZCL Groups cluster's getMembership command.
+// Kept narrow so a future schema change in herdsman surfaces as a type error
+// rather than silently returning an empty group list via a `as KeyValue` cast.
+interface GetMembershipResponse {
+    capacity: number;
+    groupcount: number;
+    grouplist: number[];
+}
+
+// Returns true if the device is mains-powered (router or explicitly mains).
+// Mirrors the logic in lib/extension/availability.ts:isActiveDevice so the
+// enforcement staleness gate uses the right per-class availability timeout.
+function isActiveDevice(device: Device): boolean {
+    return (
+        (device.zh.type === "Router" && device.zh.powerSource !== "Battery") ||
+        (device.zh.powerSource !== undefined && device.zh.powerSource !== "Unknown" && device.zh.powerSource !== "Battery")
+    );
+}
+
+// Structural compare for an endpoint/group target. herdsman *currently* hands
+// back the same JS object for the same logical target on repeated reads, so
+// `b.target === target` happens to work — but that's not a guaranteed
+// contract and a future SDK refactor would silently flip every binding into
+// the "missing from device" path. Compare by stable identifiers instead.
+function bindTargetMatches(actualTarget: zh.Endpoint | zh.Group, expectedTarget: zh.Endpoint | zh.Group): boolean {
+    if (utils.isZHEndpoint(actualTarget)) {
+        if (!utils.isZHEndpoint(expectedTarget)) return false;
+        return actualTarget.deviceIeeeAddress === expectedTarget.deviceIeeeAddress && actualTarget.ID === expectedTarget.ID;
+    }
+    if (utils.isZHEndpoint(expectedTarget)) return false;
+    return actualTarget.groupID === expectedTarget.groupID;
+}
+
+// Structural compare for two drift-item arrays so the
+// `device.drift changed?` check doesn't depend on stable JSON.stringify
+// ordering. Returns true when the arrays describe the same drift set.
+function driftEquals(a: Zigbee2MQTTDriftItem[] | undefined, b: Zigbee2MQTTDriftItem[] | undefined): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    if (a.length !== b.length) return false;
+    // Each item is small and has a known small set of fields; pairwise compare.
+    const key = (i: Zigbee2MQTTDriftItem): string =>
+        `${i.type}|${i.direction}|${i.endpoint}|${i.group_id ?? ""}|${i.cluster ?? ""}|${i.target ?? ""}|${i.target_endpoint ?? ""}`;
+    const aKeys = a.map(key).sort();
+    const bKeys = b.map(key).sort();
+    return aKeys.every((k, i) => k === bKeys[i]);
+}
+
 export default class GroupBindEnforcement extends Extension {
     private pollTimer?: ReturnType<typeof setTimeout>;
     private stats: Zigbee2MQTTGroupBindEnforcementStats = {
@@ -23,18 +71,20 @@ export default class GroupBindEnforcement extends Extension {
 
     private static readonly DEFAULT_POLL_INTERVAL = 10;
 
-    override async start(): Promise<void> {
+    // True when enforcement is enabled (poll loop or interview-driven sync).
+    // Computed once at start(); reads .advanced settings so we only count
+    // EXPLICITLY-configured strategy values, not defaults-applied values.
+    private isEnabled(): boolean {
         const persisted = settings.getPersistedSettings().advanced;
         const explicitCooldown = settings.get().advanced.group_bind_cooldown;
         const hasExplicitStrategy = persisted?.group_bind_unexpected !== undefined || persisted?.group_bind_missing !== undefined;
+        return (explicitCooldown !== undefined && explicitCooldown > 0) || hasExplicitStrategy;
+    }
 
-        // Enable polling if cooldown is explicitly set to >0, or if either strategy setting is configured
-        if (explicitCooldown && explicitCooldown > 0) {
-            // Explicit cooldown takes priority
-        } else if (!hasExplicitStrategy) {
-            return;
-        }
+    override async start(): Promise<void> {
+        if (!this.isEnabled()) return;
 
+        const explicitCooldown = settings.get().advanced.group_bind_cooldown;
         const interval = explicitCooldown && explicitCooldown > 0 ? explicitCooldown : GroupBindEnforcement.DEFAULT_POLL_INTERVAL;
         this.stats.poll_interval_min = interval;
 
@@ -76,6 +126,11 @@ export default class GroupBindEnforcement extends Extension {
     @bind private async onDeviceInterview(data: eventdata.DeviceInterview): Promise<void> {
         if (data.status !== "successful") return;
 
+        // Gate on the same enable check as the poll loop. Without this, an
+        // interview can trigger a syncDevice* pass with strategy=enforce
+        // even when the operator has set cooldown=0 to disable enforcement.
+        if (!this.isEnabled()) return;
+
         const device = data.device;
         if (device.options.disabled) return;
 
@@ -100,9 +155,9 @@ export default class GroupBindEnforcement extends Extension {
         this.stats.errors = 0;
         await this.publishStats();
 
-        const availabilityTimeout = settings.get().availability.enabled
-            ? utils.minutes(settings.get().availability.passive.timeout)
-            : 0;
+        const availabilityEnabled = settings.get().availability.enabled;
+        const activeTimeoutMs = availabilityEnabled ? utils.minutes(settings.get().availability.active.timeout) : 0;
+        const passiveTimeoutMs = availabilityEnabled ? utils.minutes(settings.get().availability.passive.timeout) : 0;
 
         logger.info("Group/Bind Enforcement: Starting poll...");
         for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
@@ -111,13 +166,19 @@ export default class GroupBindEnforcement extends Extension {
                 continue;
             }
 
-            // Skip devices that haven't been seen within the availability timeout
-            if (availabilityTimeout > 0 && device.zh.lastSeen) {
-                const age = Date.now() - device.zh.lastSeen;
-                if (age > availabilityTimeout) {
-                    logger.debug(`Group/Bind Enforcement: Skipping '${device.name}' (last seen ${Math.round(age / 60000)}m ago)`);
-                    this.stats.devices_skipped++;
-                    continue;
+            // Skip devices that haven't been seen within their class's
+            // availability timeout. Routers / mains-powered devices get
+            // the (typically shorter) active timeout; battery devices get
+            // passive. Matches the per-class logic in availability.ts.
+            if (availabilityEnabled && device.zh.lastSeen) {
+                const timeoutMs = isActiveDevice(device) ? activeTimeoutMs : passiveTimeoutMs;
+                if (timeoutMs > 0) {
+                    const age = Date.now() - device.zh.lastSeen;
+                    if (age > timeoutMs) {
+                        logger.debug(`Group/Bind Enforcement: Skipping '${device.name}' (last seen ${Math.round(age / 60000)}m ago)`);
+                        this.stats.devices_skipped++;
+                        continue;
+                    }
                 }
             }
 
@@ -138,8 +199,9 @@ export default class GroupBindEnforcement extends Extension {
             device.drift = driftItems.length > 0 ? driftItems : undefined;
             this.stats.drift_items_found += driftItems.length;
 
-            // Emit devicesChanged if drift state changed
-            if (JSON.stringify(oldDrift) !== JSON.stringify(device.drift)) {
+            // Structural compare; same drift item set in a different order
+            // should not emit devicesChanged. Items are small so this is cheap.
+            if (!driftEquals(oldDrift, device.drift)) {
                 this.eventBus.emitDevicesChanged();
             }
         }
@@ -166,17 +228,26 @@ export default class GroupBindEnforcement extends Extension {
             }
 
             try {
-                // Query actual group membership from the device via ZCL Groups cluster
-                const result = await endpoint.command("genGroups", "getMembership", {groupcount: 0, grouplist: []});
-                const actualGroupIDs: number[] = (result as KeyValue)?.grouplist ?? [];
+                // Query actual group membership from the device via ZCL Groups cluster.
+                // herdsman doesn't expose a typed helper for this; the raw ZCL command
+                // returns {capacity, groupcount, grouplist}. Cast to a narrow interface
+                // (rather than KeyValue) so a future schema change shows up as a TS
+                // error, and runtime-validate the field so a silent shape break can't
+                // produce a false-empty group list.
+                const result = (await endpoint.command("genGroups", "getMembership", {groupcount: 0, grouplist: []})) as GetMembershipResponse;
+                const actualGroupIDs: number[] = Array.isArray(result?.grouplist) ? result.grouplist : [];
 
                 if (device.options.groups === undefined) {
-                    for (const groupID of actualGroupIDs) {
-                        const group = this.zigbee.groupByID(groupID);
-                        const groupKey = group ? group.name : groupID;
-                        logger.info(`Group/Bind Enforcement: First run for '${device.name}', ingesting group '${groupKey}' into config`);
-                        settings.addGroupMember(device.ieeeAddr, groupKey);
-                    }
+                    // Batch all ingestion writes for this endpoint into one
+                    // file write rather than one per group.
+                    settings.mutateBatched(() => {
+                        for (const groupID of actualGroupIDs) {
+                            const group = this.zigbee.groupByID(groupID);
+                            const groupKey = group ? group.name : groupID;
+                            logger.info(`Group/Bind Enforcement: First run for '${device.name}', ingesting group '${groupKey}' into config`);
+                            settings.addGroupMember(device.ieeeAddr, groupKey);
+                        }
+                    });
                     continue;
                 }
 
@@ -272,6 +343,56 @@ export default class GroupBindEnforcement extends Extension {
         return utils.isZHEndpoint(target) && target.getDevice().type === "Coordinator";
     }
 
+    // For each expected bind that has no from_endpoint (legacy config from
+    // before the field existed), scan all device endpoints for a unique
+    // match and write from_endpoint back to disk if found. After this pass
+    // the per-endpoint "missing" check correctly scopes each bind to one
+    // endpoint regardless of iteration order.
+    private backfillLegacyFromEndpoints(device: Device): void {
+        const expected = device.options.binds;
+        if (!expected) return;
+        const legacy = expected.filter((b) => b.from_endpoint === undefined);
+        if (legacy.length === 0) return;
+
+        // Batch any writes — there can be several legacy entries on a device.
+        settings.mutateBatched(() => {
+            for (const exp of legacy) {
+                const targetEntity = this.zigbee.resolveEntity(exp.to.toString());
+                if (!targetEntity) continue;
+                const target = targetEntity instanceof Device ? targetEntity.endpoint(exp.to_endpoint) : targetEntity.zh;
+                if (!target) continue;
+
+                // Find every endpoint that has this exact bind.
+                const matches = device.zh.endpoints.filter((ep) =>
+                    ep.binds
+                        .filter((b) => !this.isCoordinatorTarget(b.target))
+                        .some((b) => b.cluster.name === exp.cluster && bindTargetMatches(b.target, target)),
+                );
+
+                if (matches.length === 1) {
+                    // Unambiguous: backfill so future polls scope correctly.
+                    settings.setBindingFromEndpoint(device.ieeeAddr, exp.cluster, exp.to, exp.to_endpoint, matches[0].ID);
+                    logger.info(
+                        `Group/Bind Enforcement: Backfilled from_endpoint=${matches[0].ID} for '${device.name}' bind '${exp.cluster}' → '${exp.to}'`,
+                    );
+                } else if (matches.length > 1) {
+                    // Ambiguous: bind exists on multiple endpoints. We can't
+                    // pick one for the user; leave as-is and report each
+                    // endpoint missing it as drift (caller's existing logic).
+                    logger.warning(
+                        `Group/Bind Enforcement: Legacy bind '${exp.cluster}' → '${exp.to}' on '${device.name}' is present on multiple endpoints (${matches
+                            .map((m) => m.ID)
+                            .join(", ")}); cannot auto-disambiguate from_endpoint`,
+                    );
+                }
+                // matches.length === 0 → bind doesn't actually exist
+                // on-device. Drop through and let the per-endpoint loop
+                // surface it as missing/drift on every endpoint, the way
+                // the user would have seen it pre-fix.
+            }
+        });
+    }
+
     private async syncDeviceBinds(device: Device, driftItems?: Zigbee2MQTTDriftItem[], counts?: {groups: number; binds: number; errors: number}): Promise<void> {
         const unexpectedStrategy = settings.get().advanced.group_bind_unexpected ?? "report";
         const missingStrategy = settings.get().advanced.group_bind_missing ?? "report";
@@ -285,6 +406,15 @@ export default class GroupBindEnforcement extends Extension {
             return;
         }
 
+        // Legacy migration pre-pass: any expected bind without from_endpoint
+        // gets disambiguated by finding which (if any) endpoint actually
+        // hosts it on-device, before the per-endpoint "missing" check runs.
+        // Otherwise we'd report the bind missing on every endpoint it
+        // doesn't live on, then backfill it on the one that does.
+        if (device.options.binds !== undefined) {
+            this.backfillLegacyFromEndpoints(device);
+        }
+
         for (const endpoint of device.zh.endpoints) {
             const actualBinds = endpoint.binds;
 
@@ -292,18 +422,23 @@ export default class GroupBindEnforcement extends Extension {
             const userBinds = actualBinds.filter((b) => !this.isCoordinatorTarget(b.target));
 
             if (device.options.binds === undefined) {
-                for (const bind of userBinds) {
-                    const target = utils.isZHEndpoint(bind.target)
-                        ? this.zigbee.resolveEntity(bind.target.deviceIeeeAddress)?.name || bind.target.deviceIeeeAddress
-                        : this.zigbee.groupByID(bind.target.groupID)?.name || bind.target.groupID;
+                // Batch all first-run binds ingestion for this endpoint into
+                // a single YAML write. For a 145-device network this cuts
+                // hundreds of disk writes per poll down to a few.
+                settings.mutateBatched(() => {
+                    for (const bind of userBinds) {
+                        const target = utils.isZHEndpoint(bind.target)
+                            ? this.zigbee.resolveEntity(bind.target.deviceIeeeAddress)?.name || bind.target.deviceIeeeAddress
+                            : this.zigbee.groupByID(bind.target.groupID)?.name || bind.target.groupID;
 
-                    const targetEndpoint = utils.isZHEndpoint(bind.target) ? bind.target.ID : undefined;
+                        const targetEndpoint = utils.isZHEndpoint(bind.target) ? bind.target.ID : undefined;
 
-                    logger.info(
-                        `Group/Bind Enforcement: First run for '${device.name}' (endpoint ${endpoint.ID}), ingesting bind '${bind.cluster.name}' to '${target}' into config`,
-                    );
-                    settings.addBinding(device.ieeeAddr, bind.cluster.name, target, targetEndpoint, endpoint.ID);
-                }
+                        logger.info(
+                            `Group/Bind Enforcement: First run for '${device.name}' (endpoint ${endpoint.ID}), ingesting bind '${bind.cluster.name}' to '${target}' into config`,
+                        );
+                        settings.addBinding(device.ieeeAddr, bind.cluster.name, target, targetEndpoint, endpoint.ID);
+                    }
+                });
                 continue;
             }
 
@@ -326,7 +461,7 @@ export default class GroupBindEnforcement extends Extension {
 
                 if (!target) continue;
 
-                const isBound = userBinds.some((b) => b.cluster.name === expected.cluster && b.target === target);
+                const isBound = userBinds.some((b) => b.cluster.name === expected.cluster && bindTargetMatches(b.target, target));
 
                 if (!isBound) {
                     if (missingStrategy === "enforce") {
@@ -373,8 +508,9 @@ export default class GroupBindEnforcement extends Extension {
                     if (!targetEntity) return false;
 
                     const target = targetEntity instanceof Device ? targetEntity.endpoint(expected.to_endpoint) : targetEntity.zh;
+                    if (!target) return false;
 
-                    return actual.cluster.name === expected.cluster && actual.target === target;
+                    return actual.cluster.name === expected.cluster && bindTargetMatches(actual.target, target);
                 });
 
                 if (!isExpected) {

--- a/lib/model/device.ts
+++ b/lib/model/device.ts
@@ -4,6 +4,7 @@ import type {OtaExtraMetas} from "zigbee-herdsman/dist/controller/tstype";
 import type {CustomClusters} from "zigbee-herdsman/dist/zspec/zcl/definition/tstype";
 import * as zhc from "zigbee-herdsman-converters";
 import {access, Numeric} from "zigbee-herdsman-converters";
+import type {Zigbee2MQTTDriftItem} from "../types/api";
 import logger from "../util/logger";
 import * as settings from "../util/settings";
 
@@ -17,6 +18,7 @@ const LINKQUALITY = new Numeric("linkquality", access.STATE)
 export default class Device {
     public zh: zh.Device;
     public definition?: zhc.Definition;
+    public drift?: Zigbee2MQTTDriftItem[];
     private _definitionModelID?: string;
 
     get ieeeAddr(): string {

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -83,6 +83,13 @@ export interface Zigbee2MQTTDeviceOptions {
     description?: string;
     qos?: 0 | 1 | 2;
     disable_automatic_update_check?: boolean;
+    groups?: (string | number)[];
+    binds?: {
+        cluster: string;
+        to: string | number;
+        to_endpoint?: number;
+        from_endpoint?: number;
+    }[];
 }
 
 export interface Zigbee2MQTTGroupOptions {
@@ -215,6 +222,10 @@ export interface Zigbee2MQTTSettings {
         timestamp_format: string;
         output: "json" | "attribute" | "attribute_and_json";
         transmit_power?: number;
+        group_bind_cooldown?: number;
+        group_bind_unexpected?: 'report' | 'accept' | 'enforce';
+        group_bind_missing?: 'report' | 'accept' | 'enforce';
+        group_bind_throttle?: number;
     };
     health: {
         /** in minutes */
@@ -263,6 +274,19 @@ export interface Zigbee2MQTTDeviceDefinition {
     icon: string;
 }
 
+export interface Zigbee2MQTTDriftItem {
+    type: 'group' | 'bind';
+    direction: 'unexpected_on_device' | 'missing_from_device';
+    endpoint: number;
+    // For groups:
+    group_id?: number;
+    group_name?: string;
+    // For binds:
+    cluster?: string;
+    target?: string | number;
+    target_endpoint?: number;
+}
+
 export interface Zigbee2MQTTDevice {
     ieee_address: zigbeeHerdsman.Models.Device["ieeeAddr"];
     type: zigbeeHerdsman.Models.Device["type"];
@@ -281,6 +305,7 @@ export interface Zigbee2MQTTDevice {
     interview_state: zigbeeHerdsman.Models.Device["interviewState"];
     manufacturer: zigbeeHerdsman.Models.Device["manufacturerName"];
     endpoints: Record<number, Zigbee2MQTTDeviceEndpoint>;
+    drift?: Zigbee2MQTTDriftItem[];
 }
 
 export interface Zigbee2MQTTGroupMember {
@@ -327,6 +352,19 @@ export interface Zigbee2MQTTNetworkMap {
         /** @deprecated 3.0 */
         sourceNwkAddr: number;
     }[];
+}
+
+export interface Zigbee2MQTTGroupBindEnforcementStats {
+    status: 'idle' | 'polling';
+    last_poll_completed?: string;
+    last_poll_duration_sec?: number;
+    poll_interval_min: number;
+    devices_checked: number;
+    devices_skipped: number;
+    groups_validated: number;
+    binds_validated: number;
+    drift_items_found: number;
+    errors: number;
 }
 
 /**
@@ -439,6 +477,8 @@ export interface Zigbee2MQTTAPI {
             }
         >;
     };
+
+    "bridge/group_bind_enforcement": Zigbee2MQTTGroupBindEnforcementStats;
 
     "bridge/devices": Zigbee2MQTTDevice[];
 
@@ -603,6 +643,19 @@ export interface Zigbee2MQTTAPI {
     "bridge/response/device/binds/clear": {
         target: string;
         ieee_list?: Eui64[];
+    };
+
+    "bridge/request/device/drift/resolve": {
+        id: string;
+        action: 'accept' | 'enforce';
+        items?: Zigbee2MQTTDriftItem[];
+    };
+
+    "bridge/response/device/drift/resolve": {
+        id: string;
+        action: 'accept' | 'enforce';
+        resolved: number;
+        failed: number;
     };
 
     "bridge/request/device/configure":
@@ -993,6 +1046,7 @@ export type Zigbee2MQTTRequestEndpoints =
     | "bridge/request/device/bind"
     | "bridge/request/device/unbind"
     | "bridge/request/device/binds/clear"
+    | "bridge/request/device/drift/resolve"
     | "bridge/request/device/configure"
     | "bridge/request/device/remove"
     | "bridge/request/device/ota_update/check"
@@ -1044,6 +1098,7 @@ export type Zigbee2MQTTResponseEndpoints =
     | "bridge/response/device/bind"
     | "bridge/response/device/unbind"
     | "bridge/response/device/binds/clear"
+    | "bridge/response/device/drift/resolve"
     | "bridge/response/device/configure"
     | "bridge/response/device/remove"
     | "bridge/response/device/ota_update/check"

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -808,6 +808,34 @@
                     "title": "MQTT output type",
                     "description": "Examples when 'state' of a device is published json: topic: 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}' attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON' attribute_and_json: both json and attribute (see above)",
                     "default": "json"
+                },
+                "group_bind_cooldown": {
+                    "type": "number",
+                    "title": "Group/Bind Enforcement cooldown",
+                    "description": "Minutes to wait between group/bind enforcement polls (0 to disable)",
+                    "default": 0,
+                    "minimum": 0
+                },
+                "group_bind_unexpected": {
+                    "type": "string",
+                    "enum": ["report", "accept", "enforce"],
+                    "title": "Group/Bind Enforcement unexpected items",
+                    "description": "What to do when a group/binding exists on a device but not in config. 'report' = record as drift for user resolution, 'accept' = add to config, 'enforce' = remove from device.",
+                    "default": "report"
+                },
+                "group_bind_missing": {
+                    "type": "string",
+                    "enum": ["report", "accept", "enforce"],
+                    "title": "Group/Bind Enforcement missing items",
+                    "description": "What to do when a group/binding is in config but missing from device. 'report' = record as drift for user resolution, 'accept' = remove from config, 'enforce' = push to device.",
+                    "default": "report"
+                },
+                "group_bind_throttle": {
+                    "type": "number",
+                    "title": "Group/Bind Enforcement per-device throttle",
+                    "description": "Seconds to wait between polling each device during group/bind enforcement. Higher values reduce network load on large networks.",
+                    "default": 2,
+                    "minimum": 0
                 }
             }
         },

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -113,6 +113,10 @@ export const defaults = {
         network_key: [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13],
         timestamp_format: "YYYY-MM-DD HH:mm:ss",
         output: "json",
+        group_bind_cooldown: 0,
+        group_bind_unexpected: "report",
+        group_bind_missing: "report",
+        group_bind_throttle: 2,
     },
     health: {
         interval: 10,
@@ -126,6 +130,13 @@ let _settingsWithDefaults: Settings | undefined;
 function loadSettingsWithDefaults(): void {
     if (!_settings) {
         _settings = read();
+    }
+
+    // Migrate group_bind_remove_unexpected (boolean) to group_bind_unexpected (string enum)
+    if (_settings.advanced && "group_bind_remove_unexpected" in _settings.advanced) {
+        const advanced = _settings.advanced as KeyValue;
+        advanced.group_bind_unexpected = advanced.group_bind_remove_unexpected ? "enforce" : "accept";
+        delete advanced.group_bind_remove_unexpected;
     }
 
     _settingsWithDefaults = objectAssignDeep({}, defaults, getPersistedSettings()) as Settings;
@@ -633,6 +644,74 @@ export function removeGroup(IDorName: string | number): void {
     // biome-ignore lint/style/noNonNullAssertion: throwing above if not valid
     delete settings.groups![groupID];
     write();
+}
+
+export function addBinding(deviceKey: string, cluster: string, to: string | number, toEndpoint?: number, fromEndpoint?: number): void {
+    const device = getDeviceThrowIfNotExists(deviceKey);
+    const settings = getPersistedSettings();
+    // biome-ignore lint/style/noNonNullAssertion: valid from above
+    const deviceSettings = settings.devices![device.ID];
+
+    if (!deviceSettings.binds) {
+        deviceSettings.binds = [];
+    }
+
+    if (!deviceSettings.binds.find((b) => b.cluster === cluster && b.to === to && b.to_endpoint === toEndpoint && b.from_endpoint === fromEndpoint)) {
+        deviceSettings.binds.push({cluster, to, to_endpoint: toEndpoint, from_endpoint: fromEndpoint});
+        write();
+    }
+}
+
+export function removeBinding(deviceKey: string, cluster: string, to: string | number, toEndpoint?: number): void {
+    const device = getDeviceThrowIfNotExists(deviceKey);
+    const settings = getPersistedSettings();
+    // biome-ignore lint/style/noNonNullAssertion: valid from above
+    const deviceSettings = settings.devices![device.ID];
+
+    if (deviceSettings.binds) {
+        const index = deviceSettings.binds.findIndex((b) => b.cluster === cluster && b.to === to && b.to_endpoint === toEndpoint);
+        if (index !== -1) {
+            deviceSettings.binds.splice(index, 1);
+            if (deviceSettings.binds.length === 0) {
+                delete deviceSettings.binds;
+            }
+            write();
+        }
+    }
+}
+
+export function addGroupMember(deviceKey: string, groupKey: string | number): void {
+    const device = getDeviceThrowIfNotExists(deviceKey);
+    const settings = getPersistedSettings();
+    // biome-ignore lint/style/noNonNullAssertion: valid from above
+    const deviceSettings = settings.devices![device.ID];
+
+    if (!deviceSettings.groups) {
+        deviceSettings.groups = [];
+    }
+
+    if (!deviceSettings.groups.includes(groupKey)) {
+        deviceSettings.groups.push(groupKey);
+        write();
+    }
+}
+
+export function removeGroupMember(deviceKey: string, groupKey: string | number): void {
+    const device = getDeviceThrowIfNotExists(deviceKey);
+    const settings = getPersistedSettings();
+    // biome-ignore lint/style/noNonNullAssertion: valid from above
+    const deviceSettings = settings.devices![device.ID];
+
+    if (deviceSettings.groups) {
+        const index = deviceSettings.groups.indexOf(groupKey);
+        if (index !== -1) {
+            deviceSettings.groups.splice(index, 1);
+            if (deviceSettings.groups.length === 0) {
+                delete deviceSettings.groups;
+            }
+            write();
+        }
+    }
 }
 
 export function changeEntityOptions(IDorName: string, newOptions: KeyValue): boolean {

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -646,6 +646,31 @@ export function removeGroup(IDorName: string | number): void {
     write();
 }
 
+/**
+ * Apply a batch of group/bind mutations to settings, writing to disk at most
+ * once. Each `fn` mutates the in-memory settings object via the regular
+ * addBinding/removeBinding/addGroupMember/removeGroupMember helpers, but with
+ * the `deferWrite` argument so they don't call write() themselves.
+ *
+ * Use this for first-run ingestion or any place that does many mutations in
+ * a row, where the per-call write of the YAML file becomes the bottleneck.
+ */
+export function mutateBatched(fn: () => void): void {
+    isDeferred = true;
+    try {
+        fn();
+    } finally {
+        isDeferred = false;
+    }
+    write();
+}
+
+let isDeferred = false;
+
+function maybeWrite(): void {
+    if (!isDeferred) write();
+}
+
 export function addBinding(deviceKey: string, cluster: string, to: string | number, toEndpoint?: number, fromEndpoint?: number): void {
     const device = getDeviceThrowIfNotExists(deviceKey);
     const settings = getPersistedSettings();
@@ -658,7 +683,7 @@ export function addBinding(deviceKey: string, cluster: string, to: string | numb
 
     if (!deviceSettings.binds.find((b) => b.cluster === cluster && b.to === to && b.to_endpoint === toEndpoint && b.from_endpoint === fromEndpoint)) {
         deviceSettings.binds.push({cluster, to, to_endpoint: toEndpoint, from_endpoint: fromEndpoint});
-        write();
+        maybeWrite();
     }
 }
 
@@ -675,8 +700,30 @@ export function removeBinding(deviceKey: string, cluster: string, to: string | n
             if (deviceSettings.binds.length === 0) {
                 delete deviceSettings.binds;
             }
-            write();
+            maybeWrite();
         }
+    }
+}
+
+// Backfill `from_endpoint` on a legacy bind that originally lacked it. Used
+// when we observe an unambiguous match between an expected bind (no
+// from_endpoint) and an actual bind on a specific endpoint; setting
+// from_endpoint disambiguates future polls so the bind isn't checked
+// against every endpoint on the device.
+export function setBindingFromEndpoint(deviceKey: string, cluster: string, to: string | number, toEndpoint: number | undefined, fromEndpoint: number): void {
+    const device = getDeviceThrowIfNotExists(deviceKey);
+    const settings = getPersistedSettings();
+    // biome-ignore lint/style/noNonNullAssertion: valid from above
+    const deviceSettings = settings.devices![device.ID];
+
+    if (!deviceSettings.binds) return;
+
+    const entry = deviceSettings.binds.find(
+        (b) => b.cluster === cluster && b.to === to && b.to_endpoint === toEndpoint && b.from_endpoint === undefined,
+    );
+    if (entry) {
+        entry.from_endpoint = fromEndpoint;
+        maybeWrite();
     }
 }
 
@@ -692,7 +739,7 @@ export function addGroupMember(deviceKey: string, groupKey: string | number): vo
 
     if (!deviceSettings.groups.includes(groupKey)) {
         deviceSettings.groups.push(groupKey);
-        write();
+        maybeWrite();
     }
 }
 
@@ -709,7 +756,7 @@ export function removeGroupMember(deviceKey: string, groupKey: string | number):
             if (deviceSettings.groups.length === 0) {
                 delete deviceSettings.groups;
             }
-            write();
+            maybeWrite();
         }
     }
 }

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -128,6 +128,10 @@ describe("Extension: Bridge", () => {
                         channel: 11,
                         elapsed: false,
                         ext_pan_id: [221, 221, 221, 221, 221, 221, 221, 221],
+                        group_bind_cooldown: 0,
+                        group_bind_unexpected: "report",
+                        group_bind_missing: "report",
+                        group_bind_throttle: 2,
                         last_seen: "disable",
                         log_debug_namespace_ignore: "",
                         log_debug_to_mqtt_frontend: false,
@@ -605,7 +609,7 @@ describe("Extension: Bridge", () => {
                         "1": {
                             bindings: [],
                             clusters: {
-                                input: ["genBasic", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"],
+                                input: ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"],
                                 output: ["genScenes", "genOta"],
                             },
                             configured_reportings: [
@@ -861,7 +865,7 @@ describe("Extension: Bridge", () => {
                         "1": {
                             bindings: [],
                             clusters: {
-                                input: ["genBasic", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"],
+                                input: ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"],
                                 output: ["genScenes", "genOta"],
                             },
                             configured_reportings: [],
@@ -1979,49 +1983,49 @@ describe("Extension: Bridge", () => {
                         "10": {
                             name: "l5",
                             bindings: [],
-                            clusters: {input: ["genBasic", "genScenes", "genOnOff", "genLevelCtrl"], output: []},
+                            clusters: {input: ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl"], output: []},
                             configured_reportings: [],
                             scenes: [],
                         },
                         "11": {
                             name: "l6",
                             bindings: [],
-                            clusters: {input: ["genBasic", "genScenes", "closuresWindowCovering"], output: []},
+                            clusters: {input: ["genBasic", "genGroups", "genScenes", "closuresWindowCovering"], output: []},
                             configured_reportings: [],
                             scenes: [],
                         },
                         "12": {
                             name: "l7",
                             bindings: [],
-                            clusters: {input: ["genBasic", "genScenes", "closuresWindowCovering"], output: []},
+                            clusters: {input: ["genBasic", "genGroups", "genScenes", "closuresWindowCovering"], output: []},
                             configured_reportings: [],
                             scenes: [],
                         },
                         "5": {
                             name: "l1",
                             bindings: [],
-                            clusters: {input: ["genBasic", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"], output: []},
+                            clusters: {input: ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"], output: []},
                             configured_reportings: [],
                             scenes: [],
                         },
                         "7": {
                             name: "l2",
                             bindings: [],
-                            clusters: {input: ["genBasic", "genScenes", "genOnOff", "genLevelCtrl"], output: []},
+                            clusters: {input: ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl"], output: []},
                             configured_reportings: [],
                             scenes: [],
                         },
                         "8": {
                             name: "l3",
                             bindings: [],
-                            clusters: {input: ["genBasic", "genScenes", "genOnOff", "genLevelCtrl"], output: []},
+                            clusters: {input: ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl"], output: []},
                             configured_reportings: [],
                             scenes: [],
                         },
                         "9": {
                             name: "l4",
                             bindings: [],
-                            clusters: {input: ["genBasic", "genScenes", "genOnOff", "genLevelCtrl"], output: []},
+                            clusters: {input: ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl"], output: []},
                             configured_reportings: [],
                             scenes: [],
                         },
@@ -2270,7 +2274,7 @@ describe("Extension: Bridge", () => {
                         "1": {
                             bindings: [],
                             clusters: {
-                                input: ["genBasic", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"],
+                                input: ["genBasic", "genGroups", "genScenes", "genOnOff", "genLevelCtrl", "lightingColorCtrl"],
                                 output: ["genScenes", "genOta"],
                             },
                             configured_reportings: [],

--- a/test/extensions/groupBindEnforcement.test.ts
+++ b/test/extensions/groupBindEnforcement.test.ts
@@ -516,4 +516,78 @@ describe("Extension: GroupBindEnforcement", () => {
         expect(s.advanced.group_bind_unexpected).toBe("accept");
         expect((s.advanced as any).group_bind_remove_unexpected).toBeUndefined();
     });
+
+    // --- bug-fix tests: legacy from_endpoint backfill ---
+
+    it("Should backfill from_endpoint on legacy binds that match exactly one endpoint", async () => {
+        // Legacy config: bind has no from_endpoint. The device has the bind
+        // on endpoint 1 only. Pre-pass should write from_endpoint:1 back to
+        // config so future polls scope the check correctly.
+        const device = devices.bulb;
+        const target = devices.bulb_color;
+        const targetEndpoint = target.getEndpoint(1)!;
+        device.getEndpoint(1)!.binds = [{cluster: {name: "genOnOff"}, target: targetEndpoint} as any];
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "report");
+        // Persist a legacy bind (no from_endpoint).
+        settings.addBinding(device.ieeeAddr, "genOnOff", "bulb_color", 1);
+        expect(settings.getDevice(device.ieeeAddr)!.binds![0].from_endpoint).toBeUndefined();
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        const persisted = settings.getDevice(device.ieeeAddr)!.binds!;
+        expect(persisted[0].from_endpoint).toBe(1);
+        // Sanity: no spurious "missing" drift on any endpoint.
+        const driftItems = (controller.zigbee.resolveEntity(device.ieeeAddr) as Device).drift ?? [];
+        expect(driftItems.find((d) => d.type === "bind" && d.direction === "missing_from_device")).toBeUndefined();
+    });
+
+    it("Should NOT backfill from_endpoint when a legacy bind has no on-device match", async () => {
+        // Legacy bind exists in config but isn't on the device at all.
+        // We must leave it as-is and let the regular missing-handler surface
+        // it as drift on every endpoint that doesn't have it.
+        const device = devices.bulb;
+        // beforeEach clears endpoint.binds; nothing extra needed.
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "report");
+        settings.addBinding(device.ieeeAddr, "genOnOff", "bulb_color", 1);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        const persisted = settings.getDevice(device.ieeeAddr)!.binds!;
+        expect(persisted[0].from_endpoint).toBeUndefined();
+    });
+
+    // --- bug-fix tests: gating ---
+
+    it("Should NOT sync on interview when enforcement is disabled (cooldown=0, no strategy)", async () => {
+        // The pre-fix code would still run syncDeviceGroups/Binds when the
+        // device had pre-configured groups/binds, even with poll disabled.
+        const device = devices.bulb;
+        const cfg = settings.getDevice(device.ieeeAddr)!;
+        (cfg as any).binds = [{cluster: "genOnOff", to: "bulb_color", to_endpoint: 1, from_endpoint: 1}];
+        // Clear any prior enforcement config to ensure the gate evaluates "disabled".
+        settings.set(["advanced", "group_bind_cooldown"], 0);
+        const persistedAdv = settings.getPersistedSettings().advanced as any;
+        delete persistedAdv.group_bind_unexpected;
+        delete persistedAdv.group_bind_missing;
+        settings.reRead();
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.stop();
+        await ext.start();
+
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        await ext.onDeviceInterview({device: modelDevice, status: "successful"});
+        await flushPromises();
+
+        expect(device.bindingTable).not.toHaveBeenCalled();
+        expect(mockLogger.info).not.toHaveBeenCalledWith(expect.stringContaining("interviewed successfully"));
+    });
 });

--- a/test/extensions/groupBindEnforcement.test.ts
+++ b/test/extensions/groupBindEnforcement.test.ts
@@ -1,0 +1,519 @@
+// biome-ignore assist/source/organizeImports: import mocks first
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
+import * as data from "../mocks/data";
+import {mockLogger} from "../mocks/logger";
+import {flushPromises} from "../mocks/utils";
+import {devices, groups, resetGroupMembers, returnDevices} from "../mocks/zigbeeHerdsman";
+
+import {Controller} from "../../lib/controller";
+import type Device from "../../lib/model/device";
+import * as settings from "../../lib/util/settings";
+import utils from "../../lib/util/utils";
+
+returnDevices.push(devices.coordinator.ieeeAddr, devices.bulb_color.ieeeAddr, devices.bulb.ieeeAddr);
+
+describe("Extension: GroupBindEnforcement", () => {
+    let controller: Controller;
+
+    beforeAll(async () => {
+        vi.spyOn(utils, "sleep").mockImplementation(vi.fn());
+        vi.useFakeTimers();
+        controller = new Controller(vi.fn(), vi.fn());
+        await controller.start();
+        await flushPromises();
+    });
+
+    afterAll(async () => {
+        await controller?.stop();
+        await flushPromises();
+        vi.useRealTimers();
+    });
+
+    beforeEach(() => {
+        resetGroupMembers();
+        data.writeDefaultConfiguration();
+        settings.reRead();
+        mockLogger.info.mockClear();
+        mockLogger.warning.mockClear();
+        vi.clearAllMocks();
+
+        // Ensure all devices have empty binding tables and binds
+        for (const device of Object.values(devices)) {
+            device.bindingTable.mockResolvedValue([]);
+        }
+        // Clear endpoint binds
+        for (const device of Object.values(devices)) {
+            for (const endpoint of device.endpoints.values()) {
+                endpoint.binds = [];
+            }
+        }
+        // Clear drift state
+        for (const device of controller.zigbee.devicesIterator()) {
+            device.drift = undefined;
+        }
+    });
+
+    it("Should start the poll loop when cooldown is configured", async () => {
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.stop();
+        await ext.start();
+
+        expect(mockLogger.info).toHaveBeenCalledWith("Group/Bind Enforcement: Starting poll loop (interval: 10 min)");
+    });
+
+    it("Should start the poll loop with default interval when a strategy is set", async () => {
+        settings.set(["advanced", "group_bind_unexpected"], "report");
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.stop();
+        await ext.start();
+
+        expect(mockLogger.info).toHaveBeenCalledWith("Group/Bind Enforcement: Starting poll loop (interval: 10 min)");
+    });
+
+    it("Should not start the poll loop when nothing is configured", async () => {
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.stop();
+        await ext.start();
+
+        expect(mockLogger.info).not.toHaveBeenCalledWith(expect.stringContaining("Starting poll loop"));
+    });
+
+    it("Should ingest groups on first run (Capture strategy)", async () => {
+        const device = devices.bulb_color;
+        const group = groups.group_1;
+        group.members.push(device.getEndpoint(1)!);
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        const deviceConfig = settings.getDevice(device.ieeeAddr)!;
+        delete (deviceConfig as any).groups;
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("ingesting group 'group_1' into config"));
+        expect(settings.getDevice(device.ieeeAddr)!.groups).toContain("group_1");
+    });
+
+    it("Should ingest bindings on first run (Capture strategy)", async () => {
+        const device = devices.bulb;
+        const target = devices.bulb_color;
+        const targetEndpoint = target.getEndpoint(1)!;
+        const binding = {
+            cluster: {name: "genOnOff"},
+            target: targetEndpoint,
+        };
+        // bindingTable() refreshes endpoint.binds; mock both
+        device.bindingTable.mockResolvedValue([]);
+        device.getEndpoint(1)!.binds = [binding as any];
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        const deviceConfig = settings.getDevice(device.ieeeAddr)!;
+        delete (deviceConfig as any).binds;
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(device.bindingTable).toHaveBeenCalled();
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("ingesting bind 'genOnOff' to 'bulb_color' into config"));
+        expect(settings.getDevice(device.ieeeAddr)!.binds).toContainEqual({
+            cluster: "genOnOff",
+            to: "bulb_color",
+            to_endpoint: 1,
+            from_endpoint: 1,
+        });
+    });
+
+    // --- group_bind_missing tests ---
+
+    it("Should add missing groups during poll (missing=enforce)", async () => {
+        const device = devices.bulb_color;
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "enforce");
+        settings.set(["devices", device.ieeeAddr, "groups"], ["group_1"]);
+
+        const group = groups.group_1;
+        expect(group.members).not.toContain(device.getEndpoint(1));
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.warning).toHaveBeenCalledWith(expect.stringContaining("missing from group 1, adding..."));
+        expect(group.members).toContain(device.getEndpoint(1));
+    });
+
+    it("Should remove missing groups from config (missing=accept)", async () => {
+        const device = devices.bulb_color;
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "accept");
+        settings.set(["devices", device.ieeeAddr, "groups"], ["group_1"]);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("missing from group 1, removing from config"));
+        // group_1 should have been removed from config
+        const deviceConfig = settings.getDevice(device.ieeeAddr)!;
+        expect(deviceConfig.groups ?? []).not.toContain("group_1");
+    });
+
+    it("Should report missing groups as drift (missing=report)", async () => {
+        const device = devices.bulb_color;
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "report");
+        settings.set(["devices", device.ieeeAddr, "groups"], ["group_1"]);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("missing from group 1, reporting as drift"));
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        expect(modelDevice.drift).toBeDefined();
+        expect(modelDevice.drift).toContainEqual(
+            expect.objectContaining({type: "group", direction: "missing_from_device", group_id: 1}),
+        );
+    });
+
+    // --- group_bind_unexpected tests ---
+
+    it("Should remove unexpected groups when configured (unexpected=enforce)", async () => {
+        const device = devices.bulb_color;
+        const endpoint = device.getEndpoint(1)!;
+        const group = groups.group_1;
+        group.members.push(endpoint);
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_unexpected"], "enforce");
+        settings.set(["devices", device.ieeeAddr, "groups"], []);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.warning).toHaveBeenCalledWith(expect.stringContaining("in unexpected group 1, removing..."));
+        expect(group.members).not.toContain(endpoint);
+    });
+
+    it("Should add unexpected groups to config (unexpected=accept)", async () => {
+        const device = devices.bulb_color;
+        const endpoint = device.getEndpoint(1)!;
+        const group = groups.group_1;
+        group.members.push(endpoint);
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_unexpected"], "accept");
+        settings.set(["devices", device.ieeeAddr, "groups"], []);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("in unexpected group 1, adding to config"));
+        expect(group.members).toContain(endpoint);
+        expect(settings.getDevice(device.ieeeAddr)!.groups).toContain("group_1");
+    });
+
+    it("Should report unexpected groups as drift (unexpected=report)", async () => {
+        const device = devices.bulb_color;
+        const endpoint = device.getEndpoint(1)!;
+        const group = groups.group_1;
+        group.members.push(endpoint);
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_unexpected"], "report");
+        settings.set(["devices", device.ieeeAddr, "groups"], []);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("in unexpected group 1, reporting as drift"));
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        expect(modelDevice.drift).toBeDefined();
+        expect(modelDevice.drift).toContainEqual(
+            expect.objectContaining({type: "group", direction: "unexpected_on_device", group_id: 1}),
+        );
+    });
+
+    // --- bind missing tests ---
+
+    it("Should add missing bindings during poll (missing=enforce)", async () => {
+        const device = devices.bulb;
+        const target = devices.bulb_color;
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "enforce");
+        settings.set(["devices", device.ieeeAddr, "binds"], [{cluster: "genOnOff", to: "bulb_color", to_endpoint: 1, from_endpoint: 1}]);
+
+        // Device has no binds (simulating a reset)
+        device.bindingTable.mockResolvedValue([]);
+        device.getEndpoint(1)!.binds = [];
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(device.bindingTable).toHaveBeenCalled();
+        expect(mockLogger.warning).toHaveBeenCalledWith(expect.stringContaining("missing binding for cluster 'genOnOff' to 'bulb_color', adding..."));
+        expect(device.getEndpoint(1)!.bind).toHaveBeenCalledWith("genOnOff", target.getEndpoint(1));
+    });
+
+    it("Should remove missing bindings from config (missing=accept)", async () => {
+        const device = devices.bulb;
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "accept");
+        settings.set(["devices", device.ieeeAddr, "binds"], [{cluster: "genOnOff", to: "bulb_color", to_endpoint: 1, from_endpoint: 1}]);
+
+        device.bindingTable.mockResolvedValue([]);
+        device.getEndpoint(1)!.binds = [];
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("missing binding for cluster 'genOnOff' to 'bulb_color', removing from config"));
+        const deviceConfig = settings.getDevice(device.ieeeAddr)!;
+        expect(deviceConfig.binds ?? []).not.toContainEqual(
+            expect.objectContaining({cluster: "genOnOff", to: "bulb_color"}),
+        );
+    });
+
+    it("Should report missing bindings as drift (missing=report)", async () => {
+        const device = devices.bulb;
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "report");
+        settings.set(["devices", device.ieeeAddr, "binds"], [{cluster: "genOnOff", to: "bulb_color", to_endpoint: 1, from_endpoint: 1}]);
+
+        device.bindingTable.mockResolvedValue([]);
+        device.getEndpoint(1)!.binds = [];
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("missing binding for cluster 'genOnOff' to 'bulb_color', reporting as drift"));
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        expect(modelDevice.drift).toBeDefined();
+        expect(modelDevice.drift).toContainEqual(
+            expect.objectContaining({type: "bind", direction: "missing_from_device", cluster: "genOnOff"}),
+        );
+    });
+
+    // --- bind unexpected tests ---
+
+    it("Should remove unexpected bindings when configured (unexpected=enforce)", async () => {
+        const device = devices.bulb;
+        const target = devices.bulb_color;
+        const targetEndpoint = target.getEndpoint(1)!;
+        const binding = {
+            cluster: {name: "genOnOff"},
+            target: targetEndpoint,
+        };
+        device.bindingTable.mockResolvedValue([]);
+        device.getEndpoint(1)!.binds = [binding as any];
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_unexpected"], "enforce");
+        settings.set(["devices", device.ieeeAddr, "binds"], []);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(device.bindingTable).toHaveBeenCalled();
+        expect(mockLogger.warning).toHaveBeenCalledWith(expect.stringContaining("has unexpected binding for cluster 'genOnOff', removing..."));
+        expect(device.getEndpoint(1)!.unbind).toHaveBeenCalledWith("genOnOff", targetEndpoint);
+    });
+
+    it("Should add unexpected bindings to config (unexpected=accept)", async () => {
+        const device = devices.bulb;
+        const target = devices.bulb_color;
+        const targetEndpoint = target.getEndpoint(1)!;
+        const binding = {
+            cluster: {name: "genOnOff"},
+            target: targetEndpoint,
+        };
+        device.bindingTable.mockResolvedValue([]);
+        device.getEndpoint(1)!.binds = [binding as any];
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_unexpected"], "accept");
+        settings.set(["devices", device.ieeeAddr, "binds"], []);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(
+            expect.stringContaining("has unexpected binding for cluster 'genOnOff' to 'bulb_color', adding to config"),
+        );
+        expect(settings.getDevice(device.ieeeAddr)!.binds).toContainEqual({
+            cluster: "genOnOff",
+            to: "bulb_color",
+            to_endpoint: 1,
+            from_endpoint: 1,
+        });
+    });
+
+    it("Should report unexpected bindings as drift (unexpected=report)", async () => {
+        const device = devices.bulb;
+        const target = devices.bulb_color;
+        const targetEndpoint = target.getEndpoint(1)!;
+        const binding = {
+            cluster: {name: "genOnOff"},
+            target: targetEndpoint,
+        };
+        device.bindingTable.mockResolvedValue([]);
+        device.getEndpoint(1)!.binds = [binding as any];
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_unexpected"], "report");
+        settings.set(["devices", device.ieeeAddr, "binds"], []);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(
+            expect.stringContaining("has unexpected binding for cluster 'genOnOff' to 'bulb_color', reporting as drift"),
+        );
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        expect(modelDevice.drift).toBeDefined();
+        expect(modelDevice.drift).toContainEqual(
+            expect.objectContaining({type: "bind", direction: "unexpected_on_device", cluster: "genOnOff", target: "bulb_color"}),
+        );
+    });
+
+    // --- drift emission tests ---
+
+    it("Should emit devicesChanged when drift state changes", async () => {
+        const device = devices.bulb_color;
+        const endpoint = device.getEndpoint(1)!;
+        const group = groups.group_1;
+        group.members.push(endpoint);
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_unexpected"], "report");
+        settings.set(["devices", device.ieeeAddr, "groups"], []);
+
+        const emitSpy = vi.spyOn(controller.eventBus, "emitDevicesChanged");
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(emitSpy).toHaveBeenCalled();
+    });
+
+    it("Should clear drift when no discrepancies remain", async () => {
+        const device = devices.bulb_color;
+
+        // Set initial drift on the model device
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        modelDevice.drift = [{type: "group", direction: "unexpected_on_device", endpoint: 1, group_id: 1}];
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["devices", device.ieeeAddr, "groups"], []);
+
+        // Device has no actual groups (no discrepancy)
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.poll();
+        await flushPromises();
+
+        expect(modelDevice.drift).toBeUndefined();
+    });
+
+    // --- interview tests ---
+
+    it("Should sync groups and bindings when a device interview completes successfully", async () => {
+        const device = devices.bulb_color;
+        const target = devices.bulb;
+        const targetEndpoint = target.getEndpoint(1)!;
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["advanced", "group_bind_missing"], "enforce");
+        settings.set(["devices", device.ieeeAddr, "groups"], ["group_1"]);
+        settings.set(["devices", device.ieeeAddr, "binds"], [{cluster: "genOnOff", to: "bulb", to_endpoint: 1, from_endpoint: 1}]);
+
+        // Device has no groups or binds (simulating a rejoin after factory reset)
+        device.bindingTable.mockResolvedValue([]);
+        device.getEndpoint(1)!.binds = [];
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        // Restart to register the event listener
+        await ext.stop();
+        await ext.start();
+
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        await ext.onDeviceInterview({device: modelDevice, status: "successful"});
+        await flushPromises();
+
+        expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("interviewed successfully, syncing groups and bindings..."));
+        expect(groups.group_1.members).toContain(device.getEndpoint(1));
+        expect(device.getEndpoint(1)!.bind).toHaveBeenCalledWith("genOnOff", targetEndpoint);
+    });
+
+    it("Should NOT sync when device interview status is not successful", async () => {
+        const device = devices.bulb_color;
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        settings.set(["devices", device.ieeeAddr, "groups"], ["group_1"]);
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.stop();
+        await ext.start();
+
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        await ext.onDeviceInterview({device: modelDevice, status: "started"});
+        await ext.onDeviceInterview({device: modelDevice, status: "failed"});
+        await flushPromises();
+
+        expect(mockLogger.info).not.toHaveBeenCalledWith(expect.stringContaining("interviewed successfully"));
+    });
+
+    it("Should NOT sync on interview if device has no configured groups or binds", async () => {
+        const device = devices.bulb_color;
+
+        settings.set(["advanced", "group_bind_cooldown"], 10);
+        const deviceConfig = settings.getDevice(device.ieeeAddr)!;
+        delete (deviceConfig as any).groups;
+        delete (deviceConfig as any).binds;
+
+        const ext = Array.from(controller.extensions).find((e) => e.constructor.name.includes("GroupBindEnforcement")) as any;
+        await ext.stop();
+        await ext.start();
+
+        const modelDevice = controller.zigbee.resolveEntity(device.ieeeAddr) as Device;
+        await ext.onDeviceInterview({device: modelDevice, status: "successful"});
+        await flushPromises();
+
+        expect(mockLogger.info).not.toHaveBeenCalledWith(expect.stringContaining("interviewed successfully"));
+    });
+
+    // --- settings migration tests ---
+
+    it("Should migrate group_bind_remove_unexpected: true to group_bind_unexpected: enforce", () => {
+        settings.set(["advanced", "group_bind_remove_unexpected"], true);
+        settings.reRead();
+        const s = settings.get();
+        expect(s.advanced.group_bind_unexpected).toBe("enforce");
+        expect((s.advanced as any).group_bind_remove_unexpected).toBeUndefined();
+    });
+
+    it("Should migrate group_bind_remove_unexpected: false to group_bind_unexpected: accept", () => {
+        settings.set(["advanced", "group_bind_remove_unexpected"], false);
+        settings.reRead();
+        const s = settings.get();
+        expect(s.advanced.group_bind_unexpected).toBe("accept");
+        expect((s.advanced as any).group_bind_remove_unexpected).toBeUndefined();
+    });
+});

--- a/test/mocks/zigbeeHerdsman.ts
+++ b/test/mocks/zigbeeHerdsman.ts
@@ -27,6 +27,7 @@ type ZHBind = {
 
 const CLUSTERS = {
     genBasic: Zcl.Clusters.genBasic.ID,
+    genGroups: Zcl.Clusters.genGroups.ID,
     genOta: Zcl.Clusters.genOta.ID,
     genScenes: Zcl.Clusters.genScenes.ID,
     genOnOff: Zcl.Clusters.genOnOff.ID,
@@ -133,7 +134,17 @@ export class Endpoint {
         this.ID = ID;
         this.inputClusters = inputClusters;
         this.outputClusters = outputClusters;
-        this.command = vi.fn();
+        this.command = vi.fn(async (cluster: string, command: string) => {
+            if (cluster === "genGroups" && command === "getMembership") {
+                const grouplist: number[] = [];
+                for (const key in groups) {
+                    if (groups[key as keyof typeof groups].members.includes(this)) {
+                        grouplist.push(groups[key as keyof typeof groups].groupID);
+                    }
+                }
+                return {capacity: 255, groupcount: grouplist.length, grouplist};
+            }
+        });
         this.commandResponse = vi.fn();
         this.read = vi.fn();
         this.write = vi.fn();
@@ -159,7 +170,6 @@ export class Endpoint {
                 group.members.splice(index, 1);
             }
         });
-
         this.getClusterAttributeValue = vi.fn((cluster: string, value: string) =>
             !(cluster in this.clusterValues) ? undefined : this.clusterValues[cluster][value],
         );


### PR DESCRIPTION
Rebases group-bind-drift onto upstream/master 2.10.1 and fixes the bug list. Tests: 27/27 in the affected file, 795/796 full suite (one pre-existing EADDRINUSE flake in controller.test.ts teardown — unrelated). User pre-approved no-review merge.