### PR TITLE
Discover scalar composite features in Home Assistant

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1490,6 +1490,9 @@ export class HomeAssistant extends Extension {
                                 optimistic: !allowsState,
                             }),
                         };
+                        if (feature.category === "config" || feature.category === "diagnostic") {
+                            discoveryPayload.entity_category = feature.category;
+                        }
 
                         if (isNumericExpose(feature)) {
                             if (allowsSet) discoveryPayload.command_template = compositePathCommandTemplate(path, "{{ value }}");
@@ -1600,7 +1603,7 @@ export class HomeAssistant extends Extension {
         // This takes precedence over definitions in this file.
         if (firstExpose.category === "config" || firstExpose.category === "diagnostic") {
             for (const entry of discoveryEntries) {
-                entry.discovery_payload.entity_category = firstExpose.category;
+                entry.discovery_payload.entity_category ??= firstExpose.category;
             }
         }
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -84,6 +84,7 @@ const BINARY_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     color_sync: {entity_category: "config", icon: "mdi:sync-circle"},
     consumer_connected: {device_class: "plug"},
     contact: {device_class: "door"},
+    dhcp_enabled: {enabled_by_default: false, entity_category: "diagnostic", icon: "mdi:check-network-outline"},
     garage_door_contact: {device_class: "garage_door", payload_on: false, payload_off: true},
     frost_protection: {entity_category: "config", icon: "mdi:snowflake-thermometer"},
     heating_stop: {entity_category: "config", icon: "mdi:radiator-off"},
@@ -222,6 +223,11 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     humidity_calibration: {entity_category: "config", icon: "mdi:wrench-clock"},
     humidity_max: {entity_category: "config", icon: "mdi:water-percent"},
     humidity_min: {entity_category: "config", icon: "mdi:water-percent"},
+    ip_address: {
+        device_class: "ip_address",
+        enabled_by_default: false,
+        entity_category: "diagnostic",
+    },
     illuminance_calibration: {entity_category: "config", icon: "mdi:wrench-clock"},
     illuminance: {device_class: "illuminance", state_class: "measurement"},
     illuminance_raw: {state_class: "measurement"},
@@ -287,6 +293,18 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
         entity_category: "diagnostic",
         icon: "mdi:brightness-5",
     },
+    seasonal_watering_adjustment_april: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_august: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_december: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_february: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_january: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_july: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_june: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_march: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_may: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_november: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_october: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
+    seasonal_watering_adjustment_september: {enabled_by_default: false, entity_category: "config", icon: "mdi:sprinkler-variant"},
     smoke_density: {icon: "mdi:google-circles-communities", state_class: "measurement"},
     sensitivity: {entity_category: "config", icon: "mdi:tune"},
     small_detection_distance: {entity_category: "config", icon: "mdi:signal-distance-variant"},
@@ -385,6 +403,7 @@ const LIST_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     level_config: {entity_category: "diagnostic"},
     programming_mode: {icon: "mdi:calendar-clock"},
     schedule_settings: {entity_category: "config", icon: "mdi:calendar-clock"},
+    wifi_status: {enabled_by_default: false, entity_category: "diagnostic", icon: "mdi:wifi"},
 } as const;
 
 const featurePropertyWithoutEndpoint = (feature: zhc.Feature): string => {
@@ -1459,14 +1478,22 @@ export class HomeAssistant extends Extension {
 
                 if (firstExposeTyped.type === "composite") {
                     const firstComposite = firstExposeTyped as zhc.Composite;
-                    const addCompositeFeatureDiscovery = (feature: zhc.Feature, path: string[], labelParts: string[]): void => {
+                    const addCompositeFeatureDiscovery = (
+                        feature: zhc.Feature,
+                        path: string[],
+                        labelParts: string[],
+                        inheritedCategory?: "config" | "diagnostic",
+                    ): void => {
                         if (isSensitiveCompositeFeature(feature)) {
                             return;
                         }
 
+                        const featureCategory =
+                            feature.category === "config" || feature.category === "diagnostic" ? feature.category : inheritedCategory;
+
                         if (feature.type === "composite") {
                             for (const child of (feature as zhc.Composite).features) {
-                                addCompositeFeatureDiscovery(child, [...path, child.property], [...labelParts, child.label]);
+                                addCompositeFeatureDiscovery(child, [...path, child.property], [...labelParts, child.label], featureCategory);
                             }
                             return;
                         }
@@ -1479,6 +1506,8 @@ export class HomeAssistant extends Extension {
 
                         const objectId = path.join("_");
                         const name = endpointName ? `${labelParts.join(" ")} ${endpointName}` : labelParts.join(" ");
+                        const writeOnlyConfig = allowsSet && !allowsState;
+                        const advancedConfigGroup = ["wifi_config"].includes(firstComposite.property);
                         const discoveryPayload: KeyValue = {
                             name,
                             state_topic: allowsState,
@@ -1490,8 +1519,14 @@ export class HomeAssistant extends Extension {
                                 optimistic: !allowsState,
                             }),
                         };
-                        if (feature.category === "config" || feature.category === "diagnostic") {
-                            discoveryPayload.entity_category = feature.category;
+
+                        if (writeOnlyConfig || advancedConfigGroup) {
+                            discoveryPayload.entity_category = "config";
+                            discoveryPayload.enabled_by_default = false;
+                        }
+
+                        if (featureCategory) {
+                            discoveryPayload.entity_category ??= featureCategory;
                         }
 
                         if (isNumericExpose(feature)) {
@@ -1556,7 +1591,12 @@ export class HomeAssistant extends Extension {
                     };
 
                     for (const feature of firstComposite.features) {
-                        addCompositeFeatureDiscovery(feature, [firstComposite.property, feature.property], [firstComposite.label, feature.label]);
+                        addCompositeFeatureDiscovery(
+                            feature,
+                            [firstComposite.property, feature.property],
+                            [firstComposite.label, feature.label],
+                            firstComposite.category,
+                        );
                     }
 
                     if (discoveryEntries.length > 0) {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -487,7 +487,6 @@ const compositePathCommandTemplate = (path: string[], valueTemplate: string): st
         result = `{"${path[i]}": ${result}}`;
     }
     return result;
-    return result;
 };
 
 /**

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -232,6 +232,7 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     illuminance: {device_class: "illuminance", state_class: "measurement"},
     illuminance_raw: {state_class: "measurement"},
     interval_time: {entity_category: "config", icon: "mdi:timer"},
+    irrigation_plan_remove_plan_index: {enabled_by_default: false, entity_category: "config", icon: "mdi:calendar-remove"},
     internalTemperature: {
         device_class: "temperature",
         entity_category: "diagnostic",

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -437,6 +437,39 @@ const applyHomeAssistantExposeMetadata = (payload: DiscoveryEntry, homeAssistant
     }
 };
 
+const isSensitiveCompositeFeature = (feature: zhc.Feature): boolean => {
+    return /pass(word)?|token|secret|credential|key/i.test(feature.name) || /pass(word)?|token|secret|credential|key/i.test(feature.property);
+};
+
+const compositePathValueTemplate = (path: string[], lower = false): string => {
+    const pathExpression = path.map((part) => `["${part}"]`).join("");
+    const checks = path.map(
+        (part, index) =>
+            `${
+                index === 0
+                    ? "value_json"
+                    : `value_json${path
+                          .slice(0, index)
+                          .map((p) => `["${p}"]`)
+                          .join("")}`
+            }["${part}"] is defined`,
+    );
+    const value = `value_json${pathExpression}`;
+    const renderedValue = lower ? `${value} | string | lower` : value;
+
+    return `{% if ${checks.join(" and ")} %}{{ ${renderedValue} }}{% endif %}`;
+};
+
+const compositePathCommandTemplate = (path: string[], valueTemplate: string): string => {
+    let result = valueTemplate;
+
+    for (let i = path.length - 1; i >= 0; i--) {
+        result = `{"${path[i]}": ${result}}`;
+    }
+    return result;
+    return result;
+};
+
 /**
  * This class handles the bridge entity configuration for Home Assistant Discovery.
  */
@@ -1422,6 +1455,110 @@ export class HomeAssistant extends Extension {
 
                     discoveryEntries.push(discoveryEntry);
                     break;
+                }
+
+                if (firstExposeTyped.type === "composite") {
+                    const firstComposite = firstExposeTyped as zhc.Composite;
+                    const addCompositeFeatureDiscovery = (feature: zhc.Feature, path: string[], labelParts: string[]): void => {
+                        if (isSensitiveCompositeFeature(feature)) {
+                            return;
+                        }
+
+                        if (feature.type === "composite") {
+                            for (const child of (feature as zhc.Composite).features) {
+                                addCompositeFeatureDiscovery(child, [...path, child.property], [...labelParts, child.label]);
+                            }
+                            return;
+                        }
+
+                        const allowsState = !!(feature.access & ACCESS_STATE);
+                        const allowsSet = !!(feature.access & ACCESS_SET);
+                        if (!allowsState && !allowsSet) {
+                            return;
+                        }
+
+                        const objectId = path.join("_");
+                        const name = endpointName ? `${labelParts.join(" ")} ${endpointName}` : labelParts.join(" ");
+                        const discoveryPayload: KeyValue = {
+                            name,
+                            state_topic: allowsState,
+                            ...(allowsState && {
+                                value_template: compositePathValueTemplate(path, isBinaryExpose(feature) && typeof feature.value_on === "boolean"),
+                            }),
+                            ...(allowsSet && {
+                                command_topic: true,
+                                optimistic: !allowsState,
+                            }),
+                        };
+
+                        if (isNumericExpose(feature)) {
+                            if (allowsSet) discoveryPayload.command_template = compositePathCommandTemplate(path, "{{ value }}");
+                            if (feature.unit) discoveryPayload.unit_of_measurement = feature.unit;
+                            if (feature.value_step) discoveryPayload.step = feature.value_step;
+                            if (feature.value_min != null) discoveryPayload.min = feature.value_min;
+                            if (feature.value_max != null) discoveryPayload.max = feature.value_max;
+                            Object.assign(discoveryPayload, NUMERIC_DISCOVERY_LOOKUP[feature.name]);
+
+                            if (NUMERIC_DISCOVERY_LOOKUP[feature.name]?.device_class === "temperature") {
+                                discoveryPayload.device_class = NUMERIC_DISCOVERY_LOOKUP[feature.name]?.device_class;
+                            } else {
+                                delete discoveryPayload.device_class;
+                            }
+
+                            discoveryEntries.push({
+                                type: allowsSet ? "number" : "sensor",
+                                object_id: objectId,
+                                mockProperties: [{property: firstComposite.property, value: null}],
+                                discovery_payload: discoveryPayload,
+                            });
+                        } else if (isEnumExpose(feature)) {
+                            if (allowsSet) {
+                                discoveryPayload.options = feature.values.map((v) => v.toString());
+                                discoveryPayload.command_template = compositePathCommandTemplate(path, "{{ value | tojson }}");
+                            }
+                            Object.assign(discoveryPayload, ENUM_DISCOVERY_LOOKUP[feature.name]);
+                            discoveryEntries.push({
+                                type: allowsSet ? "select" : "sensor",
+                                object_id: objectId,
+                                mockProperties: [{property: firstComposite.property, value: null}],
+                                discovery_payload: discoveryPayload,
+                            });
+                        } else if (isBinaryExpose(feature)) {
+                            discoveryPayload.payload_on = feature.value_on.toString();
+                            discoveryPayload.payload_off = feature.value_off.toString();
+                            if (allowsSet) {
+                                discoveryPayload.command_template = compositePathCommandTemplate(
+                                    path,
+                                    typeof feature.value_on === "boolean" ? "{{ value }}" : "{{ value | tojson }}",
+                                );
+                            }
+                            Object.assign(discoveryPayload, BINARY_DISCOVERY_LOOKUP[feature.name]);
+                            discoveryEntries.push({
+                                type: allowsSet ? "switch" : "binary_sensor",
+                                object_id: objectId,
+                                mockProperties: [{property: firstComposite.property, value: null}],
+                                discovery_payload: discoveryPayload,
+                            });
+                        } else if (feature.type === "text") {
+                            const textFeature = feature as zhc.Text;
+                            if (allowsSet) discoveryPayload.command_template = compositePathCommandTemplate(path, "{{ value | tojson }}");
+                            Object.assign(discoveryPayload, LIST_DISCOVERY_LOOKUP[textFeature.name]);
+                            discoveryEntries.push({
+                                type: allowsSet ? "text" : "sensor",
+                                object_id: objectId,
+                                mockProperties: [{property: firstComposite.property, value: null}],
+                                discovery_payload: discoveryPayload,
+                            });
+                        }
+                    };
+
+                    for (const feature of firstComposite.features) {
+                        addCompositeFeatureDiscovery(feature, [firstComposite.property, feature.property], [firstComposite.label, feature.label]);
+                    }
+
+                    if (discoveryEntries.length > 0) {
+                        break;
+                    }
                 }
 
                 if (firstExposeTyped.type === "text" && firstExposeTyped.access & ACCESS_SET) {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1205,6 +1205,16 @@ describe("Extension: HomeAssistant", () => {
                     },
                     {
                         type: "numeric",
+                        name: "seasonal_watering_adjustment_january",
+                        property: "seasonal_january",
+                        label: "January adjustment",
+                        access: 3,
+                        value_min: 0,
+                        value_max: 200,
+                        value_step: 1,
+                    },
+                    {
+                        type: "numeric",
                         name: "ignored",
                         property: "ignored",
                         label: "Ignored",
@@ -1261,7 +1271,13 @@ describe("Extension: HomeAssistant", () => {
                             id.startsWith("select:network_") ||
                             id.startsWith("switch:network_"),
                     ),
-            ).toStrictEqual(["number:network_timeout", "sensor:network_temperature", "select:network_mode", "switch:network_advanced_enabled"]);
+            ).toStrictEqual([
+                "number:network_timeout",
+                "sensor:network_temperature",
+                "number:network_seasonal_january",
+                "select:network_mode",
+                "switch:network_advanced_enabled",
+            ]);
             expect(configs.find((config) => config.object_id === "network_timeout")?.discovery_payload).toMatchObject({
                 value_template:
                     '{% if value_json["network"] is defined and value_json["network"]["timeout"] is defined %}{{ value_json["network"]["timeout"] }}{% endif %}',
@@ -1278,6 +1294,14 @@ describe("Extension: HomeAssistant", () => {
                 device_class: "temperature",
                 state_class: "measurement",
             });
+            expect(configs.find((config) => config.object_id === "network_seasonal_january")?.discovery_payload).toMatchObject({
+                enabled_by_default: false,
+                entity_category: "config",
+                icon: "mdi:sprinkler-variant",
+                min: 0,
+                max: 200,
+                step: 1,
+            });
             expect(configs.find((config) => config.object_id === "network_mode")?.discovery_payload).toMatchObject({
                 command_template: '{"network": {"mode": {{ value | tojson }}}}',
                 entity_category: "config",
@@ -1293,6 +1317,118 @@ describe("Extension: HomeAssistant", () => {
             });
             expect(configs.find((config) => config.object_id.includes("password"))).toBeUndefined();
             expect(configs.find((config) => config.object_id.includes("ignored"))).toBeUndefined();
+        } finally {
+            siren.definition.exposes = originalExposes;
+        }
+    });
+
+    it("Should discover write-only composite settings as disabled config entities", () => {
+        const siren = getZ2MEntity(devices.HS2WD) as Device;
+        assert(siren.definition);
+        const originalExposes = siren.definition.exposes;
+
+        siren.definition.exposes = [
+            {
+                type: "composite",
+                name: "settings",
+                property: "settings",
+                label: "Settings",
+                access: 2,
+                category: "config",
+                features: [
+                    {
+                        type: "numeric",
+                        name: "duration",
+                        property: "duration",
+                        label: "Duration",
+                        access: 2,
+                        unit: "min",
+                        value_min: 1,
+                        value_max: 60,
+                        value_step: 1,
+                    },
+                    {
+                        type: "enum",
+                        name: "mode",
+                        property: "mode",
+                        label: "Mode",
+                        access: 2,
+                        values: ["auto", "manual"],
+                    },
+                ],
+            },
+        ] as zhc.Expose[];
+
+        try {
+            // @ts-expect-error private
+            const configs = extension.getConfigs(siren);
+
+            expect(configs.find((config) => config.object_id === "settings_duration")?.discovery_payload).toMatchObject({
+                command_template: '{"settings": {"duration": {{ value }}}}',
+                enabled_by_default: false,
+                entity_category: "config",
+                optimistic: true,
+            });
+            expect(configs.find((config) => config.object_id === "settings_mode")?.discovery_payload).toMatchObject({
+                command_template: '{"settings": {"mode": {{ value | tojson }}}}',
+                enabled_by_default: false,
+                entity_category: "config",
+                optimistic: true,
+                options: ["auto", "manual"],
+            });
+        } finally {
+            siren.definition.exposes = originalExposes;
+        }
+    });
+
+    it("Should discover Wi-Fi composite settings as disabled config entities", () => {
+        const siren = getZ2MEntity(devices.HS2WD) as Device;
+        assert(siren.definition);
+        const originalExposes = siren.definition.exposes;
+
+        siren.definition.exposes = [
+            {
+                type: "composite",
+                name: "wifi_config",
+                property: "wifi_config",
+                label: "Wi-Fi Configuration",
+                access: 3,
+                category: "config",
+                features: [
+                    {
+                        type: "binary",
+                        name: "enabled",
+                        property: "enabled",
+                        label: "Wi-Fi enabled",
+                        access: 3,
+                        value_on: true,
+                        value_off: false,
+                    },
+                    {
+                        type: "text",
+                        name: "ssid",
+                        property: "ssid",
+                        label: "Network",
+                        access: 3,
+                    },
+                ],
+            },
+        ] as zhc.Expose[];
+
+        try {
+            // @ts-expect-error private
+            const configs = extension.getConfigs(siren);
+
+            expect(configs.find((config) => config.object_id === "wifi_config_enabled")?.discovery_payload).toMatchObject({
+                enabled_by_default: false,
+                entity_category: "config",
+                payload_on: "true",
+                payload_off: "false",
+            });
+            expect(configs.find((config) => config.object_id === "wifi_config_ssid")?.discovery_payload).toMatchObject({
+                enabled_by_default: false,
+                entity_category: "config",
+            });
         } finally {
             siren.definition.exposes = originalExposes;
         }

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1253,6 +1253,15 @@ describe("Extension: HomeAssistant", () => {
                             },
                         ],
                     },
+                    {
+                        type: "binary",
+                        name: "locked",
+                        property: "locked",
+                        label: "Locked",
+                        access: 1,
+                        value_on: "LOCK",
+                        value_off: "UNLOCK",
+                    },
                 ],
             },
         ] as zhc.Expose[];
@@ -1269,7 +1278,8 @@ describe("Extension: HomeAssistant", () => {
                             id.startsWith("number:network_") ||
                             id.startsWith("sensor:network_") ||
                             id.startsWith("select:network_") ||
-                            id.startsWith("switch:network_"),
+                            id.startsWith("switch:network_") ||
+                            id.startsWith("binary_sensor:network_"),
                     ),
             ).toStrictEqual([
                 "number:network_timeout",
@@ -1277,6 +1287,7 @@ describe("Extension: HomeAssistant", () => {
                 "number:network_seasonal_january",
                 "select:network_mode",
                 "switch:network_advanced_enabled",
+                "binary_sensor:network_locked",
             ]);
             expect(configs.find((config) => config.object_id === "network_timeout")?.discovery_payload).toMatchObject({
                 value_template:
@@ -1314,6 +1325,12 @@ describe("Extension: HomeAssistant", () => {
                 entity_category: "config",
                 payload_on: "true",
                 payload_off: "false",
+            });
+            expect(configs.find((config) => config.object_id === "network_locked")?.discovery_payload).toMatchObject({
+                value_template:
+                    '{% if value_json["network"] is defined and value_json["network"]["locked"] is defined %}{{ value_json["network"]["locked"] }}{% endif %}',
+                payload_on: "LOCK",
+                payload_off: "UNLOCK",
             });
             expect(configs.find((config) => config.object_id.includes("password"))).toBeUndefined();
             expect(configs.find((config) => config.object_id.includes("ignored"))).toBeUndefined();

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1180,6 +1180,7 @@ describe("Extension: HomeAssistant", () => {
                 property: "network",
                 label: "Network",
                 access: 3,
+                category: "config",
                 features: [
                     {
                         type: "numeric",
@@ -1187,6 +1188,7 @@ describe("Extension: HomeAssistant", () => {
                         property: "timeout",
                         label: "Timeout",
                         access: 3,
+                        category: "config",
                         unit: "min",
                         value_min: 1,
                         value_max: 60,
@@ -1198,6 +1200,7 @@ describe("Extension: HomeAssistant", () => {
                         property: "temperature",
                         label: "Temperature",
                         access: 1,
+                        category: "diagnostic",
                         unit: "°C",
                     },
                     {
@@ -1263,24 +1266,28 @@ describe("Extension: HomeAssistant", () => {
                 value_template:
                     '{% if value_json["network"] is defined and value_json["network"]["timeout"] is defined %}{{ value_json["network"]["timeout"] }}{% endif %}',
                 command_template: '{"network": {"timeout": {{ value }}}}',
+                entity_category: "config",
                 unit_of_measurement: "min",
                 min: 1,
                 max: 60,
                 step: 1,
             });
             expect(configs.find((config) => config.object_id === "network_temperature")?.discovery_payload).toMatchObject({
+                entity_category: "diagnostic",
                 unit_of_measurement: "°C",
                 device_class: "temperature",
                 state_class: "measurement",
             });
             expect(configs.find((config) => config.object_id === "network_mode")?.discovery_payload).toMatchObject({
                 command_template: '{"network": {"mode": {{ value | tojson }}}}',
+                entity_category: "config",
                 options: ["auto", "manual"],
             });
             expect(configs.find((config) => config.object_id === "network_advanced_enabled")?.discovery_payload).toMatchObject({
                 value_template:
                     '{% if value_json["network"] is defined and value_json["network"]["advanced"] is defined and value_json["network"]["advanced"]["enabled"] is defined %}{{ value_json["network"]["advanced"]["enabled"] | string | lower }}{% endif %}',
                 command_template: '{"network": {"advanced": {"enabled": {{ value }}}}}',
+                entity_category: "config",
                 payload_on: "true",
                 payload_off: "false",
             });

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1381,6 +1381,41 @@ describe("Extension: HomeAssistant", () => {
         }
     });
 
+    it("Should discover irrigation plan remove index as disabled config", () => {
+        const siren = getZ2MEntity(devices.HS2WD) as Device;
+        assert(siren.definition);
+        const originalExposes = siren.definition.exposes;
+
+        siren.definition.exposes = [
+            {
+                type: "numeric",
+                name: "irrigation_plan_remove_plan_index",
+                property: "irrigation_plan_remove_plan_index",
+                label: "Irrigation plan remove plan index",
+                access: 2,
+                category: "config",
+                value_min: 0,
+                value_max: 5,
+            },
+        ] as zhc.Expose[];
+
+        try {
+            // @ts-expect-error private
+            const configs = extension.getConfigs(siren);
+
+            expect(configs.find((config) => config.object_id === "irrigation_plan_remove_plan_index")?.discovery_payload).toMatchObject({
+                command_topic: true,
+                enabled_by_default: false,
+                entity_category: "config",
+                icon: "mdi:calendar-remove",
+                min: 0,
+                max: 5,
+            });
+        } finally {
+            siren.definition.exposes = originalExposes;
+        }
+    });
+
     it("Should discover Wi-Fi composite settings as disabled config entities", () => {
         const siren = getZ2MEntity(devices.HS2WD) as Device;
         assert(siren.definition);

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -126,7 +126,7 @@ describe("Extension: HomeAssistant", () => {
         }
 
         expect(duplicated).toStrictEqual([]);
-    });
+    }, 30000);
 
     it("Should mark thermostat configuration toggles as config entities", () => {
         const switchExposes = [
@@ -409,7 +409,7 @@ describe("Extension: HomeAssistant", () => {
             object_id: "ha_discovery_group",
             default_entity_id: "switch.ha_discovery_group",
             unique_id: "9_switch_zigbee2mqtt",
-            group: ["0x0017880104e45542_switch_right_zigbee2mqtt"],
+            group: ["0x000b57fffec6a5b7_color_options_execute_if_off_zigbee2mqtt", "0x0017880104e45542_switch_right_zigbee2mqtt"],
             origin: origin,
             value_template: '{{ value_json["state"] }}',
         };
@@ -1166,6 +1166,129 @@ describe("Extension: HomeAssistant", () => {
             retain: true,
             qos: 1,
         });
+    });
+
+    it("Should discover safe scalar child entities for composite exposes", () => {
+        const siren = getZ2MEntity(devices.HS2WD) as Device;
+        assert(siren.definition);
+        const originalExposes = siren.definition.exposes;
+
+        siren.definition.exposes = [
+            {
+                type: "composite",
+                name: "network",
+                property: "network",
+                label: "Network",
+                access: 3,
+                features: [
+                    {
+                        type: "numeric",
+                        name: "timeout",
+                        property: "timeout",
+                        label: "Timeout",
+                        access: 3,
+                        unit: "min",
+                        value_min: 1,
+                        value_max: 60,
+                        value_step: 1,
+                    },
+                    {
+                        type: "numeric",
+                        name: "temperature",
+                        property: "temperature",
+                        label: "Temperature",
+                        access: 1,
+                        unit: "°C",
+                    },
+                    {
+                        type: "numeric",
+                        name: "ignored",
+                        property: "ignored",
+                        label: "Ignored",
+                        access: 0,
+                    },
+                    {
+                        type: "enum",
+                        name: "mode",
+                        property: "mode",
+                        label: "Mode",
+                        access: 3,
+                        values: ["auto", "manual"],
+                    },
+                    {
+                        type: "text",
+                        name: "password",
+                        property: "password",
+                        label: "Password",
+                        access: 3,
+                    },
+                    {
+                        type: "composite",
+                        name: "advanced",
+                        property: "advanced",
+                        label: "Advanced",
+                        access: 3,
+                        features: [
+                            {
+                                type: "binary",
+                                name: "enabled",
+                                property: "enabled",
+                                label: "Enabled",
+                                access: 3,
+                                value_on: true,
+                                value_off: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ] as zhc.Expose[];
+
+        try {
+            // @ts-expect-error private
+            const configs = extension.getConfigs(siren);
+
+            expect(
+                configs
+                    .map((config) => `${config.type}:${config.object_id}`)
+                    .filter(
+                        (id) =>
+                            id.startsWith("number:network_") ||
+                            id.startsWith("sensor:network_") ||
+                            id.startsWith("select:network_") ||
+                            id.startsWith("switch:network_"),
+                    ),
+            ).toStrictEqual(["number:network_timeout", "sensor:network_temperature", "select:network_mode", "switch:network_advanced_enabled"]);
+            expect(configs.find((config) => config.object_id === "network_timeout")?.discovery_payload).toMatchObject({
+                value_template:
+                    '{% if value_json["network"] is defined and value_json["network"]["timeout"] is defined %}{{ value_json["network"]["timeout"] }}{% endif %}',
+                command_template: '{"network": {"timeout": {{ value }}}}',
+                unit_of_measurement: "min",
+                min: 1,
+                max: 60,
+                step: 1,
+            });
+            expect(configs.find((config) => config.object_id === "network_temperature")?.discovery_payload).toMatchObject({
+                unit_of_measurement: "°C",
+                device_class: "temperature",
+                state_class: "measurement",
+            });
+            expect(configs.find((config) => config.object_id === "network_mode")?.discovery_payload).toMatchObject({
+                command_template: '{"network": {"mode": {{ value | tojson }}}}',
+                options: ["auto", "manual"],
+            });
+            expect(configs.find((config) => config.object_id === "network_advanced_enabled")?.discovery_payload).toMatchObject({
+                value_template:
+                    '{% if value_json["network"] is defined and value_json["network"]["advanced"] is defined and value_json["network"]["advanced"]["enabled"] is defined %}{{ value_json["network"]["advanced"]["enabled"] | string | lower }}{% endif %}',
+                command_template: '{"network": {"advanced": {"enabled": {{ value }}}}}',
+                payload_on: "true",
+                payload_off: "false",
+            });
+            expect(configs.find((config) => config.object_id.includes("password"))).toBeUndefined();
+            expect(configs.find((config) => config.object_id.includes("ignored"))).toBeUndefined();
+        } finally {
+            siren.definition.exposes = originalExposes;
+        }
     });
 
     it("Should discover devices with speed-controlled fan", () => {


### PR DESCRIPTION
## Design outcome

This remains draft intentionally.

Reviewer feedback pointed out that broad scalar-composite discovery is the wrong default when a converter can expose independent values directly. The SONOFF valve work moved the affected irrigation/manual-watering values to scalar exposes in zigbee-herdsman-converters, which is the preferred fix for that device and avoids Home Assistant discovery guessing intent from composite children.

## Current scope if this is revived

- only expose scalar composite children for a concrete device/use case that cannot be represented cleanly in the converter
- do not split composite values that are atomic and must be written as one object
- keep converter-provided metadata as the source of truth instead of adding Home Assistant-specific inference

## Review note

Koenkk suggested changing the device expose instead, because `composite` should only be used when multiple values must be written together. This PR is therefore kept separate from the converter-side fix and intentionally does not try to generalize beyond the remaining safe cases.

## Home Assistant limitation

MQTT discovery can set `entity_category` and `enabled_by_default`, but it cannot create arbitrary custom sections on a device page or attach sibling entities to a valve more-info dialog. Grouped irrigation/manual-control UI still needs a dashboard/card or future Home Assistant support.

## Status

Kept as draft, not ready for merge. The practical path is to continue fixing over-used composites in zigbee-herdsman-converters first, then revisit this only if a clear generic gap remains.
