### PR TITLE
feat: add mqtt.server_name to override TLS SNI

### DIFF
--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -109,6 +109,11 @@ export default class Mqtt {
             options.rejectUnauthorized = false;
         }
 
+        if (mqttSettings.server_name) {
+            logger.debug(`MQTT SSL/TLS: SNI server name = ${mqttSettings.server_name}`);
+            options.servername = mqttSettings.server_name;
+        }
+
         this.client = await connectAsync(mqttSettings.server, options);
 
         // https://github.com/Koenkk/zigbee2mqtt/issues/9822

--- a/lib/types/api.ts
+++ b/lib/types/api.ts
@@ -133,6 +133,7 @@ export interface Zigbee2MQTTSettings {
         cert?: string;
         client_id?: string;
         reject_unauthorized?: boolean;
+        server_name?: string;
         maximum_packet_size: number;
     };
     serial: {

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -188,6 +188,13 @@
                     "description": "Disable self-signed SSL certificate",
                     "default": true
                 },
+                "server_name": {
+                    "type": "string",
+                    "title": "TLS server name (SNI)",
+                    "requiresRestart": true,
+                    "description": "Override the TLS SNI / hostname used for certificate verification when it differs from the host in 'server' (e.g. connecting to an internal service DNS name while validating a public certificate SAN). Leave unset to use the hostname from 'server'.",
+                    "examples": ["mqtt.example.com"]
+                },
                 "include_device_information": {
                     "type": "boolean",
                     "title": "Include device information",

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -149,6 +149,7 @@ describe("Controller", () => {
             user: "user1",
             client_id: "my_client_id",
             reject_unauthorized: false,
+            server_name: "mqtt.example.com",
             version: 5,
             maximum_packet_size: 20000,
         };
@@ -166,6 +167,7 @@ describe("Controller", () => {
             username: "user1",
             clientId: "my_client_id",
             rejectUnauthorized: false,
+            servername: "mqtt.example.com",
             protocolVersion: 5,
             properties: {maximumPacketSize: 20000},
         };


### PR DESCRIPTION
## What does this implement/fix?

Adds an optional `mqtt.server_name` setting that overrides the TLS SNI / certificate-hostname used when connecting to the MQTT broker, **without disabling certificate validation**.

Today Zigbee2MQTT derives the TLS server name (used for SNI and hostname verification) from the host in `mqtt.server`. This breaks when you need to connect to the broker via a hostname or IP that is *not* listed in the broker certificate's Subject Alternative Names — for example connecting over an internal Docker/Kubernetes network name while the certificate is only valid for a public domain.

Currently the only workarounds are:
- Connect using the public domain name even for internal traffic (defeats the purpose of keeping traffic on the internal network), or
- Set `reject_unauthorized: false`, which disables certificate validation entirely, or
- Disable TLS altogether and connect over plaintext `mqtt://` (loses encryption entirely).

`mqtt.server_name` lets you keep full certificate validation (`reject_unauthorized: true`) while connecting to an internal address: the TCP connection targets the host in `mqtt.server`, but the TLS handshake uses `server_name` for SNI and certificate hostname verification.

Example:

```yaml
mqtt:
  server: 'mqtts://mosquitto.internal:8883'   # internal connect target
  server_name: mqtt.example.com               # matches the certificate SAN
  ca: /path/to/ca.pem
  reject_unauthorized: true
```

mqtt.js already forwards a `servername` option straight to Node's `tls.connect()`; this change simply exposes it as a configuration setting.

Fixes #19450

## Changes

- `lib/mqtt.ts` — set `options.servername` from `mqtt.server_name` (when configured) before connecting.
- `lib/types/api.ts` — add `server_name?: string` to the MQTT settings type.
- `lib/util/settings.schema.json` — add the `server_name` MQTT setting (with description and `requiresRestart`).
- `test/controller.test.ts` — extend the MQTT settings test to cover the new option.

## Questions for maintainers

1. **Naming:** Is `server_name` the right key? I chose it to stay consistent with the snake_case MQTT settings, mapping to Node/mqtt.js's `servername`. Would you prefer `tls_server_name` (more explicit that it's TLS-only) or something else?
2. **Docs:** Does this need a separate documentation PR against `Koenkk/zigbee2mqtt.io`, or is the settings reference generated automatically from the schema change here?

Made with [Cursor](https://cursor.com)