### PR TITLE
Mark legacy action sensors diagnostic

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1227,6 +1227,7 @@ export class HomeAssistant extends Extension {
                         discovery_payload: {
                             name: endpointName ? `${firstExpose.label} ${endpointName}` : firstExpose.label,
                             value_template: valueTemplate,
+                            ...(firstExpose.property === "action" ? {entity_category: "diagnostic"} : {}),
                             ...ENUM_DISCOVERY_LOOKUP[firstExpose.name],
                         },
                     });

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -3023,11 +3023,15 @@ describe("Extension: HomeAssistant", () => {
         settings.set(["homeassistant", "legacy_action_sensor"], true);
         await resetExtension();
 
-        // Should discovery action sensor
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("homeassistant/sensor/0x0017880104e45520/action/config", expect.any(String), {
-            retain: true,
-            qos: 1,
+        // Should discover action sensor as a diagnostic helper instead of a primary entity.
+        const actionDiscovery = mockMQTTPublishAsync.mock.calls.find(([topic]) => topic === "homeassistant/sensor/0x0017880104e45520/action/config");
+        assert(actionDiscovery);
+        expect(JSON.parse(actionDiscovery[1])).toMatchObject({
+            entity_category: "diagnostic",
+            name: "Action",
+            object_id: "button_action",
         });
+        expect(actionDiscovery[2]).toStrictEqual({retain: true, qos: 1});
 
         // Should counter an action payload with an empty payload
         mockMQTTPublishAsync.mockClear();


### PR DESCRIPTION
## Summary

Marks legacy Home Assistant action sensors as diagnostic entities.

Zigbee2MQTT still supports `homeassistant.legacy_action_sensor`, which publishes `*_action` as MQTT sensors for compatibility. These sensors are automation/debug helpers, not primary device state, so Home Assistant should classify them as diagnostic while keeping them available for users that still rely on them.

This change only affects the legacy MQTT sensor discovery path for enum exposes whose property is `action`. Modern Home Assistant event/device automation discovery remains unchanged.

## Live validation

Validated on my Zigbee2MQTT add-on with a narrow compiled override that preserved the existing local test stack:

- retained `homeassistant/sensor/+/action/config` payloads for IKEA remotes and Shelly devices now include `entity_category: diagnostic`
- Home Assistant entity registry shows the retained MQTT `sensor.*_action` entities with `entity_category: diagnostic`
- existing user-hidden state on those entities was preserved

Sample affected entities included:

- `sensor.bad_lichtschalter_action`
- `sensor.wohnzimmer_rollo_kuche_action`
- `sensor.wohnzimmer_rollo_sofa_action`
- `sensor.schlafzimmer_rollo_action`
- IKEA remote legacy action sensors

## Validation

- `vitest run test/extensions/homeassistant.test.ts --config ./test/vitest.config.mts -t "Legacy action sensor"`
- `node --run check`
- `node --run build`
- `vitest run --config ./test/vitest.config.mts --maxWorkers=1`
- `git diff --check`

