### PR TITLE
Expose settable composite features to Home Assistant

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1300,6 +1300,53 @@ export class HomeAssistant extends Extension {
                     break;
                 }
 
+                if (firstExposeTyped.type === "composite") {
+                    for (const feature of firstExposeTyped.features) {
+                        const featureName = `${firstExposeTyped.property}_${feature.property}`;
+                        if (isNumericExpose(feature) && feature.access & ACCESS_SET) {
+                            const discoveryEntry: DiscoveryEntry = {
+                                type: "number",
+                                object_id: endpointName ? `${featureName}_${endpointName}` : featureName,
+                                mockProperties: [{property: firstExposeTyped.property, value: {[feature.property]: null}}],
+                                discovery_payload: {
+                                    name: endpointName
+                                        ? `${firstExposeTyped.label} ${feature.label} ${endpointName}`
+                                        : `${firstExposeTyped.label} ${feature.label}`,
+                                    value_template: `{{ value_json.${firstExposeTyped.property}.${feature.property} }}`,
+                                    command_topic: true,
+                                    command_template: `{ "${firstExposeTyped.property}": { "${feature.property}": {{ value }} } }`,
+                                    command_topic_prefix: endpointName,
+                                    ...(feature.unit && {unit_of_measurement: feature.unit}),
+                                    ...(feature.value_step && {step: feature.value_step}),
+                                    ...NUMERIC_DISCOVERY_LOOKUP[feature.name],
+                                },
+                            };
+
+                            if (feature.value_min != null) discoveryEntry.discovery_payload.min = feature.value_min;
+                            if (feature.value_max != null) discoveryEntry.discovery_payload.max = feature.value_max;
+                            discoveryEntries.push(discoveryEntry);
+                        } else if (isEnumExpose(feature) && feature.access & ACCESS_SET) {
+                            discoveryEntries.push({
+                                type: "select",
+                                object_id: endpointName ? `${featureName}_${endpointName}` : featureName,
+                                mockProperties: [{property: firstExposeTyped.property, value: {[feature.property]: null}}],
+                                discovery_payload: {
+                                    name: endpointName
+                                        ? `${firstExposeTyped.label} ${feature.label} ${endpointName}`
+                                        : `${firstExposeTyped.label} ${feature.label}`,
+                                    value_template: `{{ value_json.${firstExposeTyped.property}.${feature.property} }}`,
+                                    state_topic: !!(feature.access & ACCESS_STATE),
+                                    command_topic: true,
+                                    command_template: `{ "${firstExposeTyped.property}": { "${feature.property}": "{{ value }}" } }`,
+                                    command_topic_prefix: endpointName,
+                                    options: feature.values.map((v) => v.toString()),
+                                    ...ENUM_DISCOVERY_LOOKUP[feature.name],
+                                },
+                            });
+                        }
+                    }
+                }
+
                 if (firstExposeTyped.type === "text" && firstExposeTyped.access & ACCESS_SET) {
                     discoveryEntries.push({
                         type: "text",

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1424,6 +1424,53 @@ export class HomeAssistant extends Extension {
                     break;
                 }
 
+                if (firstExposeTyped.type === "composite") {
+                    for (const feature of firstExposeTyped.features) {
+                        const featureName = `${firstExposeTyped.property}_${feature.property}`;
+                        if (isNumericExpose(feature) && feature.access & ACCESS_SET) {
+                            const discoveryEntry: DiscoveryEntry = {
+                                type: "number",
+                                object_id: endpointName ? `${featureName}_${endpointName}` : featureName,
+                                mockProperties: [{property: firstExposeTyped.property, value: {[feature.property]: null}}],
+                                discovery_payload: {
+                                    name: endpointName
+                                        ? `${firstExposeTyped.label} ${feature.label} ${endpointName}`
+                                        : `${firstExposeTyped.label} ${feature.label}`,
+                                    value_template: `{{ value_json.${firstExposeTyped.property}.${feature.property} }}`,
+                                    command_topic: true,
+                                    command_template: `{ "${firstExposeTyped.property}": { "${feature.property}": {{ value }} } }`,
+                                    command_topic_prefix: endpointName,
+                                    ...(feature.unit && {unit_of_measurement: feature.unit}),
+                                    ...(feature.value_step && {step: feature.value_step}),
+                                    ...NUMERIC_DISCOVERY_LOOKUP[feature.name],
+                                },
+                            };
+
+                            if (feature.value_min != null) discoveryEntry.discovery_payload.min = feature.value_min;
+                            if (feature.value_max != null) discoveryEntry.discovery_payload.max = feature.value_max;
+                            discoveryEntries.push(discoveryEntry);
+                        } else if (isEnumExpose(feature) && feature.access & ACCESS_SET) {
+                            discoveryEntries.push({
+                                type: "select",
+                                object_id: endpointName ? `${featureName}_${endpointName}` : featureName,
+                                mockProperties: [{property: firstExposeTyped.property, value: {[feature.property]: null}}],
+                                discovery_payload: {
+                                    name: endpointName
+                                        ? `${firstExposeTyped.label} ${feature.label} ${endpointName}`
+                                        : `${firstExposeTyped.label} ${feature.label}`,
+                                    value_template: `{{ value_json.${firstExposeTyped.property}.${feature.property} }}`,
+                                    state_topic: !!(feature.access & ACCESS_STATE),
+                                    command_topic: true,
+                                    command_template: `{ "${firstExposeTyped.property}": { "${feature.property}": "{{ value }}" } }`,
+                                    command_topic_prefix: endpointName,
+                                    options: feature.values.map((v) => v.toString()),
+                                    ...ENUM_DISCOVERY_LOOKUP[feature.name],
+                                },
+                            });
+                        }
+                    }
+                }
+
                 if (firstExposeTyped.type === "text" && firstExposeTyped.access & ACCESS_SET) {
                     discoveryEntries.push({
                         type: "text",

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1260,6 +1260,76 @@ describe("Extension: HomeAssistant", () => {
         expect(payload.mode_command_topic).toStrictEqual("zigbee2mqtt/bosch_radiator/set");
     });
 
+    it("Should expose settable composite features as controls", () => {
+        const expose = {
+            type: "composite",
+            name: "manual_default_settings",
+            property: "manual_default_settings",
+            label: "Manual default settings",
+            access: 7,
+            features: [
+                {
+                    type: "numeric",
+                    name: "irrigation_duration",
+                    property: "irrigation_duration",
+                    label: "Irrigation duration",
+                    access: 7,
+                    value_min: 1,
+                    value_max: 719,
+                    unit: "min",
+                },
+                {
+                    type: "enum",
+                    name: "irrigation_mode",
+                    property: "irrigation_mode",
+                    label: "Irrigation mode",
+                    access: 7,
+                    values: ["duration", "capacity"],
+                },
+            ],
+        };
+        const device = {
+            definition: {},
+            isDevice: (): boolean => true,
+            isGroup: (): boolean => false,
+            endpoint: (): string | undefined => undefined,
+            options: {ID: "0x0000000000000001"},
+            exposes: (): unknown[] => [expose],
+            zh: {endpoints: []},
+        };
+
+        // @ts-expect-error private
+        const configs = extension.getConfigs(device);
+
+        expect(configs).toContainEqual({
+            type: "number",
+            object_id: "manual_default_settings_irrigation_duration",
+            mockProperties: [{property: "manual_default_settings", value: {irrigation_duration: null}}],
+            discovery_payload: {
+                name: "Manual default settings Irrigation duration",
+                value_template: "{{ value_json.manual_default_settings.irrigation_duration }}",
+                command_topic: true,
+                command_template: '{ "manual_default_settings": { "irrigation_duration": {{ value }} } }',
+                unit_of_measurement: "min",
+                min: 1,
+                max: 719,
+            },
+        });
+        expect(configs).toContainEqual({
+            type: "select",
+            object_id: "manual_default_settings_irrigation_mode",
+            mockProperties: [{property: "manual_default_settings", value: {irrigation_mode: null}}],
+            discovery_payload: {
+                name: "Manual default settings Irrigation mode",
+                value_template: "{{ value_json.manual_default_settings.irrigation_mode }}",
+                state_topic: true,
+                command_topic: true,
+                command_template: '{ "manual_default_settings": { "irrigation_mode": "{{ value }}" } }',
+                options: ["duration", "capacity"],
+            },
+        });
+    });
+
     it("does not throw when discovery payload override throws", async () => {
         const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1330,6 +1330,54 @@ describe("Extension: HomeAssistant", () => {
         });
     });
 
+    it("Should include endpoint names for settable composite enum controls", () => {
+        const expose = {
+            type: "composite",
+            name: "manual_default_settings",
+            property: "manual_default_settings_l1",
+            label: "Manual default settings",
+            access: 7,
+            endpoint: "l1",
+            features: [
+                {
+                    type: "enum",
+                    name: "irrigation_mode",
+                    property: "irrigation_mode",
+                    label: "Irrigation mode",
+                    access: 7,
+                    values: ["duration", "capacity"],
+                },
+            ],
+        };
+        const device = {
+            definition: {},
+            isDevice: (): boolean => true,
+            isGroup: (): boolean => false,
+            endpoint: (): string | undefined => undefined,
+            options: {ID: "0x0000000000000001"},
+            exposes: (): unknown[] => [expose],
+            zh: {endpoints: []},
+        };
+
+        // @ts-expect-error private
+        const configs = extension.getConfigs(device);
+
+        expect(configs).toContainEqual({
+            type: "select",
+            object_id: "manual_default_settings_l1_irrigation_mode_l1",
+            mockProperties: [{property: "manual_default_settings_l1", value: {irrigation_mode: null}}],
+            discovery_payload: {
+                name: "Manual default settings Irrigation mode l1",
+                value_template: "{{ value_json.manual_default_settings_l1.irrigation_mode }}",
+                state_topic: true,
+                command_topic: true,
+                command_template: '{ "manual_default_settings_l1": { "irrigation_mode": "{{ value }}" } }',
+                command_topic_prefix: "l1",
+                options: ["duration", "capacity"],
+            },
+        });
+    });
+
     it("does not throw when discovery payload override throws", async () => {
         const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1456,6 +1456,54 @@ describe("Extension: HomeAssistant", () => {
         });
     });
 
+    it("Should include endpoint names for settable composite enum controls", () => {
+        const expose = {
+            type: "composite",
+            name: "manual_default_settings",
+            property: "manual_default_settings_l1",
+            label: "Manual default settings",
+            access: 7,
+            endpoint: "l1",
+            features: [
+                {
+                    type: "enum",
+                    name: "irrigation_mode",
+                    property: "irrigation_mode",
+                    label: "Irrigation mode",
+                    access: 7,
+                    values: ["duration", "capacity"],
+                },
+            ],
+        };
+        const device = {
+            definition: {},
+            isDevice: (): boolean => true,
+            isGroup: (): boolean => false,
+            endpoint: (): string | undefined => undefined,
+            options: {ID: "0x0000000000000001"},
+            exposes: (): unknown[] => [expose],
+            zh: {endpoints: []},
+        };
+
+        // @ts-expect-error private
+        const configs = extension.getConfigs(device);
+
+        expect(configs).toContainEqual({
+            type: "select",
+            object_id: "manual_default_settings_l1_irrigation_mode_l1",
+            mockProperties: [{property: "manual_default_settings_l1", value: {irrigation_mode: null}}],
+            discovery_payload: {
+                name: "Manual default settings Irrigation mode l1",
+                value_template: "{{ value_json.manual_default_settings_l1.irrigation_mode }}",
+                state_topic: true,
+                command_topic: true,
+                command_template: '{ "manual_default_settings_l1": { "irrigation_mode": "{{ value }}" } }',
+                command_topic_prefix: "l1",
+                options: ["duration", "capacity"],
+            },
+        });
+    });
+
     it("does not throw when discovery payload override throws", async () => {
         const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1386,6 +1386,76 @@ describe("Extension: HomeAssistant", () => {
         expect(payload.mode_command_topic).toStrictEqual("zigbee2mqtt/bosch_radiator/set");
     });
 
+    it("Should expose settable composite features as controls", () => {
+        const expose = {
+            type: "composite",
+            name: "manual_default_settings",
+            property: "manual_default_settings",
+            label: "Manual default settings",
+            access: 7,
+            features: [
+                {
+                    type: "numeric",
+                    name: "irrigation_duration",
+                    property: "irrigation_duration",
+                    label: "Irrigation duration",
+                    access: 7,
+                    value_min: 1,
+                    value_max: 719,
+                    unit: "min",
+                },
+                {
+                    type: "enum",
+                    name: "irrigation_mode",
+                    property: "irrigation_mode",
+                    label: "Irrigation mode",
+                    access: 7,
+                    values: ["duration", "capacity"],
+                },
+            ],
+        };
+        const device = {
+            definition: {},
+            isDevice: (): boolean => true,
+            isGroup: (): boolean => false,
+            endpoint: (): string | undefined => undefined,
+            options: {ID: "0x0000000000000001"},
+            exposes: (): unknown[] => [expose],
+            zh: {endpoints: []},
+        };
+
+        // @ts-expect-error private
+        const configs = extension.getConfigs(device);
+
+        expect(configs).toContainEqual({
+            type: "number",
+            object_id: "manual_default_settings_irrigation_duration",
+            mockProperties: [{property: "manual_default_settings", value: {irrigation_duration: null}}],
+            discovery_payload: {
+                name: "Manual default settings Irrigation duration",
+                value_template: "{{ value_json.manual_default_settings.irrigation_duration }}",
+                command_topic: true,
+                command_template: '{ "manual_default_settings": { "irrigation_duration": {{ value }} } }',
+                unit_of_measurement: "min",
+                min: 1,
+                max: 719,
+            },
+        });
+        expect(configs).toContainEqual({
+            type: "select",
+            object_id: "manual_default_settings_irrigation_mode",
+            mockProperties: [{property: "manual_default_settings", value: {irrigation_mode: null}}],
+            discovery_payload: {
+                name: "Manual default settings Irrigation mode",
+                value_template: "{{ value_json.manual_default_settings.irrigation_mode }}",
+                state_topic: true,
+                command_topic: true,
+                command_template: '{ "manual_default_settings": { "irrigation_mode": "{{ value }}" } }',
+                options: ["duration", "capacity"],
+            },
+        });
+    });
+
     it("does not throw when discovery payload override throws", async () => {
         const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");


### PR DESCRIPTION
## Design outcome

This remains draft intentionally.

Reviewer feedback pointed out that independently controllable settings should preferably be exposed by the converter as scalar exposes instead of being recovered generically from a composite in Home Assistant discovery. That direction is now implemented for the SONOFF valve/manual-watering use case in zigbee-herdsman-converters, so this generic split is no longer the preferred fix for that device.

## Current scope if this is revived

- only split composite children when a converter cannot reasonably expose them as scalar values
- only include children that are independently writable and do not need to be sent together with sibling fields
- avoid using this as a workaround for over-broad composite modeling in converters

## Review note

Koenkk asked whether this was introduced for a specific device and suggested moving the fix to the device expose instead of applying a generic composite split. This PR stays separate from that converter-side work and remains limited to the remaining safe cases.

## Status

Kept as draft, not ready for merge. The next step would be a smaller design with a concrete remaining device/use case that cannot be fixed cleanly in zigbee-herdsman-converters.
