### PR TITLE
Read back known config states on reconnect

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -15,10 +15,30 @@ import Extension from "./extension";
  */
 const MAX_TIMEOUT = 2147483647;
 
-const RETRIEVE_ON_RECONNECT: readonly {keys: string[]; condition?: (state: KeyValue) => boolean}[] = [
+type RetrieveStateItem = {
+    keys: string[];
+    condition?: (state: KeyValue) => boolean;
+    missingOnly?: boolean;
+};
+
+const RETRIEVE_ON_RECONNECT: readonly RetrieveStateItem[] = [
     {keys: ["state"]},
     {keys: ["brightness"], condition: (state: KeyValue): boolean => state.state === "ON"},
     {keys: ["color", "color_temp"], condition: (state: KeyValue): boolean => state.state === "ON"},
+    {keys: ["power_on_behavior"], missingOnly: true},
+    {keys: ["child_lock"], missingOnly: true},
+    {keys: ["led_enable"], missingOnly: true},
+    {keys: ["switch_type"], missingOnly: true},
+    {keys: ["switch_mode"], missingOnly: true},
+    {keys: ["valve_type"], missingOnly: true},
+    {keys: ["display_switch_on_duration"], missingOnly: true},
+    {keys: ["dimming_range_minimum"], missingOnly: true},
+    {keys: ["dimming_range_maximum"], missingOnly: true},
+    {keys: ["off_on_duration"], missingOnly: true},
+    {keys: ["on_off_duration"], missingOnly: true},
+    {keys: ["indicator_mode"], missingOnly: true},
+    {keys: ["power_outage_memory"], missingOnly: true},
+    {keys: ["switch_type_button"], missingOnly: true},
 ];
 
 export default class Availability extends Extension {
@@ -314,44 +334,60 @@ export default class Availability extends Extension {
                     logger.debug(`Retrieving state of '${device.name}' after reconnect`);
 
                     // Color and color temperature converters do both, only needs to be called once.
-                    for (const item of RETRIEVE_ON_RECONNECT) {
-                        if (item.condition && this.state.get(device) && !item.condition(this.state.get(device))) {
-                            continue;
-                        }
-
-                        // biome-ignore lint/style/noNonNullAssertion: doesn't change once valid
-                        const converter = device.definition!.toZigbee.find((c) => !c.key || c.key.find((k) => item.keys.includes(k)));
-                        const options: KeyValue = device.options;
-                        const state = this.state.get(device);
-                        const meta: zhc.Tz.Meta = {
-                            message: this.state.get(device),
-                            // biome-ignore lint/style/noNonNullAssertion: doesn't change once valid
-                            mapped: device.definition!,
-                            endpoint_name: undefined,
-                            options,
-                            state,
-                            device: device.zh,
-                            /* v8 ignore start */
-                            deviceExposesChanged: (): void => this.eventBus.emitExposesAndDevicesChanged(device),
-                            /* v8 ignore stop */
-                            /* v8 ignore next */
-                            publish: (payload: KeyValue) => this.publishEntityState(device, payload),
-                        };
-
-                        try {
-                            const endpoint = device.endpoint();
-                            assert(endpoint);
-                            await converter?.convertGet?.(endpoint, item.keys[0], meta);
-                        } catch (error) {
-                            logger.error(`Failed to read state of '${device.name}' after reconnect (${(error as Error).message})`);
-                        }
-
-                        await utils.sleep(500);
-                    }
+                    await this.#retrieveStateItems(device, RETRIEVE_ON_RECONNECT);
                 }, utils.seconds(2)),
             );
         }
 
         this.retrieveStateDebouncers.get(device.ieeeAddr)?.();
+    }
+
+    async #retrieveStateItems(device: Device, items: readonly RetrieveStateItem[]): Promise<void> {
+        if (!device.definition || !device.interviewed || device.options.disabled) {
+            return;
+        }
+
+        for (const item of items) {
+            const state = this.state.get(device);
+
+            if (item.condition && state && !item.condition(state)) {
+                continue;
+            }
+
+            if (item.missingOnly && item.keys.every((key) => state[key] !== undefined && state[key] !== null && state[key] !== "unknown")) {
+                continue;
+            }
+
+            const definition = device.definition;
+            const converter = definition.toZigbee.find((c) => !c.key || c.key.find((key) => item.keys.includes(key)));
+            if (!converter?.convertGet) {
+                continue;
+            }
+
+            const options: KeyValue = device.options;
+            const meta: zhc.Tz.Meta = {
+                message: state,
+                mapped: definition,
+                endpoint_name: undefined,
+                options,
+                state,
+                device: device.zh,
+                /* v8 ignore start */
+                deviceExposesChanged: (): void => this.eventBus.emitExposesAndDevicesChanged(device),
+                /* v8 ignore stop */
+                /* v8 ignore next */
+                publish: (payload: KeyValue) => this.publishEntityState(device, payload),
+            };
+
+            try {
+                const endpoint = device.endpoint();
+                assert(endpoint);
+                await converter.convertGet(endpoint, item.keys[0], meta);
+            } catch (error) {
+                logger.error(`Failed to read state '${item.keys[0]}' of '${device.name}' after reconnect (${(error as Error).message})`);
+            }
+
+            await utils.sleep(500);
+        }
     }
 }

--- a/test/extensions/availability.test.ts
+++ b/test/extensions/availability.test.ts
@@ -8,12 +8,13 @@ import {devices, events as mockZHEvents, returnDevices} from "../mocks/zigbeeHer
 
 import assert from "node:assert";
 import {stringify} from "../../lib/util/stringify";
+import type * as zhc from "zigbee-herdsman-converters";
 import {Controller} from "../../lib/controller";
 import Availability from "../../lib/extension/availability";
 import * as settings from "../../lib/util/settings";
 import utils from "../../lib/util/utils";
 
-const mocksClear = [mockMQTTPublishAsync, mockLogger.warning, mockLogger.info];
+const mocksClear = [mockMQTTPublishAsync, mockLogger.warning, mockLogger.info, mockLogger.error];
 
 returnDevices.push(
     devices.bulb_color.ieeeAddr,
@@ -298,8 +299,10 @@ describe("Extension: Availability", () => {
         expect(endpoint.read).toHaveBeenCalledTimes(0);
         await setTimeAndAdvanceTimers(utils.seconds(2));
 
-        expect(endpoint.read).toHaveBeenCalledTimes(1);
-        expect(endpoint.read).toHaveBeenCalledWith("genOnOff", ["onOff"]);
+        expect(endpoint.read.mock.calls).toStrictEqual([
+            ["genOnOff", ["onOff"]],
+            ["genOnOff", ["startUpOnOff"]],
+        ]);
 
         endpoint.read.mockClear();
         await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
@@ -308,7 +311,250 @@ describe("Extension: Availability", () => {
             throw new Error("");
         });
         await setTimeAndAdvanceTimers(utils.seconds(3));
-        expect(endpoint.read).toHaveBeenCalledTimes(1);
+        expect(endpoint.read).toHaveBeenCalledWith("genOnOff", ["onOff"]);
+    });
+
+    it("Should retrieve missing known config state when a device reconnects", async () => {
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
+        const endpoint = devices.bulb_color.getEndpoint(1);
+        assert(endpoint);
+        endpoint.read.mockClear();
+
+        const definition = device.definition!;
+        const originalToZigbee = definition.toZigbee;
+
+        definition.toZigbee = [
+            {
+                key: ["power_on_behavior"],
+                convertGet: async (entity) => {
+                    await entity.read("genBasic", ["zclVersion"]);
+                },
+            } as zhc.Tz.Converter,
+        ];
+
+        try {
+            controller.state.clear();
+            controller.state.set(device, {});
+
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(3));
+
+            expect(endpoint.read).toHaveBeenCalledWith("genBasic", ["zclVersion"]);
+        } finally {
+            definition.toZigbee = originalToZigbee;
+        }
+    });
+
+    it("Should retrieve null known config state when a device reconnects", async () => {
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
+        const endpoint = devices.bulb_color.getEndpoint(1);
+        assert(endpoint);
+        endpoint.read.mockClear();
+
+        const definition = device.definition!;
+        const originalToZigbee = definition.toZigbee;
+
+        definition.toZigbee = [
+            {
+                key: ["power_on_behavior"],
+                convertGet: async (entity) => {
+                    await entity.read("genBasic", ["zclVersion"]);
+                },
+            } as zhc.Tz.Converter,
+        ];
+
+        try {
+            controller.state.set(device, {power_on_behavior: null});
+
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(3));
+
+            expect(endpoint.read).toHaveBeenCalledWith("genBasic", ["zclVersion"]);
+        } finally {
+            definition.toZigbee = originalToZigbee;
+        }
+    });
+
+    it("Should not retrieve known config state for devices that are unavailable for reconnect readback", async () => {
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
+        const endpoint = devices.bulb_color.getEndpoint(1);
+        assert(endpoint);
+        endpoint.read.mockClear();
+
+        const definition = device.definition!;
+        const originalDefinition = device.definition;
+        const originalToZigbee = definition.toZigbee;
+
+        definition.toZigbee = [
+            {
+                key: ["power_on_behavior"],
+                convertGet: async (entity) => {
+                    await entity.read("genBasic", ["zclVersion"]);
+                },
+            } as zhc.Tz.Converter,
+        ];
+
+        try {
+            controller.state.set(device, {});
+
+            device.definition = undefined;
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(3));
+
+            device.definition = definition;
+            devices.bulb_color.interviewState = "IN_PROGRESS";
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(3));
+
+            devices.bulb_color.interviewState = "SUCCESSFUL";
+            settings.set(["devices", devices.bulb_color.ieeeAddr, "disabled"], true);
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(3));
+
+            expect(endpoint.read).toHaveBeenCalledTimes(0);
+        } finally {
+            settings.set(["devices", devices.bulb_color.ieeeAddr, "disabled"], false);
+            devices.bulb_color.interviewState = "SUCCESSFUL";
+            device.definition = originalDefinition;
+            definition.toZigbee = originalToZigbee;
+        }
+    });
+
+    it("Should continue when known config state readback fails", async () => {
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
+        const definition = device.definition!;
+        const originalToZigbee = definition.toZigbee;
+
+        definition.toZigbee = [
+            {
+                key: ["power_on_behavior"],
+                convertGet: () => {
+                    throw new Error("read failed");
+                },
+            } as zhc.Tz.Converter,
+        ];
+
+        try {
+            controller.state.set(device, {});
+
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(3));
+
+            expect(mockLogger.error).toHaveBeenCalledTimes(1);
+            expect(mockLogger.error).toHaveBeenCalledWith("Failed to read state 'power_on_behavior' of 'bulb_color' after reconnect (read failed)");
+        } finally {
+            definition.toZigbee = originalToZigbee;
+        }
+    });
+
+    it("Should skip known config state when a device reconnects", async () => {
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
+        const endpoint = devices.bulb_color.getEndpoint(1);
+        assert(endpoint);
+        endpoint.read.mockClear();
+
+        const definition = device.definition!;
+        const originalToZigbee = definition.toZigbee;
+
+        definition.toZigbee = [
+            {
+                key: ["power_on_behavior"],
+                convertGet: async (entity, key) => {
+                    await entity.read("genBasic", [key]);
+                },
+            } as zhc.Tz.Converter,
+        ];
+
+        try {
+            controller.state.set(device, {power_on_behavior: "previous"});
+
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(3));
+
+            expect(endpoint.read).toHaveBeenCalledTimes(0);
+        } finally {
+            definition.toZigbee = originalToZigbee;
+        }
+    });
+
+    it("Should use a bounded static known-config readback list", async () => {
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
+        const definition = device.definition!;
+        const originalToZigbee = definition.toZigbee;
+        const convertGet = vi.fn();
+
+        definition.toZigbee = [
+            {
+                key: ["power_on_behavior", "child_lock"],
+                convertGet,
+            } as zhc.Tz.Converter,
+        ];
+
+        try {
+            controller.state.clear();
+            controller.state.set(device, {});
+
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(3));
+
+            expect(convertGet).toHaveBeenCalledTimes(2);
+            expect(convertGet).toHaveBeenNthCalledWith(1, expect.anything(), "power_on_behavior", expect.anything());
+            expect(convertGet).toHaveBeenNthCalledWith(2, expect.anything(), "child_lock", expect.anything());
+            expect(convertGet).not.toHaveBeenCalledWith(expect.anything(), "led_enable", expect.anything());
+        } finally {
+            definition.toZigbee = originalToZigbee;
+        }
+    });
+
+    it("Should read additional missing config states with their own converter key", async () => {
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
+        const definition = device.definition!;
+        const originalToZigbee = definition.toZigbee;
+        const convertGet = vi.fn();
+
+        definition.toZigbee = [
+            {
+                key: ["switch_type"],
+                convertGet,
+            } as zhc.Tz.Converter,
+            {
+                key: ["display_switch_on_duration"],
+                convertGet,
+            } as zhc.Tz.Converter,
+            {
+                key: ["dimming_range_maximum"],
+                convertGet,
+            } as zhc.Tz.Converter,
+            {
+                key: ["indicator_mode"],
+                convertGet,
+            } as zhc.Tz.Converter,
+        ];
+
+        try {
+            controller.state.clear();
+            controller.state.set(device, {});
+
+            await mockZHEvents.deviceAnnounce({device: devices.bulb_color});
+            await flushPromises();
+            await setTimeAndAdvanceTimers(utils.seconds(5));
+
+            expect(convertGet).toHaveBeenCalledTimes(4);
+            expect(convertGet).toHaveBeenNthCalledWith(1, expect.anything(), "switch_type", expect.anything());
+            expect(convertGet).toHaveBeenNthCalledWith(2, expect.anything(), "display_switch_on_duration", expect.anything());
+            expect(convertGet).toHaveBeenNthCalledWith(3, expect.anything(), "dimming_range_maximum", expect.anything());
+            expect(convertGet).toHaveBeenNthCalledWith(4, expect.anything(), "indicator_mode", expect.anything());
+        } finally {
+            definition.toZigbee = originalToZigbee;
+        }
     });
 
     it("Should republish availability when device is renamed", async () => {


### PR DESCRIPTION
## Summary
- read a bounded set of known configuration exposes after a device reconnects when the state is missing, `null`, or `unknown`
- cover common config values seen missing in my Home Assistant instance: `power_on_behavior`, `child_lock`, `led_enable`, input `switch_type`/`switch_mode`, Bosch thermostat `valve_type`/`display_switch_on_duration`, Aqara dimming/transition settings, and common Tuya plug config
- keep the logic in the existing reconnect readback path instead of adding new configure/interview triggers
- skip unavailable, not-yet-interviewed, disabled, or unsupported devices and continue if one read fails

## Rationale
Some devices expose configuration controls in Zigbee2MQTT/Home Assistant before their current value has been reported. The existing reconnect readback path already handles safe state refreshes, so this extends that bounded path with missing-only known config keys. It intentionally avoids dynamic expose traversal and avoids new network reads on configure/interview.

Each new entry is kept as its own readback item unless it shares the same converter semantics, so devices with independent converters do not receive a `convertGet` call for the wrong key. Unsupported keys are skipped because the converter must exist and implement `convertGet`.

## Tests
- `node --run test -- test/extensions/availability.test.ts`
- `node --run build`
- `node --run check`
- `git diff --check origin/dev...HEAD`
