### PR TITLE
Allow HA discovery user overrides to win

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1815,7 +1815,16 @@ export class HomeAssistant extends Extension {
                 payload.current_humidity_topic = stateTopic;
             }
 
-            // Override configuration with user settings.
+            if (entity.isDevice()) {
+                try {
+                    entity.definition?.meta?.overrideHaDiscoveryPayload?.(payload);
+                } catch (error) {
+                    logger.error(`Failed to override HA discovery payload (${(error as Error).stack})`);
+                }
+            }
+
+            // Override configuration with user settings after converter compatibility
+            // mappings, so per-device configuration remains the final authority.
             if (entity.options.homeassistant != null) {
                 const add = (obj: KeyValue, ignoreName: boolean): void => {
                     for (const key in obj) {
@@ -1843,14 +1852,6 @@ export class HomeAssistant extends Extension {
 
                 if (entity.options.homeassistant[config.object_id] != null) {
                     add(entity.options.homeassistant[config.object_id], false);
-                }
-            }
-
-            if (entity.isDevice()) {
-                try {
-                    entity.definition?.meta?.overrideHaDiscoveryPayload?.(payload);
-                } catch (error) {
-                    logger.error(`Failed to override HA discovery payload (${(error as Error).stack})`);
                 }
             }
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1196,6 +1196,24 @@ describe("Extension: HomeAssistant", () => {
         });
     });
 
+    it("Should apply user configuration after converter compatibility mapping", async () => {
+        settings.set(["devices", "0x18fc2600000d7ae2", "homeassistant", "climate"], {
+            modes: ["off", "heat", "auto"],
+            mode_command_template: null,
+        });
+
+        await resetExtension();
+        await flushPromises();
+
+        const call = mockMQTTPublishAsync.mock.calls.find((c) => c[0] === "homeassistant/climate/0x18fc2600000d7ae2/climate/config");
+        expect(call).toBeDefined();
+        const payload = JSON.parse(call![1] as string);
+
+        expect(payload.modes).toStrictEqual(["off", "heat", "auto"]);
+        expect(payload.mode_command_template).toBeUndefined();
+        expect(payload.mode_command_topic).toStrictEqual("zigbee2mqtt/bosch_radiator/set");
+    });
+
     it("does not throw when discovery payload override throws", async () => {
         const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");


### PR DESCRIPTION
## Summary
- Apply per-device Home Assistant user configuration after converter-provided discovery payload rewrites.
- Preserve the existing ability for users to override names, object IDs, device classes, icons, availability, and other discovery fields.

## Review feedback addressed
- The intended use case is that the user should have the final say even when a converter compatibility mapping rewrites the payload first.
- This keeps converter-provided compatibility defaults useful while still allowing a local Home Assistant override to correct or opt out of a field afterward.

## Validation
- `pnpm exec vitest run test/extensions/homeassistant.test.ts --config ./test/vitest.config.mts`
- `pnpm run check`
- `pnpm run build`