### PR TITLE
Pass device options to HA discovery overrides

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1825,7 +1825,7 @@ export class HomeAssistant extends Extension {
 
             if (entity.isDevice()) {
                 try {
-                    entity.definition?.meta?.overrideHaDiscoveryPayload?.(payload);
+                    entity.definition?.meta?.overrideHaDiscoveryPayload?.(payload, entity.options);
                 } catch (error) {
                     logger.error(`Failed to override HA discovery payload (${(error as Error).stack})`);
                 }

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1316,6 +1316,30 @@ describe("Extension: HomeAssistant", () => {
         overrideSpy.mockRestore();
     });
 
+    it("passes device options to discovery payload overrides", async () => {
+        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
+        assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");
+        const overrideSpy = vi.spyOn(bosch.definition.meta, "overrideHaDiscoveryPayload") as MockInstance;
+        settings.set(["devices", "0x18fc2600000d7ae2", "discovery_option_marker"], "passed");
+
+        overrideSpy.mockImplementation((payload, options) => {
+            if (payload.mode_command_topic?.endsWith("/system_mode")) {
+                payload.discovery_option_marker = options?.discovery_option_marker;
+            }
+        });
+
+        await resetExtension();
+
+        expect(overrideSpy).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({discovery_option_marker: "passed"}));
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
+            "homeassistant/climate/0x18fc2600000d7ae2/climate/config",
+            expect.stringContaining('"discovery_option_marker":"passed"'),
+            {qos: 1, retain: true},
+        );
+
+        overrideSpy.mockRestore();
+    });
+
     it("Should discover Bosch BTH-RM230Z with a current_humidity attribute", () => {
         const payload = {
             action_template:


### PR DESCRIPTION
## Summary

- call `entity.definition?.meta?.overrideHaDiscoveryPayload?.(payload, entity.options)` directly when publishing Home Assistant discovery
- remove the local Zigbee2MQTT-side type redeclaration for the converter hook
- add a focused regression proving a device option reaches the override and affects the retained discovery payload

## Why

Some converter-level HA discovery overrides need to be configurable per device. For example, Koenkk/zigbee-herdsman-converters#12498 adds a Bosch RM230Z option that defaults HA climate discovery to heating-only but can explicitly expose `cool` or `heat_cool` where an installation really supports cooling.

The hook signature itself belongs in zigbee-herdsman-converters, not Zigbee2MQTT. The matching converter type update is split into Koenkk/zigbee-herdsman-converters#12526.

## Dependency

- Koenkk/zigbee-herdsman-converters#12526 has merged and the consumed converter package exposes the typed optional `options` argument.
- The Zigbee2MQTT code now calls the converter-owned hook directly without local type redeclaration or suppression.

## Validation

- `node --run build`
- `node --run check`
- `vitest run test/extensions/homeassistant.test.ts --config ./test/vitest.config.mts -t "passes device options"`
- `git diff --check`

## Live validation

On my Home Assistant instance, the running Zigbee2MQTT override already had this option-passing hook. I temporarily changed `Arbeitszimmer Thermostat` from `homeassistant_climate_modes: heat` to `heat_cool` through `zigbee2mqtt/bridge/request/device/options` and verified retained HA discovery changed from `modes: ["off", "heat", "auto"]` to `modes: ["off", "heat", "cool", "auto"]` with `active_modes = ['heat','cool']`. I then reverted the option to `heat` and verified retained discovery returned to `modes: ["off", "heat", "auto"]`.

