### PR TITLE
Mark thermostat configuration switches as config

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -48,14 +48,22 @@ const GROUP_SUPPORTED_TYPES: ReadonlyArray<string> = ["light", "switch", "lock",
 const COVER_OPENING_LOOKUP: ReadonlyArray<string> = ["opening", "open", "forward", "up", "rising"];
 const COVER_CLOSING_LOOKUP: ReadonlyArray<string> = ["closing", "close", "backward", "back", "reverse", "down", "declining"];
 const COVER_STOPPED_LOOKUP: ReadonlyArray<string> = ["stopped", "stop", "pause", "paused"];
-const SWITCH_DIFFERENT: ReadonlyArray<string> = ["valve_detection", "window_detection", "auto_lock", "away_mode"];
+const CONFIG_SWITCH_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
+    auto_lock: {entity_category: "config", icon: "mdi:lock"},
+    away_mode: {entity_category: "config", icon: "mdi:home-export-outline"},
+    valve_detection: {entity_category: "config", icon: "mdi:pipe-valve"},
+    window_detection: {entity_category: "config", icon: "mdi:window-open-variant"},
+} as const;
+const SWITCH_DIFFERENT: ReadonlyArray<string> = Object.keys(CONFIG_SWITCH_DISCOVERY_LOOKUP);
 const BINARY_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     activity_led_indicator: {icon: "mdi:led-on"},
     area1Occupancy: {device_class: "occupancy"},
     area2Occupancy: {device_class: "occupancy"},
     area3Occupancy: {device_class: "occupancy"},
     area4Occupancy: {device_class: "occupancy"},
+    auto_lock: {entity_category: "config", icon: "mdi:lock"},
     auto_off: {icon: "mdi:flash-auto"},
+    away_mode: {entity_category: "config", icon: "mdi:home-export-outline"},
     battery_low: {entity_category: "diagnostic", device_class: "battery"},
     button_lock: {entity_category: "config", icon: "mdi:lock"},
     calibration: {entity_category: "config", icon: "mdi:progress-wrench"},
@@ -71,6 +79,8 @@ const BINARY_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     consumer_connected: {device_class: "plug"},
     contact: {device_class: "door"},
     garage_door_contact: {device_class: "garage_door", payload_on: false, payload_off: true},
+    frost_protection: {entity_category: "config", icon: "mdi:snowflake-thermometer"},
+    heating_stop: {entity_category: "config", icon: "mdi:radiator-off"},
     eco_mode: {entity_category: "config", icon: "mdi:leaf"},
     expose_pin: {entity_category: "config", icon: "mdi:pin"},
     flip_indicator_light: {entity_category: "config", icon: "mdi:arrow-left-right"},
@@ -103,12 +113,12 @@ const BINARY_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     th_heater: {icon: "mdi:heat-wave"},
     trigger_indicator: {icon: "mdi:led-on"},
     valve_alarm: {device_class: "problem"},
-    valve_detection: {icon: "mdi:pipe-valve"},
+    valve_detection: {entity_category: "config", icon: "mdi:pipe-valve"},
     valve_state: {device_class: "opening"},
     vibration: {device_class: "vibration"},
     water_leak: {device_class: "moisture"},
     window: {device_class: "window"},
-    window_detection: {icon: "mdi:window-open-variant"},
+    window_detection: {entity_category: "config", icon: "mdi:window-open-variant"},
     window_open: {device_class: "window"},
 } as const;
 const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
@@ -603,10 +613,7 @@ export class HomeAssistant extends Extension {
                     discoveryEntry.discovery_payload.state_off = state.value_off;
                     discoveryEntry.discovery_payload.state_on = state.value_on;
                     discoveryEntry.object_id = property;
-
-                    if (property === "window_detection") {
-                        discoveryEntry.discovery_payload.icon = "mdi:window-open-variant";
-                    }
+                    Object.assign(discoveryEntry.discovery_payload, CONFIG_SWITCH_DISCOVERY_LOOKUP[property]);
                 }
 
                 discoveryEntries.push(discoveryEntry);

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -128,6 +128,52 @@ describe("Extension: HomeAssistant", () => {
         expect(duplicated).toStrictEqual([]);
     });
 
+    it("Should mark thermostat configuration toggles as config entities", () => {
+        const switchExposes = [
+            new zhc.Switch().withLabel("Auto lock").withState("auto_lock", false, "Enable/disable auto lock", zhc.access.STATE_SET, "AUTO", "MANUAL"),
+            new zhc.Switch().withLabel("Away mode").withState("away_mode", false, "Enable/disable away mode", zhc.access.STATE_SET),
+            new zhc.Switch().withLabel("Valve detection").withState("valve_detection", true, "Valve detection", zhc.access.STATE_SET),
+            new zhc.Switch()
+                .withLabel("Window detection")
+                .withState("window_detection", true, "Enables/disables window detection", zhc.access.STATE_SET),
+        ];
+        const binaryExposes = [
+            new zhc.Binary("frost_protection", zhc.access.STATE_SET, "ON", "OFF").withDescription("Anti-freeze protection"),
+            new zhc.Binary("heating_stop", zhc.access.STATE_SET, "ON", "OFF").withDescription("Heating stop"),
+            new zhc.Binary("away_mode", zhc.access.STATE_SET, "ON", "OFF").withDescription("Away mode"),
+            new zhc.Binary("window_detection", zhc.access.STATE_SET, "ON", "OFF").withDescription("Open window detection"),
+        ];
+        const getDiscoveryConfigs = (expose: zhc.Expose): KeyValueAny[] => {
+            const device = {
+                definition: {},
+                isDevice: (): boolean => true,
+                isGroup: (): boolean => false,
+                endpoint: () => undefined,
+                options: {},
+                exposes: (): zhc.Expose[] => [expose],
+                zh: {endpoints: []},
+            };
+            // @ts-expect-error private method and minimal test device
+            return extension.getConfigs(device);
+        };
+
+        for (const expose of switchExposes) {
+            const [config] = getDiscoveryConfigs(expose);
+            expect(config.type).toStrictEqual("switch");
+            expect(config.object_id).toStrictEqual(expose.features[0].property);
+            expect(config.discovery_payload.entity_category).toStrictEqual("config");
+            expect(config.discovery_payload.command_topic_postfix).toStrictEqual(expose.features[0].property);
+        }
+
+        for (const expose of binaryExposes) {
+            const [config] = getDiscoveryConfigs(expose);
+            expect(config.type).toStrictEqual("switch");
+            expect(config.object_id).toStrictEqual(`switch_${expose.name}`);
+            expect(config.discovery_payload.entity_category).toStrictEqual("config");
+            expect(config.discovery_payload.command_topic_postfix).toStrictEqual(expose.property);
+        }
+    });
+
     it("Should discover devices and groups", async () => {
         settings.set(["homeassistant", "experimental_event_entities"], true);
         settings.set(["groups", "9", "homeassistant"], {name: "HA Discovery Group", icon: "mdi:lightbulb-group"});


### PR DESCRIPTION
## Summary

- mark thermostat-style configuration toggles as Home Assistant `config` entities in MQTT discovery
- cover both enum-backed switch exposes and binary-as-switch exposes for `window_detection`, `valve_detection`, `auto_lock`, `away_mode`, `heating_stop`, and `frost_protection`
- keep the existing icons while moving these controls out of the primary device controls area

## Why

A Home Assistant audit showed these controls as primary device controls even though they configure thermostat/device behavior rather than representing normal actor state. Examples seen live include Bosch Room Thermostat II 230V `window_detection` switches on my Home Assistant instance and thermostat config toggles such as `heating_stop`, `frost_protection`, `auto_lock`, and `away_mode` in the Home Assistant snapshot.

This PR is intentionally limited to configuration-style toggles. It does not make a broad policy change for electrical telemetry such as voltage, because voltage can be a primary measurement for dedicated metering devices.

## Validation

- `./node_modules/.bin/vitest run test/extensions/homeassistant.test.ts --config ./test/vitest.config.mts -t "thermostat configuration toggles"`
- `node --run check`
- `node --run build`
- `./node_modules/.bin/vitest run --config ./test/vitest.config.mts --maxWorkers=1` (`23` files, `777` tests)
- live my Home Assistant instance validation with a narrow add-on override: retained MQTT discovery for all five Bosch `window_detection` switches publishes `entity_category: "config"`