### PR TITLE
Fix Z2M not replying to OTA requests

### DIFF
--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -150,30 +150,28 @@ export default class OTAUpdate extends Extension {
                 const deviceLastChecked = this.#lastChecked.get(data.device.ieeeAddr);
                 const check = deviceLastChecked !== undefined ? Date.now() - deviceLastChecked > updateCheckInterval : true;
 
-                if (!check) {
-                    return;
-                }
+                if (check) {
+                    this.#inProgress.add(data.device.ieeeAddr);
+                    this.#lastChecked.set(data.device.ieeeAddr, Date.now());
+                    let availableResult: OtaUpdateAvailableResult | undefined;
 
-                this.#inProgress.add(data.device.ieeeAddr);
-                this.#lastChecked.set(data.device.ieeeAddr, Date.now());
-                let availableResult: OtaUpdateAvailableResult | undefined;
+                    try {
+                        // auto-check defaults to zigbee-OTA + potential local index, and never `downgrade`
+                        availableResult = await data.device.zh.checkOta(
+                            {downgrade: false},
+                            data.data as Zcl.ClustersTypes.TClusterCommandPayload<"genOta", "queryNextImageRequest">,
+                            data.device.otaExtraMetas,
+                            data.endpoint,
+                        );
+                    } catch (error) {
+                        logger.debug(`Failed to check if OTA update available for '${data.device.name}' (${error})`);
+                    }
 
-                try {
-                    // auto-check defaults to zigbee-OTA + potential local index, and never `downgrade`
-                    availableResult = await data.device.zh.checkOta(
-                        {downgrade: false},
-                        data.data as Zcl.ClustersTypes.TClusterCommandPayload<"genOta", "queryNextImageRequest">,
-                        data.device.otaExtraMetas,
-                        data.endpoint,
-                    );
-                } catch (error) {
-                    logger.debug(`Failed to check if OTA update available for '${data.device.name}' (${error})`);
-                }
+                    await this.publishEntityState(data.device, this.#getEntityPublishPayload(data.device, availableResult ?? "idle"));
 
-                await this.publishEntityState(data.device, this.#getEntityPublishPayload(data.device, availableResult ?? "idle"));
-
-                if (availableResult?.available) {
-                    logger.info(`OTA update available for '${data.device.name}'`);
+                    if (availableResult?.available) {
+                        logger.info(`OTA update available for '${data.device.name}'`);
+                    }
                 }
             }
         }


### PR DESCRIPTION
I saw a Philips Hue bulb spamming OTA requests.

I expected Z2M to reply "No image available", so the bulb would stop asking.
Is this omitted on purpose @Nerivec?

Ctrl+F `requested OTA`: [log.log](https://github.com/user-attachments/files/28185540/log.log)

<img width="1227" height="759" alt="Screenshot From 2026-05-24 03-52-40" src="https://github.com/user-attachments/assets/26f72dcc-bf3a-41e6-87b3-0c8aadb908f5" />

