### PR TITLE
feat: allow multiple OTA override index locations

### DIFF
--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import {existsSync, mkdirSync, rmSync, writeFileSync} from "node:fs";
+import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import {join} from "node:path";
 import bind from "bind-decorator";
 import stringify from "json-stable-stringify-without-jsonify";
@@ -56,12 +56,11 @@ export default class OTAUpdate extends Extension {
     #inProgress = new Set<string>();
     #lastChecked = new Map<string, number>();
 
-    // biome-ignore lint/suspicious/useAwait: API
     override async start(): Promise<void> {
         this.eventBus.onMQTTMessage(this, this.onMQTTMessage);
         this.eventBus.onDeviceMessage(this, this.onZigbeeEvent);
 
-        setOtaConfiguration(dataDir.getPath(), settings.get().ota.zigbee_ota_override_index_location);
+        setOtaConfiguration(dataDir.getPath(), await this.#resolveOverrideIndexLocation(settings.get().ota.zigbee_ota_override_index_location));
 
         // In case Zigbee2MQTT is restared during an update, progress and remaining values are still in state, remove them.
         for (const device of this.zigbee.devicesIterator(utils.deviceNotCoordinator)) {
@@ -78,6 +77,67 @@ export default class OTAUpdate extends Extension {
     clearState(): void {
         this.#inProgress.clear();
         this.#lastChecked.clear();
+    }
+
+    /**
+     * Resolve the override index location(s); a list is fetched/read and merged into a single index in `dataDir`
+     */
+    async #resolveOverrideIndexLocation(location: string | string[] | undefined): Promise<string | undefined> {
+        if (location === undefined || typeof location === "string") {
+            return location;
+        }
+
+        const merged: unknown[] = [];
+
+        for (const source of location) {
+            try {
+                const index = await this.#readOverrideIndex(source);
+
+                if (!Array.isArray(index)) {
+                    throw new Error("expected a JSON array");
+                }
+
+                merged.push(...index);
+
+                logger.debug(`Loaded OTA override index '${source}' (${index.length} entries)`);
+            } catch (error) {
+                logger.warning(`Failed to load OTA override index '${source}', skipping it (${(error as Error).message})`);
+            }
+        }
+
+        if (merged.length === 0) {
+            logger.error("None of the configured OTA override index locations could be loaded, ignoring override index");
+
+            return undefined;
+        }
+
+        const baseDir = dataDir.joinPath("ota");
+
+        if (!existsSync(baseDir)) {
+            mkdirSync(baseDir, {recursive: true});
+        }
+
+        const mergedPath = join(baseDir, "override_index.json");
+
+        writeFileSync(mergedPath, stringify(merged));
+
+        logger.info(`Merged ${location.length} OTA override index sources (${merged.length} entries) into '${mergedPath}'`);
+
+        return mergedPath;
+    }
+
+    async #readOverrideIndex(source: string): Promise<unknown> {
+        if (/^https?:\/\//i.test(source)) {
+            const response = await fetch(source);
+
+            if (!response.ok) {
+                throw new Error(`status=${response.status}`);
+            }
+
+            return await response.json();
+        }
+
+        return JSON.parse(readFileSync(dataDir.joinPath(source), "utf8"));
     }
 
     #removeProgressAndRemainingFromState(device: Device): void {

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -167,7 +167,7 @@ export interface Zigbee2MQTTSettings {
     ota: {
         update_check_interval: number;
         disable_automatic_update_check: boolean;
-        zigbee_ota_override_index_location?: string;
+        zigbee_ota_override_index_location?: string | string[];
         image_block_request_timeout?: number;
         image_block_response_delay?: number;
         default_maximum_data_size?: number;

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -360,11 +360,12 @@
                     "default": false
                 },
                 "zigbee_ota_override_index_location": {
-                    "type": ["string", "null"],
+                    "type": ["string", "array", "null"],
+                    "items": {"type": "string"},
                     "title": "OTA index override file name",
                     "requiresRestart": true,
-                    "description": "Location of override OTA index file",
-                    "examples": ["index.json"]
+                    "description": "Location of override OTA index file (local path or URL). Can also be a list of locations: they are fetched and merged into a single index, with earlier entries taking precedence. See https://github.com/Koenkk/zigbee2mqtt/discussions/10032",
+                    "examples": ["index.json", ["index.json", "https://example.org/ota/index.json"]]
                 },
                 "image_block_request_timeout": {
                     "type": "number",

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -8,7 +8,7 @@ import {flushPromises} from "../mocks/utils";
 import {devices, events as mockZHEvents} from "../mocks/zigbeeHerdsman";
 
 import {join} from "node:path";
-import {existsSync, readFileSync, rmSync} from "node:fs";
+import {existsSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import stringify from "json-stable-stringify-without-jsonify";
 import {Controller} from "../../lib/controller";
 import OTAUpdate from "../../lib/extension/otaUpdate";
@@ -1258,6 +1258,69 @@ describe("Extension: OTAUpdate", () => {
         settings.set(["ota", "zigbee_ota_override_index_location"], "http://my.site/index.json");
         await resetExtension();
         expect(setOtaConfigurationSpy).toHaveBeenCalledWith(data.mockDir, "http://my.site/index.json");
+        setOtaConfigurationSpy.mockClear();
+
+        settings.set(["ota", "zigbee_ota_override_index_location"], undefined);
+    });
+
+    it("merges multiple override index locations into a single index", async () => {
+        const setOtaConfigurationSpy = vi.spyOn(zh, "setOtaConfiguration");
+        const localEntry = {...DEFAULT_AVAILABLE_META, imageType: 100};
+        const remoteEntry = {...DEFAULT_AVAILABLE_META, imageType: 200};
+        writeFileSync(join(data.mockDir, "local.index.json"), stringify([localEntry]));
+        const fetchSpy = vi.fn().mockResolvedValue({ok: true, json: async () => [remoteEntry]});
+        vi.stubGlobal("fetch", fetchSpy);
+
+        settings.set(["ota", "zigbee_ota_override_index_location"], ["local.index.json", "https://my.site/index.json"]);
+        await resetExtension();
+
+        const mergedPath = join(data.mockDir, "ota", "override_index.json");
+        expect(setOtaConfigurationSpy).toHaveBeenCalledWith(data.mockDir, mergedPath);
+        expect(fetchSpy).toHaveBeenCalledWith("https://my.site/index.json");
+        expect(JSON.parse(readFileSync(mergedPath, "utf8"))).toStrictEqual([localEntry, remoteEntry]);
+
+        vi.unstubAllGlobals();
+        settings.set(["ota", "zigbee_ota_override_index_location"], undefined);
+        setOtaConfigurationSpy.mockClear();
+    });
+
+    it("skips override index locations that fail to load but keeps the others", async () => {
+        const setOtaConfigurationSpy = vi.spyOn(zh, "setOtaConfiguration");
+        mockLogger.warning.mockClear();
+        const remoteEntry = {...DEFAULT_AVAILABLE_META, imageType: 200};
+        const fetchSpy = vi
+            .fn()
+            .mockResolvedValueOnce({ok: false, status: 404})
+            .mockResolvedValueOnce({ok: true, json: async () => [remoteEntry]});
+        vi.stubGlobal("fetch", fetchSpy);
+
+        settings.set(["ota", "zigbee_ota_override_index_location"], ["https://bad.site/index.json", "https://good.site/index.json"]);
+        await resetExtension();
+
+        const mergedPath = join(data.mockDir, "ota", "override_index.json");
+        expect(setOtaConfigurationSpy).toHaveBeenCalledWith(data.mockDir, mergedPath);
+        expect(JSON.parse(readFileSync(mergedPath, "utf8"))).toStrictEqual([remoteEntry]);
+        expect(mockLogger.warning).toHaveBeenCalledWith(expect.stringContaining("https://bad.site/index.json"));
+
+        vi.unstubAllGlobals();
+        settings.set(["ota", "zigbee_ota_override_index_location"], undefined);
+        setOtaConfigurationSpy.mockClear();
+    });
+
+    it("ignores override index when all locations fail to load", async () => {
+        const setOtaConfigurationSpy = vi.spyOn(zh, "setOtaConfiguration");
+        mockLogger.error.mockClear();
+        const fetchSpy = vi.fn().mockResolvedValue({ok: false, status: 500});
+        vi.stubGlobal("fetch", fetchSpy);
+
+        settings.set(["ota", "zigbee_ota_override_index_location"], ["https://bad.site/index.json"]);
+        await resetExtension();
+
+        expect(setOtaConfigurationSpy).toHaveBeenCalledWith(data.mockDir, undefined);
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining("could be loaded"));
+
+        vi.unstubAllGlobals();
+        settings.set(["ota", "zigbee_ota_override_index_location"], undefined);
         setOtaConfigurationSpy.mockClear();
     });
 


### PR DESCRIPTION
zigbee_ota_override_index_location` now accepts a list of locations in addition to a single one. When a list is given, each source (local path or URL) is fetched/read and merged into a single index, so several independent OTA index sources (e.g. community/DIY firmware) can be used at once. Earlier entries take precedence; a source that fails to load is skipped with a warning, and if all fail the override index is ignored.

Ref https://github.com/Koenkk/zigbee2mqtt/discussions/10032
