### PR TITLE
feat: add desired state scheduler

### DIFF
--- a/data/configuration.example.yaml
+++ b/data/configuration.example.yaml
@@ -38,6 +38,22 @@ mqtt:
 # Advanced settings
 advanced:
     # channel: 11
+    # Keeps verifiable device /set commands alive until the requested state is
+    # observed from the device, a newer target supersedes it, or the bounded
+    # attempts/deadline are exhausted. In a healthy network this sends only the
+    # original command: the first real state report completes the desired state.
+    # desired_state:
+    #     enabled: true
+    #     # Total sends including the first command.
+    #     max_attempts: 3
+    #     # Seconds to wait for a real state report before retrying.
+    #     retry_cooldown: 8
+    #     # Seconds after which an unresolved target is abandoned.
+    #     deadline: 90
+    #     # Orders same-burst sends by cached network-map topology and observed
+    #     # apply latency when available. Unknown topology remains FIFO and this
+    #     # never scans the network while handling a set command.
+    #     topology_ordering: true
     # Let Zigbee2MQTT generate a network key on first start
     network_key: GENERATE
     # Let Zigbee2MQTT generate a pan_id on first start

--- a/lib/extension/networkMap.ts
+++ b/lib/extension/networkMap.ts
@@ -5,6 +5,7 @@ import type {LQITableEntry, RoutingTableEntry} from "zigbee-herdsman/dist/zspec/
 import type {Zigbee2MQTTAPI, Zigbee2MQTTNetworkMap} from "../types/api";
 import logger from "../util/logger";
 import * as settings from "../util/settings";
+import topologyState from "../util/topologyState";
 import utils from "../util/utils";
 import Extension from "./extension";
 
@@ -19,6 +20,9 @@ export default class NetworkMap extends Extension {
     // biome-ignore lint/suspicious/useAwait: API
     override async start(): Promise<void> {
         this.eventBus.onMQTTMessage(this, this.onMQTTMessage);
+        this.eventBus.onDeviceJoined(this, () => topologyState.invalidateNetworkMap());
+        this.eventBus.onDeviceLeave(this, () => topologyState.invalidateNetworkMap());
+        this.eventBus.onDeviceNetworkAddressChanged(this, () => topologyState.invalidateNetworkMap());
     }
 
     @bind async onMQTTMessage(data: eventdata.MQTTMessage): Promise<void> {
@@ -34,6 +38,7 @@ export default class NetworkMap extends Extension {
 
                 const routes = typeof message === "object" && message.routes;
                 const topology = await this.networkScan(routes);
+                topologyState.updateFromNetworkMap(topology);
                 let responseData: Zigbee2MQTTAPI["bridge/response/networkmap"];
 
                 switch (type) {

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -4,8 +4,10 @@ import type * as zhc from "zigbee-herdsman-converters";
 
 import Device from "../model/device";
 import Group from "../model/group";
+import DesiredStateScheduler from "../util/desiredStateScheduler";
 import logger from "../util/logger";
 import * as settings from "../util/settings";
+import topologyState from "../util/topologyState";
 import utils from "../util/utils";
 import Extension from "./extension";
 
@@ -27,10 +29,19 @@ interface ParsedTopic {
 }
 
 export default class Publish extends Extension {
+    private desiredStateScheduler: DesiredStateScheduler | undefined;
+
     // biome-ignore lint/suspicious/useAwait: API
     override async start(): Promise<void> {
         loadTopicGetSetRegex();
+        this.desiredStateScheduler = new DesiredStateScheduler(this.eventBus);
+        this.desiredStateScheduler.start();
         this.eventBus.onMQTTMessage(this, this.onMQTTMessage);
+    }
+
+    override async stop(): Promise<void> {
+        this.desiredStateScheduler?.stop();
+        await super.stop();
     }
 
     parseTopic(topic: string): ParsedTopic | undefined {
@@ -242,31 +253,59 @@ export default class Publish extends Extension {
 
             try {
                 if (parsedTopic.type === "set" && converter.convertSet) {
-                    logger.debug(`Publishing '${parsedTopic.type}' '${key}' to '${re.name}'`);
-                    const result = await converter.convertSet(localTarget, key, value, meta);
-                    const optimistic = entitySettings.optimistic === undefined || entitySettings.optimistic;
+                    const convertSet = converter.convertSet;
+                    const publishSet = async (): Promise<KeyValue | undefined> => {
+                        logger.debug(`Publishing '${parsedTopic.type}' '${key}' to '${re.name}'`);
+                        const result = await convertSet(localTarget, key, value, meta);
+                        const optimistic = entitySettings.optimistic === undefined || entitySettings.optimistic;
+                        let desiredState: KeyValue | undefined;
 
-                    if (result?.state && optimistic) {
-                        const msg = result.state;
+                        if (result?.state && optimistic) {
+                            const msg = this.stateForEndpoint(result.state, endpointName);
 
-                        if (endpointName) {
-                            for (const key of Object.keys(msg)) {
-                                msg[`${key}_${endpointName}`] = msg[key];
-                                delete msg[key];
+                            // filter out attribute listed in filtered_optimistic
+                            utils.filterProperties(entitySettings.filtered_optimistic, msg);
+                            desiredState = {...msg};
+
+                            if (this.desiredStateScheduler?.enabled()) {
+                                await this.publishEntityState(re, msg, "publishOptimistic");
+                            } else {
+                                addToToPublish(re, msg);
                             }
                         }
 
-                        // filter out attribute listed in filtered_optimistic
-                        utils.filterProperties(entitySettings.filtered_optimistic, msg);
+                        if (result?.membersState && optimistic) {
+                            for (const [ieeeAddr, state] of Object.entries(result.membersState)) {
+                                // biome-ignore lint/style/noNonNullAssertion: might be a bit much assumed here?
+                                const entity = this.zigbee.resolveEntity(ieeeAddr)!;
 
-                        addToToPublish(re, msg);
-                    }
-
-                    if (result?.membersState && optimistic) {
-                        for (const [ieeeAddr, state] of Object.entries(result.membersState)) {
-                            // biome-ignore lint/style/noNonNullAssertion: might be a bit much assumed here?
-                            addToToPublish(this.zigbee.resolveEntity(ieeeAddr)!, state);
+                                if (this.desiredStateScheduler?.enabled()) {
+                                    await this.publishEntityState(entity, state, "publishOptimistic");
+                                } else {
+                                    addToToPublish(entity, state);
+                                }
+                            }
                         }
+
+                        return desiredState;
+                    };
+
+                    if (this.desiredStateScheduler?.enabled() && re instanceof Device && !utils.isZHGroup(localTarget)) {
+                        const useTopologyOrdering = settings.get().advanced.desired_state.topology_ordering;
+
+                        this.desiredStateScheduler.enqueue({
+                            entity: re,
+                            endpointName,
+                            endpointID: endpointOrGroupID,
+                            orderHint: useTopologyOrdering ? topologyState.orderHint(re.ieeeAddr) : 0,
+                            onApplied: (latencyMs) => topologyState.observeDesiredStateApplied(re.ieeeAddr, latencyMs),
+                            onFailed: () => topologyState.observeDesiredStateFailure(re.ieeeAddr),
+                            property: key,
+                            value,
+                            send: publishSet,
+                        });
+                    } else {
+                        await publishSet();
                     }
                 } else if (parsedTopic.type === "get" && converter.convertGet) {
                     logger.debug(`Publishing get '${parsedTopic.type}' '${key}' to '${re.name}'`);
@@ -306,5 +345,18 @@ export default class Publish extends Extension {
         }
 
         return definition?.toZigbee;
+    }
+
+    private stateForEndpoint(state: KeyValue, endpointName: string | undefined): KeyValue {
+        const msg = {...state};
+
+        if (endpointName) {
+            for (const key of Object.keys(msg)) {
+                msg[`${key}_${endpointName}`] = msg[key];
+                delete msg[key];
+            }
+        }
+
+        return msg;
     }
 }

--- a/lib/extension/receive.ts
+++ b/lib/extension/receive.ts
@@ -9,6 +9,7 @@ import * as zhc from "zigbee-herdsman-converters";
 
 import logger from "../util/logger";
 import * as settings from "../util/settings";
+import topologyState from "../util/topologyState";
 import utils from "../util/utils";
 import Extension from "./extension";
 
@@ -105,6 +106,8 @@ export default class Receive extends Extension {
     @bind async onDeviceMessage(data: eventdata.DeviceMessage): Promise<void> {
         /* v8 ignore next */
         if (!data.device) return;
+
+        topologyState.observeMessage(data.device.ieeeAddr, data.linkquality);
 
         if (!data.device.definition || !data.device.interviewed) {
             logger.debug("Skipping message, still interviewing");

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -206,6 +206,13 @@ export interface Zigbee2MQTTSettings {
         channel: number;
         adapter_concurrent?: number;
         adapter_delay?: number;
+        desired_state: {
+            enabled: boolean;
+            max_attempts: number;
+            retry_cooldown: number;
+            deadline: number;
+            topology_ordering: boolean;
+        };
         cache_state: boolean;
         cache_state_persistent: boolean;
         cache_state_send_on_startup: boolean;

--- a/lib/types/types.d.ts
+++ b/lib/types/types.d.ts
@@ -22,7 +22,7 @@ declare global {
     type Extension = TypeExtension;
 
     // Types
-    type StateChangeReason = "publishDebounce" | "groupOptimistic" | "lastSeenChanged" | "publishCached" | "publishThrottle";
+    type StateChangeReason = "publishDebounce" | "groupOptimistic" | "lastSeenChanged" | "publishCached" | "publishOptimistic" | "publishThrottle";
     type PublishEntityState = (entity: Device | Group, payload: KeyValue, stateChangeReason?: StateChangeReason) => Promise<void>;
     type RecursivePartial<T> = {[P in keyof T]?: RecursivePartial<T[P]>};
     type MakePartialExcept<T, K extends keyof T> = Partial<Omit<T, K>> & Pick<T, K>;

--- a/lib/util/desiredStateScheduler.ts
+++ b/lib/util/desiredStateScheduler.ts
@@ -1,0 +1,257 @@
+import stringify from "json-stable-stringify-without-jsonify";
+
+import type Device from "../model/device";
+import logger from "./logger";
+import * as settings from "./settings";
+
+type SendResult = KeyValue | undefined;
+
+export interface DesiredStateRequest {
+    entity: Device;
+    endpointName: string | undefined;
+    endpointID: string | number;
+    orderHint?: number;
+    onApplied?: (latencyMs: number) => void;
+    onFailed?: () => void;
+    property: string;
+    value: unknown;
+    send: () => Promise<SendResult>;
+}
+
+interface DesiredState extends DesiredStateRequest {
+    attempts: number;
+    createdAt: number;
+    deadlineAt: number;
+    failures: number;
+    inFlight: boolean;
+    nextEligibleAt: number;
+    orderHint: number;
+    sentAt: number | undefined;
+    targetHash: string;
+    targetState: KeyValue | undefined;
+    timer: NodeJS.Timeout | undefined;
+}
+
+export default class DesiredStateScheduler {
+    readonly #eventBus: EventBus;
+    readonly #states = new Map<string, DesiredState>();
+    #running = false;
+    #runScheduled = false;
+
+    constructor(eventBus: EventBus) {
+        this.#eventBus = eventBus;
+    }
+
+    public start(): void {
+        this.#eventBus.onStateChange(this, this.#onStateChange);
+    }
+
+    public stop(): void {
+        for (const state of this.#states.values()) {
+            this.#clearTimer(state);
+        }
+
+        this.#runScheduled = false;
+        this.#states.clear();
+        this.#eventBus.removeListeners(this);
+    }
+
+    public enabled(): boolean {
+        return settings.get().advanced.desired_state.enabled;
+    }
+
+    public enqueue(request: DesiredStateRequest): void {
+        const key = this.#key(request);
+        const existing = this.#states.get(key);
+        const targetHash = stringify(request.value);
+
+        if (existing) {
+            if (existing.targetHash === targetHash) {
+                existing.orderHint = request.orderHint ?? 0;
+                existing.onApplied = request.onApplied;
+                existing.onFailed = request.onFailed;
+                existing.send = request.send;
+                logger.debug(`Coalesced desired state '${key}' target '${targetHash}'`);
+                return;
+            }
+
+            this.#supersede(existing, key, targetHash);
+        }
+
+        const now = Date.now();
+        const state: DesiredState = {
+            ...request,
+            attempts: 0,
+            createdAt: now,
+            deadlineAt: now + settings.get().advanced.desired_state.deadline * 1000,
+            failures: 0,
+            inFlight: false,
+            nextEligibleAt: now,
+            orderHint: request.orderHint ?? 0,
+            sentAt: undefined,
+            targetHash,
+            targetState: undefined,
+            timer: undefined,
+        };
+
+        this.#states.set(key, state);
+        logger.debug(`Queued desired state '${key}' target '${targetHash}'`);
+        this.#scheduleRun();
+    }
+
+    #scheduleRun(): void {
+        if (this.#runScheduled) {
+            return;
+        }
+
+        this.#runScheduled = true;
+        queueMicrotask(() => {
+            this.#runScheduled = false;
+            void this.#run();
+        });
+    }
+
+    #key(request: Pick<DesiredStateRequest, "entity" | "endpointID">): string {
+        return `${request.entity.ieeeAddr}/${request.endpointID}`;
+    }
+
+    #supersede(state: DesiredState, key: string, newTargetHash: string): void {
+        this.#clearTimer(state);
+        this.#states.delete(key);
+        logger.debug(`Superseded desired state '${key}' target '${state.targetHash}' with '${newTargetHash}'`);
+    }
+
+    #clearTimer(state: DesiredState): void {
+        if (state.timer) {
+            clearTimeout(state.timer);
+            state.timer = undefined;
+        }
+    }
+
+    #onStateChange = (data: eventdata.StateChange): void => {
+        // Optimistic publishes mirror the requested payload immediately; they
+        // are useful for UI feedback but are not proof that the device applied
+        // the command. Only later, non-optimistic state changes can complete.
+        if (data.reason === "publishOptimistic" || !data.entity.isDevice()) {
+            return;
+        }
+
+        for (const [key, state] of this.#states) {
+            if (state.entity.ieeeAddr !== data.entity.ieeeAddr || !state.targetState) {
+                continue;
+            }
+
+            if (this.#isApplied(state.targetState, data.to)) {
+                if (state.sentAt !== undefined) {
+                    state.onApplied?.(Date.now() - state.sentAt);
+                }
+
+                this.#complete(key, state, "applied");
+            }
+        }
+
+        this.#scheduleRun();
+    };
+
+    #complete(key: string, state: DesiredState, status: "applied" | "failed" | "one-shot"): void {
+        this.#clearTimer(state);
+        this.#states.delete(key);
+        if (status === "failed") {
+            state.onFailed?.();
+        }
+
+        logger.debug(`Desired state '${key}' ${status} after ${state.attempts} attempt(s)`);
+    }
+
+    #isApplied(targetState: KeyValue, current: KeyValue): boolean {
+        for (const [key, value] of Object.entries(targetState)) {
+            if (current[key] !== value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    async #run(): Promise<void> {
+        if (this.#running) {
+            return;
+        }
+
+        this.#running = true;
+
+        try {
+            while (true) {
+                const state = this.#nextEligible();
+
+                if (!state) {
+                    break;
+                }
+
+                await this.#send(state);
+            }
+        } finally {
+            this.#running = false;
+        }
+    }
+
+    #nextEligible(): DesiredState | undefined {
+        const now = Date.now();
+        const candidates = Array.from(this.#states.values()).filter((state) => !state.inFlight && state.nextEligibleAt <= now);
+
+        candidates.sort((a, b) => {
+            // If one target keeps failing, let other devices make progress
+            // before returning to it. Among equally healthy targets, preserve
+            // FIFO order.
+            const failureDiff = a.failures - b.failures;
+            if (failureDiff !== 0) return failureDiff;
+
+            const orderHintDiff = b.orderHint - a.orderHint;
+            if (orderHintDiff !== 0) return orderHintDiff;
+
+            return a.createdAt - b.createdAt;
+        });
+
+        return candidates[0];
+    }
+
+    async #send(state: DesiredState): Promise<void> {
+        const key = this.#key(state);
+        const config = settings.get().advanced.desired_state;
+
+        if (Date.now() >= state.deadlineAt || state.attempts >= config.max_attempts) {
+            this.#complete(key, state, "failed");
+            return;
+        }
+
+        state.inFlight = true;
+        state.attempts += 1;
+        state.sentAt = Date.now();
+
+        try {
+            logger.debug(`Sending desired state '${key}' attempt ${state.attempts}/${config.max_attempts}`);
+            const targetState = await state.send();
+
+            if (targetState && Object.keys(targetState).length) {
+                state.targetState = targetState;
+            } else {
+                this.#complete(key, state, "one-shot");
+                return;
+            }
+        } catch (error) {
+            state.failures += 1;
+            state.onFailed?.();
+            logger.debug(`Desired state '${key}' send failed on attempt ${state.attempts}: '${error}'`);
+        } finally {
+            state.inFlight = false;
+        }
+
+        if (this.#states.get(key) !== state) {
+            return;
+        }
+
+        state.nextEligibleAt = Date.now() + config.retry_cooldown * 1000;
+        this.#clearTimer(state);
+        state.timer = setTimeout(() => void this.#run(), Math.max(0, state.nextEligibleAt - Date.now()));
+    }
+}

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -736,6 +736,58 @@
                     "default": null,
                     "description": "Adapter delay"
                 },
+                "desired_state": {
+                    "type": "object",
+                    "title": "Desired state",
+                    "description": "Apply verifiable device set commands until the requested state is observed, superseded or exhausted. When the first command is confirmed by a normal device state update, no retry is sent.",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "title": "Enable desired state scheduler",
+                            "description": "When enabled, Zigbee2MQTT tracks optimistic device set commands and retries only if the requested state is not later observed. Set to false to keep the old one-shot behavior.",
+                            "default": true
+                        },
+                        "max_attempts": {
+                            "type": "number",
+                            "minimum": 1,
+                            "maximum": 10,
+                            "default": 3,
+                            "title": "Maximum desired state attempts",
+                            "description": "Maximum total sends for one unresolved desired state, including the initial send"
+                        },
+                        "retry_cooldown": {
+                            "type": "number",
+                            "minimum": 1,
+                            "maximum": 300,
+                            "default": 8,
+                            "title": "Desired state retry cooldown",
+                            "description": "Seconds to wait before retrying a desired state after it was not observed"
+                        },
+                        "deadline": {
+                            "type": "number",
+                            "minimum": 1,
+                            "maximum": 3600,
+                            "default": 90,
+                            "title": "Desired state deadline",
+                            "description": "Seconds after which an unresolved desired state is failed"
+                        },
+                        "topology_ordering": {
+                            "type": "boolean",
+                            "default": true,
+                            "title": "Desired state topology ordering",
+                            "description": "Order same-burst desired state sends by cached topology and observed apply latency when available. This never performs a network scan while handling a set command; unknown topology falls back to FIFO."
+                        }
+                    },
+                    "required": ["enabled", "max_attempts", "retry_cooldown", "deadline", "topology_ordering"],
+                    "additionalProperties": false,
+                    "default": {
+                        "enabled": true,
+                        "max_attempts": 3,
+                        "retry_cooldown": 8,
+                        "deadline": 90,
+                        "topology_ordering": true
+                    }
+                },
                 "cache_state": {
                     "type": "boolean",
                     "title": "Cache state",

--- a/lib/util/settings.ts
+++ b/lib/util/settings.ts
@@ -105,6 +105,13 @@ export const defaults = {
         channel: 11,
         adapter_concurrent: undefined,
         adapter_delay: undefined,
+        desired_state: {
+            enabled: true,
+            max_attempts: 3,
+            retry_cooldown: 8,
+            deadline: 90,
+            topology_ordering: true,
+        },
         cache_state: true,
         cache_state_persistent: true,
         cache_state_send_on_startup: true,

--- a/lib/util/topologyState.ts
+++ b/lib/util/topologyState.ts
@@ -1,0 +1,113 @@
+import type {Zigbee2MQTTNetworkMap} from "../types/api";
+
+interface DeviceTopology {
+    applyLatencyMs: number | undefined;
+    depth: number | undefined;
+    failures: number;
+    lastHeardAt: number | undefined;
+    lastHopLqi: number | undefined;
+    pathLqi: number | undefined;
+}
+
+const DEFAULT_TOPOLOGY: DeviceTopology = {
+    applyLatencyMs: undefined,
+    depth: undefined,
+    failures: 0,
+    lastHeardAt: undefined,
+    lastHopLqi: undefined,
+    pathLqi: undefined,
+};
+
+class TopologyState {
+    #devices = new Map<string, DeviceTopology>();
+    #networkMapValid = false;
+
+    public clear(): void {
+        this.#devices.clear();
+        this.#networkMapValid = false;
+    }
+
+    public invalidateNetworkMap(): void {
+        this.#networkMapValid = false;
+
+        for (const topology of this.#devices.values()) {
+            topology.depth = undefined;
+            topology.pathLqi = undefined;
+        }
+    }
+
+    public updateFromNetworkMap(topology: Zigbee2MQTTNetworkMap): void {
+        const next = new Map<string, DeviceTopology>();
+
+        for (const node of topology.nodes) {
+            const existing = this.#get(node.ieeeAddr);
+            next.set(node.ieeeAddr, {
+                ...existing,
+                depth: node.type === "Coordinator" ? 0 : undefined,
+                pathLqi: undefined,
+            });
+        }
+
+        for (const link of topology.links) {
+            const current = next.get(link.source.ieeeAddr) ?? this.#get(link.source.ieeeAddr);
+
+            next.set(link.source.ieeeAddr, {
+                ...current,
+                depth: current.depth === undefined ? link.depth : Math.max(current.depth, link.depth),
+                pathLqi: current.pathLqi === undefined ? link.lqi : Math.min(current.pathLqi, link.lqi),
+            });
+        }
+
+        for (const [ieeeAddr, existing] of this.#devices) {
+            if (!next.has(ieeeAddr)) {
+                next.set(ieeeAddr, {...existing, depth: undefined, pathLqi: undefined});
+            }
+        }
+
+        this.#devices = next;
+        this.#networkMapValid = true;
+    }
+
+    public observeMessage(ieeeAddr: string, linkquality: number, now = Date.now()): void {
+        const topology = this.#get(ieeeAddr);
+        topology.lastHeardAt = now;
+        topology.lastHopLqi = linkquality;
+        this.#devices.set(ieeeAddr, topology);
+    }
+
+    public observeDesiredStateApplied(ieeeAddr: string, latencyMs: number): void {
+        const topology = this.#get(ieeeAddr);
+        topology.applyLatencyMs = topology.applyLatencyMs === undefined ? latencyMs : Math.round((topology.applyLatencyMs + latencyMs) / 2);
+        topology.failures = Math.max(0, topology.failures - 1);
+        this.#devices.set(ieeeAddr, topology);
+    }
+
+    public observeDesiredStateFailure(ieeeAddr: string): void {
+        const topology = this.#get(ieeeAddr);
+        topology.failures += 1;
+        this.#devices.set(ieeeAddr, topology);
+    }
+
+    public orderHint(ieeeAddr: string): number {
+        const topology = this.#devices.get(ieeeAddr);
+
+        if (!topology) {
+            return 0;
+        }
+
+        // Keep the score deterministic and monotonic. Depth from a fresh network
+        // map represents topology distance. Passive message LQI is last-hop only
+        // on Ember, so it is not used as distance.
+        const depth = this.#networkMapValid && topology.depth !== undefined ? topology.depth : 0;
+        const applyLatency = topology.applyLatencyMs ?? 0;
+        const pathWeakness = this.#networkMapValid && topology.pathLqi !== undefined ? 255 - topology.pathLqi : 0;
+
+        return depth * 1_000_000_000 + topology.failures * 1_000_000 + applyLatency * 1_000 + pathWeakness;
+    }
+
+    #get(ieeeAddr: string): DeviceTopology {
+        return {...DEFAULT_TOPOLOGY, ...this.#devices.get(ieeeAddr)};
+    }
+}
+
+export default new TopologyState();

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -126,6 +126,13 @@ describe("Extension: Bridge", () => {
                         cache_state_persistent: true,
                         cache_state_send_on_startup: true,
                         channel: 11,
+                        desired_state: {
+                            deadline: 90,
+                            enabled: true,
+                            max_attempts: 3,
+                            retry_cooldown: 8,
+                            topology_ordering: true,
+                        },
                         elapsed: false,
                         ext_pan_id: [221, 221, 221, 221, 221, 221, 221, 221],
                         last_seen: "disable",

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -42,6 +42,7 @@ describe("Extension: Groups", () => {
         resetGroupMembers();
         data.writeDefaultConfiguration();
         settings.reRead();
+        settings.set(["advanced", "desired_state", "enabled"], false);
         mockMQTTPublishAsync.mockClear();
         groups.gledopto_group.command.mockClear();
         zhcGlobalStore.clear();

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -44,6 +44,7 @@ describe("Extension: Publish", () => {
         data.writeDefaultConfiguration();
         controller.state.clear();
         settings.reRead();
+        settings.set(["advanced", "desired_state", "enabled"], false);
         loadTopicGetSetRegex();
         for (const mock of mocksClear) mock.mockClear();
         for (const key in devices) {
@@ -61,9 +62,9 @@ describe("Extension: Publish", () => {
     });
 
     afterAll(async () => {
-        await vi.runOnlyPendingTimersAsync();
         mockSleep.restore();
         await controller?.stop();
+        await vi.runOnlyPendingTimersAsync();
         await flushPromises();
         vi.useRealTimers();
     });
@@ -116,6 +117,72 @@ describe("Extension: Publish", () => {
         expect(mockMQTTPublishAsync.mock.calls[0][0]).toStrictEqual("zigbee2mqtt/wohnzimmer.light.wall.right");
         expect(JSON.parse(mockMQTTPublishAsync.mock.calls[0][1])).toStrictEqual({state: "ON"});
         expect(mockMQTTPublishAsync.mock.calls[0][2]).toStrictEqual({qos: 0, retain: false});
+    });
+
+    it("Should coalesce duplicate desired state publishes until observed", async () => {
+        settings.set(["advanced", "desired_state", "enabled"], true);
+        settings.set(["advanced", "desired_state", "retry_cooldown"], 8);
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr)!;
+        const endpoint = device.zh.getEndpoint(1)!;
+
+        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "ON"}));
+        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "ON"}));
+        await flushPromises();
+
+        expect(endpoint.command).toHaveBeenCalledTimes(1);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(8000);
+        await flushPromises();
+
+        expect(endpoint.command).toHaveBeenCalledTimes(2);
+
+        controller.state.set(device, {state: "ON"});
+        await vi.advanceTimersByTimeAsync(8000);
+        await flushPromises();
+
+        expect(endpoint.command).toHaveBeenCalledTimes(2);
+    });
+
+    it("Should not retry desired state when the first send is observed", async () => {
+        settings.set(["advanced", "desired_state", "enabled"], true);
+        settings.set(["advanced", "desired_state", "topology_ordering"], false);
+        settings.set(["advanced", "desired_state", "retry_cooldown"], 8);
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr)!;
+        const endpoint = device.zh.getEndpoint(1)!;
+
+        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "ON"}));
+        await flushPromises();
+
+        expect(endpoint.command).toHaveBeenCalledTimes(1);
+
+        controller.state.set(device, {state: "ON"});
+        await vi.advanceTimersByTimeAsync(8000);
+        await flushPromises();
+
+        expect(endpoint.command).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should supersede old desired state targets", async () => {
+        settings.set(["advanced", "desired_state", "enabled"], true);
+        settings.set(["advanced", "desired_state", "retry_cooldown"], 8);
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr)!;
+        const endpoint = device.zh.getEndpoint(1)!;
+
+        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "ON"}));
+        await flushPromises();
+        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "OFF"}));
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(8000);
+        await flushPromises();
+
+        expect(endpoint.command.mock.calls).toEqual([
+            ["genOnOff", "on", {}, {}],
+            ["genOnOff", "off", {}, {}],
+            ["genOnOff", "off", {}, {}],
+        ]);
+
+        controller.state.set(device, {state: "OFF"});
     });
 
     it("Should publish messages to zigbee devices when brightness is in %", async () => {
@@ -485,6 +552,19 @@ describe("Extension: Publish", () => {
         group.members.pop();
     });
 
+    it("Should publish desired member state for groups when desired state is enabled", async () => {
+        settings.set(["advanced", "desired_state", "enabled"], true);
+        const group = groups.group_1;
+        group.members.push(devices.bulb_color.getEndpoint(1)!);
+        await mockMQTTEvents.message("zigbee2mqtt/group_1/set", stringify({state: "ON"}));
+        await flushPromises();
+        expect(group.command).toHaveBeenCalledTimes(1);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2); // 'zigbee2mqtt/bulb_color' + below
+        expect(mockMQTTPublishAsync.mock.calls[1][0]).toStrictEqual("zigbee2mqtt/group_1");
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON"});
+        group.members.pop();
+    });
+
     it("Should publish messages to groups with brightness_percent", async () => {
         const group = groups.group_1;
         group.members.push(devices.bulb_color.getEndpoint(1)!);
@@ -647,6 +727,29 @@ describe("Extension: Publish", () => {
         await mockMQTTEvents.message("zigbee2mqtt/group_2/set", stringify({brightness: "200"}));
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(0);
+    });
+
+    it("Should publish desired member state from device converters", async () => {
+        settings.set(["advanced", "desired_state", "enabled"], true);
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr)!;
+        const originalDefinition = device.definition;
+        device.definition = {
+            ...device.definition!,
+            toZigbee: [
+                {
+                    key: ["members_state_test"],
+                    convertSet: vi.fn().mockResolvedValue({membersState: {[devices.bulb.ieeeAddr]: {state: "ON"}}}),
+                },
+            ],
+        };
+
+        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({members_state_test: "ON"}));
+        await flushPromises();
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
+        expect(mockMQTTPublishAsync.mock.calls[0][0]).toStrictEqual("zigbee2mqtt/bulb");
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[0][1])).toStrictEqual({state: "ON"});
+        device.definition = originalDefinition;
     });
 
     it("Should handle non-valid topics", async () => {

--- a/test/extensions/receive.test.ts
+++ b/test/extensions/receive.test.ts
@@ -664,9 +664,10 @@ describe("Extension: Receive", () => {
         settings.set(["advanced", "elapsed"], true);
         const device = devices.E1743;
         const payload = {data: {}, cluster: "genLevelCtrl", device, endpoint: device.getEndpoint(1), type: "commandStopWithOnOff"};
-        vi.spyOn(Date, "now").mockReturnValueOnce(150).mockReturnValueOnce(200);
+        vi.setSystemTime(150);
         await mockZHEvents.message({...payload, meta: {zclTransactionSequenceNumber: 2}});
         await flushPromises();
+        vi.setSystemTime(200);
         await mockZHEvents.message({...payload, meta: {zclTransactionSequenceNumber: 3}});
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);

--- a/test/util/desiredStateScheduler.test.ts
+++ b/test/util/desiredStateScheduler.test.ts
@@ -1,0 +1,275 @@
+import "../mocks/data";
+import "../mocks/logger";
+
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import EventBus from "../../lib/eventBus";
+import type Device from "../../lib/model/device";
+import DesiredStateScheduler from "../../lib/util/desiredStateScheduler";
+import * as settings from "../../lib/util/settings";
+import * as data from "../mocks/data";
+import {flushPromises} from "../mocks/utils";
+
+describe("DesiredStateScheduler", () => {
+    let eventBus: EventBus;
+    let scheduler: DesiredStateScheduler;
+    const device = {ieeeAddr: "0x1234", isDevice: () => true} as Device;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        data.writeDefaultConfiguration();
+        settings.reRead();
+        settings.set(["advanced", "desired_state", "enabled"], true);
+        settings.set(["advanced", "desired_state", "max_attempts"], 2);
+        settings.set(["advanced", "desired_state", "retry_cooldown"], 1);
+        settings.set(["advanced", "desired_state", "deadline"], 5);
+        eventBus = new EventBus();
+        scheduler = new DesiredStateScheduler(eventBus);
+        scheduler.start();
+    });
+
+    afterEach(() => {
+        scheduler?.stop();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+    });
+
+    const runQueued = async (): Promise<void> => {
+        await vi.advanceTimersByTimeAsync(0);
+        await flushPromises();
+    };
+
+    it("Should complete one-shot sends without retrying", async () => {
+        const send = vi.fn().mockResolvedValue(undefined);
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "ON", send});
+        await runQueued();
+        await vi.advanceTimersByTimeAsync(1000);
+        await flushPromises();
+
+        expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should retry failed sends until max attempts is reached", async () => {
+        const send = vi.fn().mockRejectedValue(new Error("no route"));
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "ON", send});
+        await runQueued();
+        await vi.advanceTimersByTimeAsync(1000);
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(1000);
+        await flushPromises();
+
+        expect(send).toHaveBeenCalledTimes(2);
+    });
+
+    it("Should ignore optimistic and non-device state changes", async () => {
+        const send = vi.fn().mockResolvedValue({state: "ON"});
+        const group = {ieeeAddr: "group", isDevice: () => false} as Device;
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "ON", send});
+        await runQueued();
+        eventBus.emitStateChange({entity: device, from: {}, to: {state: "ON"}, reason: "publishOptimistic"});
+        eventBus.emitStateChange({entity: group, from: {}, to: {state: "ON"}, reason: "publishDebounce"});
+        eventBus.emitStateChange({entity: device, from: {}, to: {state: "OFF"}, reason: "publishDebounce"});
+        await vi.advanceTimersByTimeAsync(1000);
+        await runQueued();
+
+        expect(send).toHaveBeenCalledTimes(2);
+    });
+
+    it("Should supersede different properties on the same endpoint", async () => {
+        const stateSend = vi.fn().mockResolvedValue({state: "OPEN"});
+        const positionSend = vi.fn().mockResolvedValue({position: 0});
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "OPEN", send: stateSend});
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "position", value: 0, send: positionSend});
+        await runQueued();
+        await vi.advanceTimersByTimeAsync(1000);
+        await runQueued();
+
+        expect(stateSend).toHaveBeenCalledTimes(0);
+        expect(positionSend).toHaveBeenCalledTimes(2);
+    });
+
+    it("Should keep different endpoints independent", async () => {
+        const leftSend = vi.fn().mockResolvedValue({position_left: 100});
+        const rightSend = vi.fn().mockResolvedValue({position_right: 0});
+
+        scheduler.enqueue({entity: device, endpointName: "left", endpointID: 1, property: "position", value: 100, send: leftSend});
+        scheduler.enqueue({entity: device, endpointName: "right", endpointID: 2, property: "position", value: 0, send: rightSend});
+        await runQueued();
+        await vi.advanceTimersByTimeAsync(1000);
+        await runQueued();
+
+        expect(leftSend).toHaveBeenCalledTimes(2);
+        expect(rightSend).toHaveBeenCalledTimes(2);
+    });
+
+    it("Should order same-tick bursts by order hint", async () => {
+        const firstSend = vi.fn().mockResolvedValue(undefined);
+        const secondSend = vi.fn().mockResolvedValue(undefined);
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, orderHint: 1, property: "state", value: "FIRST", send: firstSend});
+        scheduler.enqueue({
+            entity: device,
+            endpointName: undefined,
+            endpointID: 2,
+            orderHint: 2,
+            property: "state",
+            value: "SECOND",
+            send: secondSend,
+        });
+        await runQueued();
+
+        expect(secondSend.mock.invocationCallOrder[0]).toBeLessThan(firstSend.mock.invocationCallOrder[0]);
+    });
+
+    it("Should update order hint when coalescing duplicate targets", async () => {
+        const firstSend = vi.fn().mockResolvedValue(undefined);
+        const secondSend = vi.fn().mockResolvedValue(undefined);
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, orderHint: 0, property: "state", value: "ON", send: firstSend});
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, orderHint: 2, property: "state", value: "ON", send: firstSend});
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 2, orderHint: 1, property: "state", value: "OFF", send: secondSend});
+        await runQueued();
+
+        expect(firstSend.mock.invocationCallOrder[0]).toBeLessThan(secondSend.mock.invocationCallOrder[0]);
+    });
+
+    it("Should keep neutral order hint when coalescing duplicate targets without a hint", async () => {
+        const firstSend = vi.fn().mockResolvedValue(undefined);
+        const secondSend = vi.fn().mockResolvedValue(undefined);
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "ON", send: firstSend});
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "ON", send: firstSend});
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 2, orderHint: 1, property: "state", value: "OFF", send: secondSend});
+        await runQueued();
+
+        expect(secondSend.mock.invocationCallOrder[0]).toBeLessThan(firstSend.mock.invocationCallOrder[0]);
+    });
+
+    it("Should report send failures", async () => {
+        const onFailed = vi.fn();
+        const send = vi.fn().mockRejectedValue(new Error("busy"));
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, onFailed, property: "state", value: "ON", send});
+        await runQueued();
+
+        expect(onFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should not retry in a perfect network", async () => {
+        const onApplied = vi.fn();
+        const onFailed = vi.fn();
+        const send = vi.fn().mockResolvedValue({state: "ON"});
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, onApplied, onFailed, property: "state", value: "ON", send});
+        await runQueued();
+        await vi.advanceTimersByTimeAsync(100);
+        eventBus.emitStateChange({entity: device, from: {}, to: {state: "ON"}, reason: "publishDebounce"});
+        await vi.advanceTimersByTimeAsync(1000);
+        await flushPromises();
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(onApplied).toHaveBeenCalledWith(100);
+        expect(onFailed).not.toHaveBeenCalled();
+    });
+
+    it("Should not let a superseded in-flight send re-arm itself", async () => {
+        let resolveOldSend: (value: KeyValue) => void;
+        const oldSend = vi.fn(
+            () =>
+                new Promise<KeyValue>((resolve) => {
+                    resolveOldSend = resolve;
+                }),
+        );
+        const newSend = vi.fn().mockResolvedValue({position: 0});
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "OPEN", send: oldSend});
+        await runQueued();
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "position", value: 0, send: newSend});
+        await flushPromises();
+
+        resolveOldSend!({state: "OPEN"});
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(1000);
+        await runQueued();
+
+        expect(oldSend).toHaveBeenCalledTimes(1);
+        expect(newSend).toHaveBeenCalledTimes(2);
+    });
+
+    it("Should not re-arm a stopped in-flight send", async () => {
+        let resolveSend: (value: KeyValue) => void;
+        const send = vi.fn(
+            () =>
+                new Promise<KeyValue>((resolve) => {
+                    resolveSend = resolve;
+                }),
+        );
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "ON", send});
+        await runQueued();
+        eventBus.emitStateChange({entity: device, from: {}, to: {state: "ON"}, reason: "publishDebounce"});
+        await flushPromises();
+        scheduler.stop();
+        resolveSend!({state: "ON"});
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(1000);
+        await flushPromises();
+
+        expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should ignore enqueue while a run is already active", async () => {
+        let resolveSend: (value: KeyValue | undefined) => void;
+        const firstSend = vi.fn(
+            () =>
+                new Promise<KeyValue | undefined>((resolve) => {
+                    resolveSend = resolve;
+                }),
+        );
+        const secondSend = vi.fn().mockResolvedValue(undefined);
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "ON", send: firstSend});
+        await runQueued();
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 2, property: "state", value: "OFF", send: secondSend});
+        await flushPromises();
+        expect(secondSend).toHaveBeenCalledTimes(0);
+
+        resolveSend!(undefined);
+        await flushPromises();
+
+        expect(secondSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("Should prefer older lower-failure candidates", async () => {
+        let resolveBlockingSend: (value: KeyValue | undefined) => void;
+        const failedSend = vi.fn().mockRejectedValue(new Error("busy"));
+        const blockingSend = vi.fn(
+            () =>
+                new Promise<KeyValue | undefined>((resolve) => {
+                    resolveBlockingSend = resolve;
+                }),
+        );
+        const newerSend = vi.fn().mockResolvedValue(undefined);
+        const olderSend = vi.fn().mockResolvedValue(undefined);
+
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 1, property: "state", value: "ON", send: failedSend});
+        await runQueued();
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 2, property: "state", value: "BLOCK", send: blockingSend});
+        await flushPromises();
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 3, property: "state", value: "OLDER", send: olderSend});
+        await flushPromises();
+        scheduler.enqueue({entity: device, endpointName: undefined, endpointID: 4, property: "state", value: "NEWER", send: newerSend});
+        await flushPromises();
+
+        await vi.advanceTimersByTimeAsync(1000);
+        resolveBlockingSend!(undefined);
+        await flushPromises();
+
+        expect(olderSend.mock.invocationCallOrder[0]).toBeLessThan(newerSend.mock.invocationCallOrder[0]);
+        expect(newerSend.mock.invocationCallOrder[0]).toBeLessThan(failedSend.mock.invocationCallOrder[1]);
+        expect(failedSend).toHaveBeenCalledTimes(2);
+    });
+});

--- a/test/util/topologyState.test.ts
+++ b/test/util/topologyState.test.ts
@@ -1,0 +1,109 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import type {Zigbee2MQTTNetworkMap} from "../../lib/types/api";
+import topologyState from "../../lib/util/topologyState";
+
+const topology = (links: Zigbee2MQTTNetworkMap["links"]): Zigbee2MQTTNetworkMap => ({
+    nodes: [
+        {
+            ieeeAddr: "0x0000000000000000",
+            friendlyName: "Coordinator",
+            type: "Coordinator",
+            networkAddress: 0,
+            manufacturerName: undefined,
+            modelID: undefined,
+            lastSeen: undefined,
+            definition: undefined,
+        },
+        {
+            ieeeAddr: "0x1111111111111111",
+            friendlyName: "near",
+            type: "Router",
+            networkAddress: 1,
+            manufacturerName: undefined,
+            modelID: undefined,
+            lastSeen: undefined,
+            definition: undefined,
+        },
+        {
+            ieeeAddr: "0x2222222222222222",
+            friendlyName: "far",
+            type: "EndDevice",
+            networkAddress: 2,
+            manufacturerName: undefined,
+            modelID: undefined,
+            lastSeen: undefined,
+            definition: undefined,
+        },
+    ],
+    links,
+});
+
+describe("TopologyState", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        topologyState.clear();
+    });
+
+    it("Should order deeper devices before nearer devices", () => {
+        topologyState.updateFromNetworkMap(
+            topology([
+                {
+                    source: {ieeeAddr: "0x1111111111111111", networkAddress: 1},
+                    target: {ieeeAddr: "0x0000000000000000", networkAddress: 0},
+                    sourceIeeeAddr: "0x1111111111111111",
+                    targetIeeeAddr: "0x0000000000000000",
+                    sourceNwkAddr: 1,
+                    deviceType: 0,
+                    rxOnWhenIdle: 0,
+                    relationship: 2,
+                    permitJoining: 0,
+                    depth: 1,
+                    lqi: 200,
+                    linkquality: 200,
+                    routes: [],
+                },
+                {
+                    source: {ieeeAddr: "0x2222222222222222", networkAddress: 2},
+                    target: {ieeeAddr: "0x1111111111111111", networkAddress: 1},
+                    sourceIeeeAddr: "0x2222222222222222",
+                    targetIeeeAddr: "0x1111111111111111",
+                    sourceNwkAddr: 2,
+                    deviceType: 0,
+                    rxOnWhenIdle: 0,
+                    relationship: 1,
+                    permitJoining: 0,
+                    depth: 2,
+                    lqi: 180,
+                    linkquality: 180,
+                    routes: [],
+                },
+            ]),
+        );
+
+        expect(topologyState.orderHint("0x2222222222222222")).toBeGreaterThan(topologyState.orderHint("0x1111111111111111"));
+    });
+
+    it("Should fall back to neutral ordering when topology is unknown or invalidated", () => {
+        topologyState.updateFromNetworkMap(topology([]));
+        topologyState.observeMessage("0x2222222222222222", 1);
+        topologyState.invalidateNetworkMap();
+
+        expect(topologyState.orderHint("0x1111111111111111")).toStrictEqual(0);
+        expect(topologyState.orderHint("0x2222222222222222")).toStrictEqual(0);
+    });
+
+    it("Should keep passive observations when a network map no longer contains the device", () => {
+        topologyState.observeDesiredStateApplied("0x2222222222222222", 42);
+        topologyState.updateFromNetworkMap({nodes: [], links: []});
+
+        expect(topologyState.orderHint("0x2222222222222222")).toStrictEqual(42000);
+    });
+
+    it("Should use observed apply latency without treating last-hop LQI as distance", () => {
+        vi.spyOn(Date, "now").mockReturnValue(1000);
+        topologyState.observeMessage("0x2222222222222222", 1);
+        topologyState.observeDesiredStateApplied("0x2222222222222222", 42);
+
+        expect(topologyState.orderHint("0x2222222222222222")).toStrictEqual(42000);
+    });
+});


### PR DESCRIPTION
## Summary

- add a desired state scheduler for verifiable device `/set` commands, enabled by default under `advanced.desired_state`
- always send the original command, then retry only while the requested state has not been observed, superseded, or exhausted
- coalesce duplicate unresolved targets, supersede older targets per device endpoint, and deprioritize targets that fail so other devices can continue making progress
- order same-burst sends with cached topology and observed apply latency when available, while preserving FIFO when topology is unknown

## Notes

The scheduler only handles device set commands where the converter returns an optimistic state that can be matched later through normal state updates. Unsupported/unverifiable commands and group commands keep the existing one-shot behavior.

Optimistic publishes are tagged with `publishOptimistic` so they do not count as physical confirmation; the desired state is completed only by a later non-optimistic state change.

Unresolved targets are keyed per device endpoint. A newer command to the same endpoint supersedes older pending desired states even when the exposed property differs, so an old retry cannot fire after a newer actuator target has been requested. Different endpoints on the same device remain independent.

Same-tick bursts are scheduled on the next microtask before the first send. This lets commands from the same incoming burst be ordered together without adding a real delay in the normal path.

Topology ordering is optional through `advanced.desired_state.topology_ordering` and defaults to `true`. It uses the cached raw network map when available, invalidates that map on join/leave/network-address changes, and also learns from passive device messages plus desired-state apply latency/failures. It never performs a network scan while handling a `/set` command. Ember `linkquality` is treated as last-hop health evidence only, not as coordinator-to-device distance.

In a healthy network this is intended to be a no-op after the initial send: the first real state update completes the target before the cooldown expires, so no retry is sent. `test/extensions/publish.test.ts` and `test/util/desiredStateScheduler.test.ts` cover this by asserting that a confirmed first send remains a single Zigbee command after the retry cooldown.

## Validation

- `corepack pnpm --ignore-workspace run test:coverage`
- `corepack pnpm --ignore-workspace exec tsc --noEmit`
- `corepack pnpm --ignore-workspace run check`
- `git diff --check`
