### PR TITLE
fix: support OTA updates for devices with multiple image types

### DIFF
--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -111,7 +111,7 @@ export default class OTAUpdate extends Extension {
 
     #deleteAutoInProgress(ieeeAddr: string, imageType: number): void {
         this.#inProgressAuto.delete(`${ieeeAddr}_${imageType}`);
-        const count = (this.#inProgressAutoCount.get(ieeeAddr) ?? 1) - 1;
+        const count = (this.#inProgressAutoCount.get(ieeeAddr) ?? /* v8 ignore next */ 1) - 1;
 
         if (count <= 0) {
             this.#inProgressAutoCount.delete(ieeeAddr);
@@ -608,7 +608,7 @@ export default class OTAUpdate extends Extension {
         // For concurrent auto-checks (e.g. two-firmware devices): re-interview only after the last update.
         // autoImageType is defined when called from the auto-check path; the count includes the current
         // in-progress entry (not yet deleted by the caller), so > 1 means other imageTypes still running.
-        const otherAutoRunning = autoImageType !== undefined && (this.#inProgressAutoCount.get(device.ieeeAddr) ?? 0) > 1;
+        const otherAutoRunning = autoImageType !== undefined && (this.#inProgressAutoCount.get(device.ieeeAddr) ?? /* v8 ignore next */ 0) > 1;
 
         if (!otherAutoRunning) {
             setTimeout(() => {

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -53,8 +53,24 @@ export default class OTAUpdate extends Extension {
         `^${settings.get().mqtt.base_topic}/bridge/request/device/ota_update/(update|check|schedule|unschedule)/?(downgrade|abort)?`,
         "i",
     );
-    #inProgress = new Set<string>();
+    // Manual MQTT-initiated ops (check/update/schedule/unschedule): keyed by bare ieeeAddr
+    #inProgressManual = new Set<string>();
+    // Auto-check ops from Zigbee events: keyed by `${ieeeAddr}_${imageType}`
+    #inProgressAuto = new Set<string>();
+    // Per-device count of running auto-checks — enables O(1) #hasInProgress lookup without iterating #inProgressAuto
+    #inProgressAutoCount = new Map<string, number>();
+    // Throttling per imageType: keyed by `${ieeeAddr}_${imageType}`
     #lastChecked = new Map<string, number>();
+    // Cache of pending queryNextImageRequest payloads for devices where auto-check detected an available update.
+    // Keyed by bare ieeeAddr. Used to retry a manual update when the wrong MCU responds first (race condition).
+    #pendingAvailableRequests = new Map<
+        string,
+        {
+            payload: Zcl.ClustersTypes.TClusterCommandPayload<"genOta", "queryNextImageRequest">;
+            endpoint: zh.Endpoint;
+            ts: number;
+        }
+    >();
 
     // biome-ignore lint/suspicious/useAwait: API
     override async start(): Promise<void> {
@@ -76,8 +92,32 @@ export default class OTAUpdate extends Extension {
 
     // mostly intended for testing
     clearState(): void {
-        this.#inProgress.clear();
+        this.#inProgressManual.clear();
+        this.#inProgressAuto.clear();
+        this.#inProgressAutoCount.clear();
         this.#lastChecked.clear();
+        this.#pendingAvailableRequests.clear();
+    }
+
+    // O(1)×2: checks both manual (bare ieeeAddr) and auto (per-device count)
+    #hasInProgress(ieeeAddr: string): boolean {
+        return this.#inProgressManual.has(ieeeAddr) || this.#inProgressAutoCount.has(ieeeAddr);
+    }
+
+    #addAutoInProgress(ieeeAddr: string, imageType: number): void {
+        this.#inProgressAuto.add(`${ieeeAddr}_${imageType}`);
+        this.#inProgressAutoCount.set(ieeeAddr, (this.#inProgressAutoCount.get(ieeeAddr) ?? 0) + 1);
+    }
+
+    #deleteAutoInProgress(ieeeAddr: string, imageType: number): void {
+        this.#inProgressAuto.delete(`${ieeeAddr}_${imageType}`);
+        const count = (this.#inProgressAutoCount.get(ieeeAddr) ?? 1) - 1;
+
+        if (count <= 0) {
+            this.#inProgressAutoCount.delete(ieeeAddr);
+        } else {
+            this.#inProgressAutoCount.set(ieeeAddr, count);
+        }
     }
 
     #removeProgressAndRemainingFromState(device: Device): void {
@@ -90,7 +130,14 @@ export default class OTAUpdate extends Extension {
     }
 
     @bind private async onZigbeeEvent(data: eventdata.DeviceMessage): Promise<void> {
-        if (data.type !== "commandQueryNextImageRequest" || !data.device.definition || this.#inProgress.has(data.device.ieeeAddr)) {
+        if (data.type !== "commandQueryNextImageRequest" || !data.device.definition) {
+            return;
+        }
+
+        const requestPayload = data.data as Zcl.ClustersTypes.TClusterCommandPayload<"genOta", "queryNextImageRequest">;
+        const inProgressKey = `${data.device.ieeeAddr}_${requestPayload.imageType}`;
+
+        if (this.#inProgressAuto.has(inProgressKey) || this.#inProgressManual.has(data.device.ieeeAddr)) {
             return;
         }
 
@@ -105,7 +152,7 @@ export default class OTAUpdate extends Extension {
         if (data.device.zh.scheduledOta) {
             // allow custom source to override check for definition `ota`
             if (data.device.zh.scheduledOta?.url !== undefined || data.device.definition.ota) {
-                this.#inProgress.add(data.device.ieeeAddr);
+                this.#addAutoInProgress(data.device.ieeeAddr, requestPayload.imageType);
 
                 logger.info(`Updating '${data.device.name}' to latest firmware`);
 
@@ -114,7 +161,7 @@ export default class OTAUpdate extends Extension {
                     const [, toVersion] = await this.#update(
                         undefined, // uses internally registered schedule
                         data.device,
-                        data.data as Zcl.ClustersTypes.TClusterCommandPayload<"genOta", "queryNextImageRequest">,
+                        requestPayload,
                         data.meta.zclTransactionSequenceNumber,
                         {
                             // fallbacks are only to satisfy typing, should always be defined from settings defaults
@@ -123,6 +170,7 @@ export default class OTAUpdate extends Extension {
                             baseSize: otaSettings.default_maximum_data_size ?? /* v8 ignore next */ 50,
                         },
                         data.endpoint,
+                        requestPayload.imageType,
                     );
 
                     if (toVersion === undefined) {
@@ -135,7 +183,7 @@ export default class OTAUpdate extends Extension {
                     await this.publishEntityState(data.device, this.#getEntityPublishPayload(data.device, "scheduled"));
                 }
 
-                this.#inProgress.delete(data.device.ieeeAddr);
+                this.#deleteAutoInProgress(data.device.ieeeAddr, requestPayload.imageType);
 
                 return; // we're done
             }
@@ -147,22 +195,22 @@ export default class OTAUpdate extends Extension {
                 // with only 10 - 60 seconds inbetween. It doesn't make sense to check for a new update
                 // each time, so this interval can be set by the user. The default is 1,440 minutes (one day).
                 const updateCheckInterval = settings.get().ota.update_check_interval * 1000 * 60;
-                const deviceLastChecked = this.#lastChecked.get(data.device.ieeeAddr);
+                const deviceLastChecked = this.#lastChecked.get(inProgressKey);
                 const check = deviceLastChecked !== undefined ? Date.now() - deviceLastChecked > updateCheckInterval : true;
 
                 if (!check) {
                     return;
                 }
 
-                this.#inProgress.add(data.device.ieeeAddr);
-                this.#lastChecked.set(data.device.ieeeAddr, Date.now());
+                this.#addAutoInProgress(data.device.ieeeAddr, requestPayload.imageType);
+                this.#lastChecked.set(inProgressKey, Date.now());
                 let availableResult: OtaUpdateAvailableResult | undefined;
 
                 try {
                     // auto-check defaults to zigbee-OTA + potential local index, and never `downgrade`
                     availableResult = await data.device.zh.checkOta(
                         {downgrade: false},
-                        data.data as Zcl.ClustersTypes.TClusterCommandPayload<"genOta", "queryNextImageRequest">,
+                        requestPayload,
                         data.device.otaExtraMetas,
                         data.endpoint,
                     );
@@ -174,7 +222,15 @@ export default class OTAUpdate extends Extension {
 
                 if (availableResult?.available) {
                     logger.info(`OTA update available for '${data.device.name}'`);
+                    // Cache the pending request so a manual update can retry if the wrong MCU responds first
+                    this.#pendingAvailableRequests.set(data.device.ieeeAddr, {
+                        payload: requestPayload,
+                        endpoint: data.endpoint,
+                        ts: Date.now(),
+                    });
                 }
+
+                this.#deleteAutoInProgress(data.device.ieeeAddr, requestPayload.imageType);
             }
         }
 
@@ -187,7 +243,6 @@ export default class OTAUpdate extends Extension {
             data.meta.zclTransactionSequenceNumber,
         );
         logger.debug(`Responded to OTA request of '${data.device.name}' with 'NO_IMAGE_AVAILABLE'`);
-        this.#inProgress.delete(data.device.ieeeAddr);
     }
 
     async #readSoftwareBuildIDAndDateCode(
@@ -269,10 +324,10 @@ export default class OTAUpdate extends Extension {
 
         if (!(device instanceof Device)) {
             error = `Device '${id}' does not exist`;
-        } else if (this.#inProgress.has(device.ieeeAddr)) {
+        } else if (this.#hasInProgress(device.ieeeAddr)) {
             if (abort) {
                 device.zh.abortOta();
-                this.#inProgress.delete(device.ieeeAddr);
+                this.#inProgressManual.delete(device.ieeeAddr);
                 // cleanup same as a fail
                 this.#removeProgressAndRemainingFromState(device);
                 await this.publishEntityState(device, this.#getEntityPublishPayload(device, "available"));
@@ -287,7 +342,7 @@ export default class OTAUpdate extends Extension {
         } else {
             switch (type) {
                 case "check": {
-                    this.#inProgress.add(device.ieeeAddr);
+                    this.#inProgressManual.add(device.ieeeAddr);
 
                     const source: OtaSource = {downgrade};
 
@@ -315,7 +370,7 @@ export default class OTAUpdate extends Extension {
                         logger.info(`${availableResult.available ? "" : "No "}OTA update available for '${device.name}'`);
 
                         await this.publishEntityState(device, this.#getEntityPublishPayload(device, availableResult));
-                        this.#lastChecked.set(device.ieeeAddr, Date.now());
+                        this.#lastChecked.set(`${device.ieeeAddr}_${availableResult.current.imageType}`, Date.now());
 
                         const response = utils.getResponse<"bridge/response/device/ota_update/check">(message, {
                             id,
@@ -340,7 +395,7 @@ export default class OTAUpdate extends Extension {
                         break;
                     }
 
-                    this.#inProgress.add(device.ieeeAddr);
+                    this.#inProgressManual.add(device.ieeeAddr);
 
                     const otaSettings = settings.get().ota;
                     const source: OtaSource = {downgrade};
@@ -388,7 +443,18 @@ export default class OTAUpdate extends Extension {
 
                     try {
                         const firmwareFrom = await this.#readSoftwareBuildIDAndDateCode(device, "immediate");
-                        const [fromVersion, toVersion] = await this.#update(source, device, undefined, undefined, dataSettings);
+                        let [fromVersion, toVersion] = await this.#update(source, device, undefined, undefined, dataSettings);
+
+                        if (toVersion === undefined) {
+                            // Check if there's a recent pending request from auto-check (TTL 5 min).
+                            // This handles the race where a different MCU responds first to the imageNotify.
+                            const pending = this.#pendingAvailableRequests.get(device.ieeeAddr);
+
+                            if (pending !== undefined && Date.now() - pending.ts < 5 * 60 * 1000) {
+                                this.#pendingAvailableRequests.delete(device.ieeeAddr);
+                                [, toVersion] = await this.#update(source, device, pending.payload, undefined, dataSettings, pending.endpoint);
+                            }
+                        }
 
                         if (toVersion === undefined) {
                             error = `Update of '${device.name}' failed (No image currently available)`;
@@ -469,7 +535,7 @@ export default class OTAUpdate extends Extension {
                 }
             }
 
-            this.#inProgress.delete(device.ieeeAddr);
+            this.#inProgressManual.delete(device.ieeeAddr);
         }
 
         if (error) {
@@ -488,6 +554,9 @@ export default class OTAUpdate extends Extension {
      * Do the bulk of the update work (hand over to zigbee-herdsman, then re-interview).
      *
      * `dataSettings` object may be mutated by zigbee-herdsman to fit request (e.g. known manuf quirk)
+     *
+     * `autoImageType` is defined when called from the scheduled/auto-check path (Zigbee event). Used to
+     * skip re-interview when other imageTypes of the same device are still being updated concurrently.
      */
     async #update(
         source: OtaSource | undefined,
@@ -496,6 +565,7 @@ export default class OTAUpdate extends Extension {
         requestTsn: number | undefined,
         dataSettings: OtaDataSettings,
         endpoint?: zh.Endpoint,
+        autoImageType?: number,
     ): Promise<[from: number, to: number | undefined]> {
         const [from, to] = await device.zh.updateOta(
             source,
@@ -523,6 +593,16 @@ export default class OTAUpdate extends Extension {
 
         logger.info(() => `Device '${device.name}' was OTA updated from '${from.fileVersion}' to '${to.fileVersion}'`);
 
+        // Reset #lastChecked for all imageTypes of this device so siblings can be auto-checked immediately
+        for (const key of this.#lastChecked.keys()) {
+            if (key.startsWith(`${device.ieeeAddr}_`)) {
+                this.#lastChecked.delete(key);
+            }
+        }
+
+        // Clear any stale pending request — device will repopulate if still needed
+        this.#pendingAvailableRequests.delete(device.ieeeAddr);
+
         // OTA update can bring new features & co, force full re-interview and re-configure, same as a "device joined"
         if (device.zh.meta.configured !== undefined) {
             delete device.zh.meta.configured;
@@ -530,11 +610,18 @@ export default class OTAUpdate extends Extension {
             device.zh.save();
         }
 
-        setTimeout(() => {
-            device.reInterview(this.eventBus).catch((error) => {
-                logger.error(`${error.message}. Re-try manually after some time.`);
-            });
-        }, 5000);
+        // For concurrent auto-checks (e.g. two-firmware devices): re-interview only after the last update.
+        // autoImageType is defined when called from the auto-check path; the count includes the current
+        // in-progress entry (not yet deleted by the caller), so > 1 means other imageTypes still running.
+        const otherAutoRunning = autoImageType !== undefined && (this.#inProgressAutoCount.get(device.ieeeAddr) ?? 0) > 1;
+
+        if (!otherAutoRunning) {
+            setTimeout(() => {
+                device.reInterview(this.eventBus).catch((error) => {
+                    logger.error(`${error.message}. Re-try manually after some time.`);
+                });
+            }, 5000);
+        }
 
         return [from.fileVersion, to.fileVersion];
     }

--- a/lib/extension/otaUpdate.ts
+++ b/lib/extension/otaUpdate.ts
@@ -208,12 +208,7 @@ export default class OTAUpdate extends Extension {
 
                 try {
                     // auto-check defaults to zigbee-OTA + potential local index, and never `downgrade`
-                    availableResult = await data.device.zh.checkOta(
-                        {downgrade: false},
-                        requestPayload,
-                        data.device.otaExtraMetas,
-                        data.endpoint,
-                    );
+                    availableResult = await data.device.zh.checkOta({downgrade: false}, requestPayload, data.device.otaExtraMetas, data.endpoint);
                 } catch (error) {
                     logger.debug(`Failed to check if OTA update available for '${data.device.name}' (${error})`);
                 }

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -1554,12 +1554,10 @@ describe("Extension: OTAUpdate", () => {
 
         // Step 2 — MQTT update: first call returns no image, pending cache triggers a retry that succeeds
         devices.bulb.endpoints[0].read.mockImplementation(() => ({swBuildId: "1", dateCode: "20240101"}));
-        devices.bulb.updateOta
-            .mockResolvedValueOnce([{...DEFAULT_CURRENT, ...data}, undefined])
-            .mockResolvedValueOnce([
-                {...DEFAULT_CURRENT, ...data, fileVersion: 1},
-                {...DEFAULT_CURRENT, ...data, fileVersion: 2},
-            ]);
+        devices.bulb.updateOta.mockResolvedValueOnce([{...DEFAULT_CURRENT, ...data}, undefined]).mockResolvedValueOnce([
+            {...DEFAULT_CURRENT, ...data, fileVersion: 1},
+            {...DEFAULT_CURRENT, ...data, fileVersion: 2},
+        ]);
 
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/ota_update/update", stringify({id: "bulb"}));
         await flushPromises();
@@ -1584,7 +1582,7 @@ describe("Extension: OTAUpdate", () => {
 
         // Spy on the Z2M Device wrapper's reInterview (not the ZH mock device)
         const z2mDevice = controller.zigbee.resolveEntity(devices.bulb.ieeeAddr)!;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // biome-ignore lint/suspicious/noExplicitAny: spying on a private-ish method for test purposes
         const reInterviewSpy = vi.spyOn(z2mDevice as any, "reInterview").mockResolvedValue(undefined);
 
         devices.bulb.updateOta

--- a/test/extensions/otaUpdate.test.ts
+++ b/test/extensions/otaUpdate.test.ts
@@ -1414,4 +1414,244 @@ describe("Extension: OTAUpdate", () => {
             {},
         );
     });
+
+    it("allows independent auto-check for different imageType while another imageType check is already in progress", async () => {
+        settings.set(["devices", devices.bulb.ieeeAddr, "disable_automatic_update_check"], false);
+        const dataA = {imageType: 100, manufacturerCode: 0x128b, fileVersion: 1, fieldControl: 0};
+        const dataB = {imageType: 200, manufacturerCode: 0x128b, fileVersion: 1, fieldControl: 0};
+
+        let resolveCheckA!: (val: ReturnType<typeof devices.bulb.checkOta> extends Promise<infer T> ? T : never) => void;
+
+        // A's checkOta hangs
+        devices.bulb.checkOta.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveCheckA = resolve as typeof resolveCheckA;
+                }),
+        );
+        // B's checkOta resolves normally
+        devices.bulb.checkOta.mockResolvedValueOnce({
+            available: true,
+            current: {...DEFAULT_CURRENT, ...dataB},
+            availableMeta: {...DEFAULT_AVAILABLE_META, ...dataB, fileVersion: 2},
+        });
+
+        const payloadA = {
+            data: dataA,
+            cluster: "genOta",
+            device: devices.bulb,
+            endpoint: devices.bulb.getEndpoint(1)!,
+            type: "commandQueryNextImageRequest",
+            linkquality: 10,
+            meta: {zclTransactionSequenceNumber: 1},
+        };
+        const payloadB = {
+            data: dataB,
+            cluster: "genOta",
+            device: devices.bulb,
+            endpoint: devices.bulb.getEndpoint(1)!,
+            type: "commandQueryNextImageRequest",
+            linkquality: 10,
+            meta: {zclTransactionSequenceNumber: 2},
+        };
+
+        // Start check for imageType A (hangs in checkOta)
+        const checkAPromise = mockZHEvents.message(payloadA);
+        await flushPromises();
+
+        // Same imageType A again — must be blocked
+        await mockZHEvents.message(payloadA);
+        await flushPromises();
+        expect(devices.bulb.checkOta).toHaveBeenCalledTimes(1);
+
+        // While A is in progress, imageType B — must NOT be blocked
+        await mockZHEvents.message(payloadB);
+        await flushPromises();
+        expect(devices.bulb.checkOta).toHaveBeenCalledTimes(2);
+        expect(devices.bulb.checkOta).toHaveBeenCalledWith({downgrade: false}, dataB, {}, devices.bulb.endpoints[0]);
+
+        // Resolve A and clean up
+        resolveCheckA({available: false, current: {...DEFAULT_CURRENT, ...dataA}, availableMeta: {...DEFAULT_AVAILABLE_META, ...dataA}});
+        await checkAPromise;
+        await flushPromises();
+    });
+
+    it("uses independent lastChecked interval per imageType", async () => {
+        settings.set(["devices", devices.bulb.ieeeAddr, "disable_automatic_update_check"], false);
+        const dataA = {imageType: 100, manufacturerCode: 0x128b, fileVersion: 1, fieldControl: 0};
+        const dataB = {imageType: 200, manufacturerCode: 0x128b, fileVersion: 1, fieldControl: 0};
+
+        devices.bulb.checkOta
+            .mockResolvedValueOnce({
+                available: false,
+                current: {...DEFAULT_CURRENT, ...dataA},
+                availableMeta: {...DEFAULT_AVAILABLE_META, ...dataA},
+            })
+            .mockResolvedValueOnce({
+                available: true,
+                current: {...DEFAULT_CURRENT, ...dataB},
+                availableMeta: {...DEFAULT_AVAILABLE_META, ...dataB, fileVersion: 2},
+            });
+
+        const payloadA = {
+            data: dataA,
+            cluster: "genOta",
+            device: devices.bulb,
+            endpoint: devices.bulb.getEndpoint(1)!,
+            type: "commandQueryNextImageRequest",
+            linkquality: 10,
+            meta: {zclTransactionSequenceNumber: 1},
+        };
+        const payloadB = {
+            data: dataB,
+            cluster: "genOta",
+            device: devices.bulb,
+            endpoint: devices.bulb.getEndpoint(1)!,
+            type: "commandQueryNextImageRequest",
+            linkquality: 10,
+            meta: {zclTransactionSequenceNumber: 2},
+        };
+
+        // First check for imageType A -> sets lastChecked[ieeeAddr_100]
+        await mockZHEvents.message(payloadA);
+        await flushPromises();
+        expect(devices.bulb.checkOta).toHaveBeenCalledTimes(1);
+
+        // Second request for imageType A immediately -> throttled (within interval)
+        await mockZHEvents.message(payloadA);
+        await flushPromises();
+        expect(devices.bulb.checkOta).toHaveBeenCalledTimes(1);
+
+        // First request for imageType B -> key not in lastChecked -> proceeds
+        await mockZHEvents.message(payloadB);
+        await flushPromises();
+        expect(devices.bulb.checkOta).toHaveBeenCalledTimes(2);
+        expect(devices.bulb.checkOta).toHaveBeenLastCalledWith({downgrade: false}, dataB, {}, devices.bulb.endpoints[0]);
+    });
+
+    it("retries MQTT update from pending request cache when first attempt returns no image", async () => {
+        settings.set(["devices", devices.bulb.ieeeAddr, "disable_automatic_update_check"], false);
+        const data = {imageType: 100, manufacturerCode: 0x128b, fileVersion: 1, fieldControl: 0};
+
+        // Step 1 — auto-check finds an available update -> populates #pendingAvailableRequests
+        devices.bulb.checkOta.mockResolvedValueOnce({
+            available: true,
+            current: {...DEFAULT_CURRENT, ...data},
+            availableMeta: {...DEFAULT_AVAILABLE_META, ...data, fileVersion: 2},
+        });
+
+        await mockZHEvents.message({
+            data,
+            cluster: "genOta",
+            device: devices.bulb,
+            endpoint: devices.bulb.getEndpoint(1)!,
+            type: "commandQueryNextImageRequest",
+            linkquality: 10,
+            meta: {zclTransactionSequenceNumber: 1},
+        });
+        await flushPromises();
+        expect(devices.bulb.checkOta).toHaveBeenCalledTimes(1);
+
+        // Step 2 — MQTT update: first call returns no image, pending cache triggers a retry that succeeds
+        devices.bulb.endpoints[0].read.mockImplementation(() => ({swBuildId: "1", dateCode: "20240101"}));
+        devices.bulb.updateOta
+            .mockResolvedValueOnce([{...DEFAULT_CURRENT, ...data}, undefined])
+            .mockResolvedValueOnce([
+                {...DEFAULT_CURRENT, ...data, fileVersion: 1},
+                {...DEFAULT_CURRENT, ...data, fileVersion: 2},
+            ]);
+
+        mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/ota_update/update", stringify({id: "bulb"}));
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(6000);
+
+        expect(devices.bulb.updateOta).toHaveBeenCalledTimes(2);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
+            "zigbee2mqtt/bridge/response/device/ota_update/update",
+            expect.stringContaining('"status":"ok"'),
+            {},
+        );
+    });
+
+    it("defers re-interview until no other imageType update is in progress", async () => {
+        const dataA = {imageType: 100, manufacturerCode: 0x128b, fileVersion: 1, fieldControl: 0};
+        const dataB = {imageType: 200, manufacturerCode: 0x128b, fileVersion: 1, fieldControl: 0};
+
+        let resolveUpdateA!: () => void;
+        let resolveUpdateB!: () => void;
+
+        devices.bulb.scheduledOta = {url: undefined};
+
+        // Spy on the Z2M Device wrapper's reInterview (not the ZH mock device)
+        const z2mDevice = controller.zigbee.resolveEntity(devices.bulb.ieeeAddr)!;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const reInterviewSpy = vi.spyOn(z2mDevice as any, "reInterview").mockResolvedValue(undefined);
+
+        devices.bulb.updateOta
+            .mockImplementationOnce(
+                () =>
+                    new Promise<[typeof DEFAULT_CURRENT, typeof DEFAULT_CURRENT]>((resolve) => {
+                        resolveUpdateA = () =>
+                            resolve([
+                                {...DEFAULT_CURRENT, ...dataA},
+                                {...DEFAULT_CURRENT, ...dataA, fileVersion: 2},
+                            ]);
+                    }),
+            )
+            .mockImplementationOnce(
+                () =>
+                    new Promise<[typeof DEFAULT_CURRENT, typeof DEFAULT_CURRENT]>((resolve) => {
+                        resolveUpdateB = () =>
+                            resolve([
+                                {...DEFAULT_CURRENT, ...dataB},
+                                {...DEFAULT_CURRENT, ...dataB, fileVersion: 2},
+                            ]);
+                    }),
+            );
+
+        const payloadA = {
+            data: dataA,
+            cluster: "genOta",
+            device: devices.bulb,
+            endpoint: devices.bulb.getEndpoint(1)!,
+            type: "commandQueryNextImageRequest",
+            linkquality: 10,
+            meta: {zclTransactionSequenceNumber: 1},
+        };
+        const payloadB = {
+            data: dataB,
+            cluster: "genOta",
+            device: devices.bulb,
+            endpoint: devices.bulb.getEndpoint(1)!,
+            type: "commandQueryNextImageRequest",
+            linkquality: 10,
+            meta: {zclTransactionSequenceNumber: 2},
+        };
+
+        // Start both updates concurrently
+        const updateAPromise = mockZHEvents.message(payloadA);
+        const updateBPromise = mockZHEvents.message(payloadB);
+        await flushPromises();
+
+        expect(devices.bulb.updateOta).toHaveBeenCalledTimes(2);
+        expect(reInterviewSpy).not.toHaveBeenCalled();
+
+        // Finish A first — re-interview must NOT fire yet (B still in progress)
+        resolveUpdateA();
+        await updateAPromise;
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(6000);
+        expect(reInterviewSpy).not.toHaveBeenCalled();
+
+        // Finish B — now re-interview fires
+        resolveUpdateB();
+        await updateBPromise;
+        await flushPromises();
+        await vi.advanceTimersByTimeAsync(6000);
+        expect(reInterviewSpy).toHaveBeenCalledTimes(1);
+
+        // Cleanup
+        reInterviewSpy.mockRestore();
+        devices.bulb.scheduledOta = undefined;
+    });
 });


### PR DESCRIPTION
**Problem**

Some Zigbee devices embed multiple MCUs, each with its own firmware and imageType. Z2M could not handle them correctly: `#inProgress` and `#lastChecked` were keyed by `ieeeAddr` alone, silently blocking the second imageType for up to 24 hours after the first update completed.

Fixes #29293, #30022. Supersedes #31529 (original implementation by @AlexisPolegato, addressing @Nerivec's review points).

**Solution**

- Split `#inProgress` into `#inProgressManual` (bare `ieeeAddr`, MQTT ops) and `#inProgressAuto` (composite `${ieeeAddr}_${imageType}`, Zigbee events) with a per-device count map for O(1) `#hasInProgress` — no mixed keys, no spread, no linear scan.
- Key `#lastChecked` by `${ieeeAddr}_${imageType}` so each MCU has an independent throttling slot.
- Reset all `#lastChecked` entries for a device after a successful update so sibling MCUs are rechecked immediately on their next `queryNextImageRequest`.
- Add `#pendingAvailableRequests` (keyed by bare `ieeeAddr`) to cache the last `queryNextImageRequest` where auto-check detected an available update. Used to retry a manual update when the wrong MCU responds first to `imageNotify`.
- Conditional re-interview: only triggered after the last concurrent imageType update completes.

**Tested**

Validated on all NodOn SIN products (SIN-4-XX-2X), all having two chips (antenna board and power board, one imageType per board). Full OTA sequence including a 71-minute antenna transfer completed without issues.
