### PR TITLE
Fix unit conversion for derived weather sensors by restoring device_class with name preservation

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -130,7 +130,7 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     alarm_temperature_min: {device_class: "temperature", entity_category: "config", icon: "mdi:thermometer-low"},
     angle: {icon: "angle-acute"},
     angle_axis: {icon: "angle-acute"},
-    apparent_temperature: {icon: "mdi:thermometer-lines", state_class: "measurement"},
+    apparent_temperature: {device_class: "temperature", icon: "mdi:thermometer-lines", preserve_name: true, state_class: "measurement"},
     aqi: {device_class: "aqi", state_class: "measurement"},
     auto_relock_time: {entity_category: "config", icon: "mdi:timer"},
     away_preset_days: {entity_category: "config", icon: "mdi:timer"},
@@ -165,7 +165,7 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
         entity_category: "diagnostic",
         state_class: "measurement",
     },
-    dew_point: {icon: "mdi:thermometer-water", state_class: "measurement"},
+    dew_point: {device_class: "temperature", icon: "mdi:thermometer-water", preserve_name: true, state_class: "measurement"},
     distance: {device_class: "distance", state_class: "measurement"},
     duration: {entity_category: "config", icon: "mdi:timer"},
     eco2: {device_class: "volatile_organic_compounds_parts", state_class: "measurement"},
@@ -178,10 +178,10 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     flow: {device_class: "volume_flow_rate", state_class: "measurement"},
     gas: {device_class: "gas", state_class: "total_increasing", icon: "mdi:meter-gas"},
     gas_density: {icon: "mdi:google-circles-communities", state_class: "measurement"},
-    gust_speed: {icon: "mdi:weather-windy-variant", state_class: "measurement"},
+    gust_speed: {device_class: "wind_speed", icon: "mdi:weather-windy-variant", preserve_name: true, state_class: "measurement"},
     hcho: {icon: "mdi:air-filter", state_class: "measurement"},
     heat_stress: {icon: "mdi:weather-sunny-alert", state_class: "measurement"},
-    humidex: {icon: "mdi:thermometer-alert", state_class: "measurement"},
+    humidex: {device_class: "temperature", icon: "mdi:thermometer-alert", preserve_name: true, state_class: "measurement"},
     humidity: {device_class: "humidity", state_class: "measurement"},
     humidity_calibration: {entity_category: "config", icon: "mdi:wrench-clock"},
     humidity_max: {entity_category: "config", icon: "mdi:water-percent"},
@@ -266,7 +266,7 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
         device_class: "water",
         state_class: "total_increasing",
     },
-    wind_chill: {icon: "mdi:snowflake-thermometer", state_class: "measurement"},
+    wind_chill: {device_class: "temperature", icon: "mdi:snowflake-thermometer", preserve_name: true, state_class: "measurement"},
     wind_direction: {icon: "mdi:compass-outline", state_class: "measurement"},
     wind_speed: {device_class: "wind_speed", icon: "mdi:weather-windy", state_class: "measurement"},
     x: {icon: "mdi:axis-x-arrow", state_class: "measurement"},
@@ -1356,8 +1356,9 @@ export class HomeAssistant extends Extension {
                 delete entry.discovery_payload.entity_category;
             }
 
-            // Let Home Assistant generate entity name when device_class is present
-            if (entry.discovery_payload.device_class) {
+            // Let Home Assistant generate entity name when device_class is present.
+            // preserve_name allows device_class and explicit name to coexist (e.g. derived sensors).
+            if (entry.discovery_payload.device_class && !NUMERIC_DISCOVERY_LOOKUP[firstExpose.name]?.preserve_name) {
                 delete entry.discovery_payload.name;
             }
 


### PR DESCRIPTION
## What

Restores `device_class` on 5 derived weather-station sensors and introduces a `preserve_name` flag so that both unit auto-conversion and descriptive entity naming work simultaneously.

The 5 affected sensors:
- `apparent_temperature` → `device_class: temperature`
- `dew_point` → `device_class: temperature`
- `humidex` → `device_class: temperature`
- `wind_chill` → `device_class: temperature`
- `gust_speed` → `device_class: wind_speed`

## Why

PR #31234 removed `device_class` from these entries to fix a naming collision: when multiple sensors share `device_class: temperature`, Home Assistant auto-generates "Temperature" for all of them because Z2M deletes the `name` field from the discovery payload whenever `device_class` is present.

This had an unintended regression: HA relies on `device_class: temperature` to know it should auto-convert °C→°F. Removing it silently broke unit conversion for all users with Imperial units set in HA (reported in #32337).

## How

A `preserve_name: true` flag is added to `NUMERIC_DISCOVERY_LOOKUP` entries for derived sensors. The name-deletion guard at line 1360 is updated to skip deletion when this flag is set, allowing `device_class` and the explicit sensor name to coexist in the discovery payload.

All existing sensors that have `device_class` but no `preserve_name` flag continue to work exactly as before — name is still deleted and HA auto-generates it from the device class.

## Related

- Fixes #32337
- Improves on #31234