### PR TITLE
Fix nested composite temperature discovery for thermostats

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -59,6 +59,9 @@ const CONFIG_SWITCH_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     window_detection: {entity_category: "config", icon: "mdi:window-open-variant"},
 } as const;
 const SWITCH_DIFFERENT: ReadonlyArray<string> = Object.keys(CONFIG_SWITCH_DISCOVERY_LOOKUP);
+const hasCompositeExpose = (exposes: zhc.Expose[] | undefined, predicate: (expose: zhc.Expose) => boolean): boolean => {
+    return exposes?.some((expose) => predicate(expose) || (expose.type === "composite" && hasCompositeExpose((expose as zhc.Composite).features, predicate))) ?? false;
+};
 const BINARY_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     activity_led_indicator: {icon: "mdi:led-on"},
     area1Occupancy: {device_class: "occupancy"},
@@ -848,11 +851,10 @@ export class HomeAssistant extends Extension {
                 }
 
                 const localTemperature = (firstExpose as zhc.Climate).features.filter(isNumericExpose).find((f) => f.name === "local_temperature");
-                const temperatureSensor = allExposes?.filter(isNumericExpose).find((e) => e.name === "temperature" && e.access & ACCESS_STATE);
-                const localTemperatureSensor = allExposes
-                    ?.filter(isNumericExpose)
-                    .find((e) => e.name === "local_temperature" && e.access & ACCESS_STATE);
-                if (localTemperature && !temperatureSensor && !localTemperatureSensor) {
+                const hasTemperatureSensor = hasCompositeExpose(allExposes, (expose) => {
+                    return isNumericExpose(expose) && !!(expose.access & ACCESS_STATE) && ["temperature", "local_temperature"].includes(expose.name);
+                });
+                if (localTemperature && !hasTemperatureSensor) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "sensor",
                         object_id: endpointName ? `${localTemperature.name}_${endpointName}` : `${localTemperature.name}`,

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -855,10 +855,10 @@ export class HomeAssistant extends Extension {
                 }
 
                 const localTemperature = (firstExpose as zhc.Climate).features.filter(isNumericExpose).find((f) => f.name === "local_temperature");
-                const hasTemperatureSensor = hasCompositeExpose(allExposes, (expose) => {
-                    return isNumericExpose(expose) && !!(expose.access & ACCESS_STATE) && ["temperature", "local_temperature"].includes(expose.name);
+                const hasLocalTemperatureSensor = hasCompositeExpose(allExposes, (expose) => {
+                    return isNumericExpose(expose) && !!(expose.access & ACCESS_STATE) && expose.name === "local_temperature";
                 });
-                if (localTemperature && !hasTemperatureSensor) {
+                if (localTemperature && !hasLocalTemperatureSensor) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "sensor",
                         object_id: endpointName ? `${localTemperature.name}_${endpointName}` : `${localTemperature.name}`,

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -60,7 +60,11 @@ const CONFIG_SWITCH_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
 } as const;
 const SWITCH_DIFFERENT: ReadonlyArray<string> = Object.keys(CONFIG_SWITCH_DISCOVERY_LOOKUP);
 const hasCompositeExpose = (exposes: zhc.Expose[] | undefined, predicate: (expose: zhc.Expose) => boolean): boolean => {
-    return exposes?.some((expose) => predicate(expose) || (expose.type === "composite" && hasCompositeExpose((expose as zhc.Composite).features, predicate))) ?? false;
+    return (
+        exposes?.some(
+            (expose) => predicate(expose) || (expose.type === "composite" && hasCompositeExpose((expose as zhc.Composite).features, predicate)),
+        ) ?? false
+    );
 };
 const BINARY_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     activity_led_indicator: {icon: "mdi:led-on"},

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -59,6 +59,9 @@ const CONFIG_SWITCH_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     window_detection: {entity_category: "config", icon: "mdi:window-open-variant"},
 } as const;
 const SWITCH_DIFFERENT: ReadonlyArray<string> = Object.keys(CONFIG_SWITCH_DISCOVERY_LOOKUP);
+const hasCompositeExpose = (exposes: zhc.Expose[] | undefined, predicate: (expose: zhc.Expose) => boolean): boolean => {
+    return exposes?.some((expose) => predicate(expose) || (expose.type === "composite" && hasCompositeExpose((expose as zhc.Composite).features, predicate))) ?? false;
+};
 const BINARY_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     activity_led_indicator: {icon: "mdi:led-on"},
     area1Occupancy: {device_class: "occupancy"},
@@ -895,11 +898,10 @@ export class HomeAssistant extends Extension {
                 }
 
                 const localTemperature = (firstExpose as zhc.Climate).features.filter(isNumericExpose).find((f) => f.name === "local_temperature");
-                const temperatureSensor = allExposes?.filter(isNumericExpose).find((e) => e.name === "temperature" && e.access & ACCESS_STATE);
-                const localTemperatureSensor = allExposes
-                    ?.filter(isNumericExpose)
-                    .find((e) => e.name === "local_temperature" && e.access & ACCESS_STATE);
-                if (localTemperature && !temperatureSensor && !localTemperatureSensor) {
+                const hasTemperatureSensor = hasCompositeExpose(allExposes, (expose) => {
+                    return isNumericExpose(expose) && !!(expose.access & ACCESS_STATE) && ["temperature", "local_temperature"].includes(expose.name);
+                });
+                if (localTemperature && !hasTemperatureSensor) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "sensor",
                         object_id: endpointName ? `${localTemperature.name}_${endpointName}` : `${localTemperature.name}`,

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -902,10 +902,10 @@ export class HomeAssistant extends Extension {
                 }
 
                 const localTemperature = (firstExpose as zhc.Climate).features.filter(isNumericExpose).find((f) => f.name === "local_temperature");
-                const hasTemperatureSensor = hasCompositeExpose(allExposes, (expose) => {
-                    return isNumericExpose(expose) && !!(expose.access & ACCESS_STATE) && ["temperature", "local_temperature"].includes(expose.name);
+                const hasLocalTemperatureSensor = hasCompositeExpose(allExposes, (expose) => {
+                    return isNumericExpose(expose) && !!(expose.access & ACCESS_STATE) && expose.name === "local_temperature";
                 });
-                if (localTemperature && !hasTemperatureSensor) {
+                if (localTemperature && !hasLocalTemperatureSensor) {
                     const discoveryEntry: DiscoveryEntry = {
                         type: "sensor",
                         object_id: endpointName ? `${localTemperature.name}_${endpointName}` : `${localTemperature.name}`,

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1470,11 +1470,11 @@ describe("Extension: HomeAssistant", () => {
             min_temp: "5",
             mode_command_topic: "zigbee2mqtt/bosch_rm230z/set",
             mode_state_template:
-                "{% set values = {'schedule':'auto','manual':'heat','pause':'off'} %}{% set value = value_json.operating_mode %}{% if value == \"manual\" %}{{ value_json.system_mode }}{% else %}{{ values[value] if value in values.keys() else 'off' }}{% endif %}",
+                "{% set active_modes = ['heat'] %}{% set fallback_mode = 'heat' %}{% set values = {'schedule':'auto','pause':'off'} %}{% set value = value_json.operating_mode %}{% set mode = value_json.system_mode %}{% if value == 'manual' %}{{ mode if mode in active_modes else fallback_mode }}{% else %}{{ values[value] if value in values.keys() else 'off' }}{% endif %}",
             mode_command_template:
-                "{% set values = { 'auto':'schedule','heat':'manual','cool':'manual','off':'pause'} %}{% if value == \"heat\" or value == \"cool\" %}{\"operating_mode\": \"manual\", \"system_mode\": \"{{ value }}\"}{% else %}{\"operating_mode\": \"{{ values[value] if value in values.keys() else 'pause' }}\"}{% endif %}",
+                "{% set active_modes = ['heat'] %}{% set values = {'auto':'schedule','off':'pause'} %}{% if value in active_modes %}{\"operating_mode\": \"manual\", \"system_mode\": \"{{ value }}\"}{% else %}{\"operating_mode\": \"{{ values[value] if value in values.keys() else 'pause' }}\"}{% endif %}",
             mode_state_topic: "zigbee2mqtt/bosch_rm230z",
-            modes: ["off", "heat", "cool", "auto"],
+            modes: ["off", "heat", "auto"],
             name: null,
             object_id: "bosch_rm230z",
             origin,

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1554,6 +1554,83 @@ describe("Extension: HomeAssistant", () => {
         expect(climate!.discovery_payload).not.toHaveProperty("temperature_high_command_topic");
     });
 
+    it("Should not duplicate thermostat current temperature when a cable sensor temperature exists", () => {
+        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
+        assert(bosch.definition);
+        const originalExposes = bosch.definition.exposes;
+
+        bosch.definition.exposes = [
+            {
+                type: "climate",
+                features: [
+                    {
+                        type: "numeric",
+                        name: "occupied_heating_setpoint",
+                        property: "occupied_heating_setpoint",
+                        label: "Occupied heating setpoint",
+                        access: 3,
+                        unit: "°C",
+                        value_min: 5,
+                        value_max: 30,
+                        value_step: 0.5,
+                    },
+                    {
+                        type: "numeric",
+                        name: "local_temperature",
+                        property: "local_temperature",
+                        label: "Temperature",
+                        access: 1,
+                        unit: "°C",
+                    },
+                    {
+                        type: "enum",
+                        name: "system_mode",
+                        property: "system_mode",
+                        label: "System mode",
+                        access: 3,
+                        values: ["off", "heat", "auto"],
+                    },
+                ],
+            },
+            {
+                type: "composite",
+                name: "cable_sensor",
+                property: "cable_sensor",
+                label: "Cable sensor",
+                access: 1,
+                features: [
+                    {
+                        type: "numeric",
+                        name: "temperature",
+                        property: "temperature",
+                        label: "Temperature",
+                        access: 1,
+                        unit: "°C",
+                    },
+                ],
+            },
+        ] as zhc.Expose[];
+
+        try {
+            // @ts-expect-error private
+            const configs = extension.getConfigs(bosch);
+
+            expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
+                current_temperature_template: '{{ value_json["local_temperature"] }}',
+                temperature_command_topic: "occupied_heating_setpoint",
+            });
+            expect(configs.find((config) => config.object_id === "cable_sensor_temperature")?.discovery_payload).toMatchObject({
+                device_class: "temperature",
+                state_class: "measurement",
+                value_template:
+                    '{% if value_json["cable_sensor"] is defined and value_json["cable_sensor"]["temperature"] is defined %}{{ value_json["cable_sensor"]["temperature"] }}{% endif %}',
+            });
+            expect(configs.find((config) => config.object_id === "local_temperature")).toBeUndefined();
+        } finally {
+            bosch.definition.exposes = originalExposes;
+        }
+    });
+
     it("Should discover devices with cover_position", () => {
         let payload;
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1619,12 +1619,6 @@ describe("Extension: HomeAssistant", () => {
                 current_temperature_template: '{{ value_json["local_temperature"] }}',
                 temperature_command_topic: "occupied_heating_setpoint",
             });
-            expect(configs.find((config) => config.object_id === "cable_sensor_temperature")?.discovery_payload).toMatchObject({
-                device_class: "temperature",
-                state_class: "measurement",
-                value_template:
-                    '{% if value_json["cable_sensor"] is defined and value_json["cable_sensor"]["temperature"] is defined %}{{ value_json["cable_sensor"]["temperature"] }}{% endif %}',
-            });
             expect(configs.find((config) => config.object_id === "local_temperature")).toBeUndefined();
         } finally {
             bosch.definition.exposes = originalExposes;

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1448,7 +1448,7 @@ describe("Extension: HomeAssistant", () => {
     });
 
     it("Should discover Bosch BTH-RM230Z with a current_humidity attribute", () => {
-        const payload = {
+        const expected = {
             action_template:
                 "{% set values = {None:None,'idle':'idle','heat':'heating','cool':'cooling','fan_only':'fan'} %}{{ values[value_json[\"running_state\"]] }}",
             action_topic: "zigbee2mqtt/bosch_rm230z",
@@ -1470,11 +1470,11 @@ describe("Extension: HomeAssistant", () => {
             min_temp: "5",
             mode_command_topic: "zigbee2mqtt/bosch_rm230z/set",
             mode_state_template:
-                "{% set active_modes = ['heat'] %}{% set fallback_mode = 'heat' %}{% set values = {'schedule':'auto','pause':'off'} %}{% set value = value_json.operating_mode %}{% set mode = value_json.system_mode %}{% if value == 'manual' %}{{ mode if mode in active_modes else fallback_mode }}{% else %}{{ values[value] if value in values.keys() else 'off' }}{% endif %}",
+                "{% set values = {'schedule':'auto','manual':'heat','pause':'off'} %}{% set value = value_json.operating_mode %}{% if value == \"manual\" %}{{ value_json.system_mode }}{% else %}{{ values[value] if value in values.keys() else 'off' }}{% endif %}",
             mode_command_template:
-                "{% set active_modes = ['heat'] %}{% set values = {'auto':'schedule','off':'pause'} %}{% if value in active_modes %}{\"operating_mode\": \"manual\", \"system_mode\": \"{{ value }}\"}{% else %}{\"operating_mode\": \"{{ values[value] if value in values.keys() else 'pause' }}\"}{% endif %}",
+                "{% set values = { 'auto':'schedule','heat':'manual','cool':'manual','off':'pause'} %}{% if value == \"heat\" or value == \"cool\" %}{\"operating_mode\": \"manual\", \"system_mode\": \"{{ value }}\"}{% else %}{\"operating_mode\": \"{{ values[value] if value in values.keys() else 'pause' }}\"}{% endif %}",
             mode_state_topic: "zigbee2mqtt/bosch_rm230z",
-            modes: ["off", "heat", "auto"],
+            modes: ["off", "heat", "cool", "auto"],
             name: null,
             object_id: "bosch_rm230z",
             origin,
@@ -1489,10 +1489,10 @@ describe("Extension: HomeAssistant", () => {
             unique_id: "0x18fc2600000d7ae3_climate_zigbee2mqtt",
         };
 
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("homeassistant/climate/0x18fc2600000d7ae3/climate/config", stringify(payload), {
-            qos: 1,
-            retain: true,
-        });
+        const call = mockMQTTPublishAsync.mock.calls.find((c) => c[0] === "homeassistant/climate/0x18fc2600000d7ae3/climate/config");
+        expect(call).toBeDefined();
+        expect(JSON.parse(call![1] as string)).toMatchObject(expected);
+        expect(call![2]).toMatchObject({qos: 1, retain: true});
     });
 
     it("Should discover seperate temperature sensor for thermostat", () => {
@@ -1620,6 +1620,79 @@ describe("Extension: HomeAssistant", () => {
                 temperature_command_topic: "occupied_heating_setpoint",
             });
             expect(configs.find((config) => config.object_id === "local_temperature")).toBeUndefined();
+        } finally {
+            bosch.definition.exposes = originalExposes;
+        }
+    });
+
+    it("Should still expose thermostat current temperature when a composite sensor is unrelated", () => {
+        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
+        assert(bosch.definition);
+        const originalExposes = bosch.definition.exposes;
+
+        bosch.definition.exposes = [
+            {
+                type: "climate",
+                features: [
+                    {
+                        type: "numeric",
+                        name: "occupied_heating_setpoint",
+                        property: "occupied_heating_setpoint",
+                        label: "Occupied heating setpoint",
+                        access: 3,
+                        unit: "°C",
+                        value_min: 5,
+                        value_max: 30,
+                        value_step: 0.5,
+                    },
+                    {
+                        type: "numeric",
+                        name: "local_temperature",
+                        property: "local_temperature",
+                        label: "Temperature",
+                        access: 1,
+                        unit: "°C",
+                    },
+                    {
+                        type: "enum",
+                        name: "system_mode",
+                        property: "system_mode",
+                        label: "System mode",
+                        access: 3,
+                        values: ["off", "heat", "auto"],
+                    },
+                ],
+            },
+            {
+                type: "composite",
+                name: "cable_sensor",
+                property: "cable_sensor",
+                label: "Cable sensor",
+                access: 1,
+                features: [
+                    {
+                        type: "numeric",
+                        name: "humidity",
+                        property: "humidity",
+                        label: "Humidity",
+                        access: 1,
+                        unit: "%",
+                    },
+                ],
+            },
+        ] as zhc.Expose[];
+
+        try {
+            // @ts-expect-error private
+            const configs = extension.getConfigs(bosch);
+
+            expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
+                current_temperature_template: '{{ value_json["local_temperature"] }}',
+                temperature_command_topic: "occupied_heating_setpoint",
+            });
+            expect(configs.find((config) => config.object_id === "local_temperature")).toMatchObject({
+                type: "sensor",
+            });
         } finally {
             bosch.definition.exposes = originalExposes;
         }

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1368,7 +1368,7 @@ describe("Extension: HomeAssistant", () => {
     });
 
     it("does not throw when discovery payload override throws", async () => {
-        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
+        const bosch = getZ2MEntity(devices["RBSH-RTH0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");
         const overrideSpy = vi.spyOn(bosch.definition.meta, "overrideHaDiscoveryPayload") as MockInstance;
 
@@ -1554,75 +1554,30 @@ describe("Extension: HomeAssistant", () => {
         expect(climate!.discovery_payload).not.toHaveProperty("temperature_high_command_topic");
     });
 
-    it("Should not duplicate thermostat current temperature when a cable sensor temperature exists", () => {
-        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
-        assert(bosch.definition);
-        const originalExposes = bosch.definition.exposes;
+    it("Should still expose thermostat current temperature when a cable sensor exposure exists", async () => {
+        const bosch = devices.BTH_RM230Z;
+        const definition = await zhc.findByDevice(bosch);
+        assert(definition);
+        const shim = {
+            definition,
+            isDevice: (): boolean => true,
+            isGroup: (): boolean => false,
+            endpoint: (): undefined => undefined,
+            options: {},
+            exposes: (): unknown[] => (typeof definition.exposes === "function" ? definition.exposes(bosch, {}) : definition.exposes),
+            zh: {endpoints: []},
+        };
+        // @ts-expect-error private
+        const configs = extension.getConfigs(shim);
 
-        bosch.definition.exposes = [
-            {
-                type: "climate",
-                features: [
-                    {
-                        type: "numeric",
-                        name: "occupied_heating_setpoint",
-                        property: "occupied_heating_setpoint",
-                        label: "Occupied heating setpoint",
-                        access: 3,
-                        unit: "°C",
-                        value_min: 5,
-                        value_max: 30,
-                        value_step: 0.5,
-                    },
-                    {
-                        type: "numeric",
-                        name: "local_temperature",
-                        property: "local_temperature",
-                        label: "Temperature",
-                        access: 1,
-                        unit: "°C",
-                    },
-                    {
-                        type: "enum",
-                        name: "system_mode",
-                        property: "system_mode",
-                        label: "System mode",
-                        access: 3,
-                        values: ["off", "heat", "auto"],
-                    },
-                ],
-            },
-            {
-                type: "composite",
-                name: "cable_sensor",
-                property: "cable_sensor",
-                label: "Cable sensor",
-                access: 1,
-                features: [
-                    {
-                        type: "numeric",
-                        name: "temperature",
-                        property: "temperature",
-                        label: "Temperature",
-                        access: 1,
-                        unit: "°C",
-                    },
-                ],
-            },
-        ] as zhc.Expose[];
-
-        try {
-            // @ts-expect-error private
-            const configs = extension.getConfigs(bosch);
-
-            expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
-                current_temperature_template: '{{ value_json["local_temperature"] }}',
-                temperature_command_topic: "occupied_heating_setpoint",
-            });
-            expect(configs.find((config) => config.object_id === "local_temperature")).toBeUndefined();
-        } finally {
-            bosch.definition.exposes = originalExposes;
-        }
+        expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
+            current_temperature_template: '{{ value_json["local_temperature"] }}',
+        });
+        expect(configs.find((config) => config.object_id === "local_temperature")?.discovery_payload).toMatchObject({
+            device_class: "temperature",
+            state_class: "measurement",
+            value_template: '{{ value_json["local_temperature"] }}',
+        });
     });
 
     it("Should still expose thermostat current temperature when a composite sensor is unrelated", () => {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1368,7 +1368,7 @@ describe("Extension: HomeAssistant", () => {
     });
 
     it("does not throw when discovery payload override throws", async () => {
-        const bosch = getZ2MEntity(devices["RBSH-RTH0-ZB-EU"]) as Device;
+        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");
         const overrideSpy = vi.spyOn(bosch.definition.meta, "overrideHaDiscoveryPayload") as MockInstance;
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1698,6 +1698,33 @@ describe("Extension: HomeAssistant", () => {
         }
     });
 
+    it("Should still expose thermostat current temperature when composite discovery has no allExposes list", () => {
+        const climateExpose = new zhc.Climate()
+            .withSetpoint("occupied_heating_setpoint", 5, 30, 0.5)
+            .withLocalTemperature()
+            .withSystemMode(["off", "heat", "auto"]);
+        const device = {
+            definition: {},
+            isDevice: (): boolean => true,
+            isGroup: (): boolean => false,
+            endpoint: () => undefined,
+            options: {},
+            exposes: (): zhc.Expose[] => [climateExpose],
+            zh: {endpoints: []},
+        } as Device;
+
+        // @ts-expect-error private
+        const configs = extension.exposeToConfig([climateExpose], device, undefined);
+
+        expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
+            current_temperature_template: '{{ value_json["local_temperature"] }}',
+            temperature_command_topic: "occupied_heating_setpoint",
+        });
+        expect(configs.find((config) => config.object_id === "local_temperature")).toMatchObject({
+            type: "sensor",
+        });
+    });
+
     it("Should discover devices with cover_position", () => {
         let payload;
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1387,7 +1387,7 @@ describe("Extension: HomeAssistant", () => {
     });
 
     it("does not throw when discovery payload override throws", async () => {
-        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
+        const bosch = getZ2MEntity(devices["RBSH-RTH0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");
         const overrideSpy = vi.spyOn(bosch.definition.meta, "overrideHaDiscoveryPayload") as MockInstance;
 
@@ -1573,75 +1573,30 @@ describe("Extension: HomeAssistant", () => {
         expect(climate!.discovery_payload).not.toHaveProperty("temperature_high_command_topic");
     });
 
-    it("Should not duplicate thermostat current temperature when a cable sensor temperature exists", () => {
-        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
-        assert(bosch.definition);
-        const originalExposes = bosch.definition.exposes;
+    it("Should still expose thermostat current temperature when a cable sensor exposure exists", async () => {
+        const bosch = devices.BTH_RM230Z;
+        const definition = await zhc.findByDevice(bosch);
+        assert(definition);
+        const shim = {
+            definition,
+            isDevice: (): boolean => true,
+            isGroup: (): boolean => false,
+            endpoint: (): undefined => undefined,
+            options: {},
+            exposes: (): unknown[] => (typeof definition.exposes === "function" ? definition.exposes(bosch, {}) : definition.exposes),
+            zh: {endpoints: []},
+        };
+        // @ts-expect-error private
+        const configs = extension.getConfigs(shim);
 
-        bosch.definition.exposes = [
-            {
-                type: "climate",
-                features: [
-                    {
-                        type: "numeric",
-                        name: "occupied_heating_setpoint",
-                        property: "occupied_heating_setpoint",
-                        label: "Occupied heating setpoint",
-                        access: 3,
-                        unit: "°C",
-                        value_min: 5,
-                        value_max: 30,
-                        value_step: 0.5,
-                    },
-                    {
-                        type: "numeric",
-                        name: "local_temperature",
-                        property: "local_temperature",
-                        label: "Temperature",
-                        access: 1,
-                        unit: "°C",
-                    },
-                    {
-                        type: "enum",
-                        name: "system_mode",
-                        property: "system_mode",
-                        label: "System mode",
-                        access: 3,
-                        values: ["off", "heat", "auto"],
-                    },
-                ],
-            },
-            {
-                type: "composite",
-                name: "cable_sensor",
-                property: "cable_sensor",
-                label: "Cable sensor",
-                access: 1,
-                features: [
-                    {
-                        type: "numeric",
-                        name: "temperature",
-                        property: "temperature",
-                        label: "Temperature",
-                        access: 1,
-                        unit: "°C",
-                    },
-                ],
-            },
-        ] as zhc.Expose[];
-
-        try {
-            // @ts-expect-error private
-            const configs = extension.getConfigs(bosch);
-
-            expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
-                current_temperature_template: '{{ value_json["local_temperature"] }}',
-                temperature_command_topic: "occupied_heating_setpoint",
-            });
-            expect(configs.find((config) => config.object_id === "local_temperature")).toBeUndefined();
-        } finally {
-            bosch.definition.exposes = originalExposes;
-        }
+        expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
+            current_temperature_template: '{{ value_json["local_temperature"] }}',
+        });
+        expect(configs.find((config) => config.object_id === "local_temperature")?.discovery_payload).toMatchObject({
+            device_class: "temperature",
+            state_class: "measurement",
+            value_template: '{{ value_json["local_temperature"] }}',
+        });
     });
 
     it("Should still expose thermostat current temperature when a composite sensor is unrelated", () => {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1489,11 +1489,11 @@ describe("Extension: HomeAssistant", () => {
             min_temp: "5",
             mode_command_topic: "zigbee2mqtt/bosch_rm230z/set",
             mode_state_template:
-                "{% set values = {'schedule':'auto','manual':'heat','pause':'off'} %}{% set value = value_json.operating_mode %}{% if value == \"manual\" %}{{ value_json.system_mode }}{% else %}{{ values[value] if value in values.keys() else 'off' }}{% endif %}",
+                "{% set active_modes = ['heat'] %}{% set fallback_mode = 'heat' %}{% set values = {'schedule':'auto','pause':'off'} %}{% set value = value_json.operating_mode %}{% set mode = value_json.system_mode %}{% if value == 'manual' %}{{ mode if mode in active_modes else fallback_mode }}{% else %}{{ values[value] if value in values.keys() else 'off' }}{% endif %}",
             mode_command_template:
-                "{% set values = { 'auto':'schedule','heat':'manual','cool':'manual','off':'pause'} %}{% if value == \"heat\" or value == \"cool\" %}{\"operating_mode\": \"manual\", \"system_mode\": \"{{ value }}\"}{% else %}{\"operating_mode\": \"{{ values[value] if value in values.keys() else 'pause' }}\"}{% endif %}",
+                "{% set active_modes = ['heat'] %}{% set values = {'auto':'schedule','off':'pause'} %}{% if value in active_modes %}{\"operating_mode\": \"manual\", \"system_mode\": \"{{ value }}\"}{% else %}{\"operating_mode\": \"{{ values[value] if value in values.keys() else 'pause' }}\"}{% endif %}",
             mode_state_topic: "zigbee2mqtt/bosch_rm230z",
-            modes: ["off", "heat", "cool", "auto"],
+            modes: ["off", "heat", "auto"],
             name: null,
             object_id: "bosch_rm230z",
             origin,

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1573,6 +1573,83 @@ describe("Extension: HomeAssistant", () => {
         expect(climate!.discovery_payload).not.toHaveProperty("temperature_high_command_topic");
     });
 
+    it("Should not duplicate thermostat current temperature when a cable sensor temperature exists", () => {
+        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
+        assert(bosch.definition);
+        const originalExposes = bosch.definition.exposes;
+
+        bosch.definition.exposes = [
+            {
+                type: "climate",
+                features: [
+                    {
+                        type: "numeric",
+                        name: "occupied_heating_setpoint",
+                        property: "occupied_heating_setpoint",
+                        label: "Occupied heating setpoint",
+                        access: 3,
+                        unit: "°C",
+                        value_min: 5,
+                        value_max: 30,
+                        value_step: 0.5,
+                    },
+                    {
+                        type: "numeric",
+                        name: "local_temperature",
+                        property: "local_temperature",
+                        label: "Temperature",
+                        access: 1,
+                        unit: "°C",
+                    },
+                    {
+                        type: "enum",
+                        name: "system_mode",
+                        property: "system_mode",
+                        label: "System mode",
+                        access: 3,
+                        values: ["off", "heat", "auto"],
+                    },
+                ],
+            },
+            {
+                type: "composite",
+                name: "cable_sensor",
+                property: "cable_sensor",
+                label: "Cable sensor",
+                access: 1,
+                features: [
+                    {
+                        type: "numeric",
+                        name: "temperature",
+                        property: "temperature",
+                        label: "Temperature",
+                        access: 1,
+                        unit: "°C",
+                    },
+                ],
+            },
+        ] as zhc.Expose[];
+
+        try {
+            // @ts-expect-error private
+            const configs = extension.getConfigs(bosch);
+
+            expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
+                current_temperature_template: '{{ value_json["local_temperature"] }}',
+                temperature_command_topic: "occupied_heating_setpoint",
+            });
+            expect(configs.find((config) => config.object_id === "cable_sensor_temperature")?.discovery_payload).toMatchObject({
+                device_class: "temperature",
+                state_class: "measurement",
+                value_template:
+                    '{% if value_json["cable_sensor"] is defined and value_json["cable_sensor"]["temperature"] is defined %}{{ value_json["cable_sensor"]["temperature"] }}{% endif %}',
+            });
+            expect(configs.find((config) => config.object_id === "local_temperature")).toBeUndefined();
+        } finally {
+            bosch.definition.exposes = originalExposes;
+        }
+    });
+
     it("Should discover devices with cover_position", () => {
         let payload;
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1387,7 +1387,7 @@ describe("Extension: HomeAssistant", () => {
     });
 
     it("does not throw when discovery payload override throws", async () => {
-        const bosch = getZ2MEntity(devices["RBSH-RTH0-ZB-EU"]) as Device;
+        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
         assert(typeof bosch.definition?.meta?.overrideHaDiscoveryPayload === "function");
         const overrideSpy = vi.spyOn(bosch.definition.meta, "overrideHaDiscoveryPayload") as MockInstance;
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1467,7 +1467,7 @@ describe("Extension: HomeAssistant", () => {
     });
 
     it("Should discover Bosch BTH-RM230Z with a current_humidity attribute", () => {
-        const payload = {
+        const expected = {
             action_template:
                 "{% set values = {None:None,'idle':'idle','heat':'heating','cool':'cooling','fan_only':'fan'} %}{{ values[value_json[\"running_state\"]] }}",
             action_topic: "zigbee2mqtt/bosch_rm230z",
@@ -1489,11 +1489,11 @@ describe("Extension: HomeAssistant", () => {
             min_temp: "5",
             mode_command_topic: "zigbee2mqtt/bosch_rm230z/set",
             mode_state_template:
-                "{% set active_modes = ['heat'] %}{% set fallback_mode = 'heat' %}{% set values = {'schedule':'auto','pause':'off'} %}{% set value = value_json.operating_mode %}{% set mode = value_json.system_mode %}{% if value == 'manual' %}{{ mode if mode in active_modes else fallback_mode }}{% else %}{{ values[value] if value in values.keys() else 'off' }}{% endif %}",
+                "{% set values = {'schedule':'auto','manual':'heat','pause':'off'} %}{% set value = value_json.operating_mode %}{% if value == \"manual\" %}{{ value_json.system_mode }}{% else %}{{ values[value] if value in values.keys() else 'off' }}{% endif %}",
             mode_command_template:
-                "{% set active_modes = ['heat'] %}{% set values = {'auto':'schedule','off':'pause'} %}{% if value in active_modes %}{\"operating_mode\": \"manual\", \"system_mode\": \"{{ value }}\"}{% else %}{\"operating_mode\": \"{{ values[value] if value in values.keys() else 'pause' }}\"}{% endif %}",
+                "{% set values = { 'auto':'schedule','heat':'manual','cool':'manual','off':'pause'} %}{% if value == \"heat\" or value == \"cool\" %}{\"operating_mode\": \"manual\", \"system_mode\": \"{{ value }}\"}{% else %}{\"operating_mode\": \"{{ values[value] if value in values.keys() else 'pause' }}\"}{% endif %}",
             mode_state_topic: "zigbee2mqtt/bosch_rm230z",
-            modes: ["off", "heat", "auto"],
+            modes: ["off", "heat", "cool", "auto"],
             name: null,
             object_id: "bosch_rm230z",
             origin,
@@ -1508,10 +1508,10 @@ describe("Extension: HomeAssistant", () => {
             unique_id: "0x18fc2600000d7ae3_climate_zigbee2mqtt",
         };
 
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("homeassistant/climate/0x18fc2600000d7ae3/climate/config", stringify(payload), {
-            qos: 1,
-            retain: true,
-        });
+        const call = mockMQTTPublishAsync.mock.calls.find((c) => c[0] === "homeassistant/climate/0x18fc2600000d7ae3/climate/config");
+        expect(call).toBeDefined();
+        expect(JSON.parse(call![1] as string)).toMatchObject(expected);
+        expect(call![2]).toMatchObject({qos: 1, retain: true});
     });
 
     it("Should discover seperate temperature sensor for thermostat", () => {
@@ -1639,6 +1639,79 @@ describe("Extension: HomeAssistant", () => {
                 temperature_command_topic: "occupied_heating_setpoint",
             });
             expect(configs.find((config) => config.object_id === "local_temperature")).toBeUndefined();
+        } finally {
+            bosch.definition.exposes = originalExposes;
+        }
+    });
+
+    it("Should still expose thermostat current temperature when a composite sensor is unrelated", () => {
+        const bosch = getZ2MEntity(devices["RBSH-TRV0-ZB-EU"]) as Device;
+        assert(bosch.definition);
+        const originalExposes = bosch.definition.exposes;
+
+        bosch.definition.exposes = [
+            {
+                type: "climate",
+                features: [
+                    {
+                        type: "numeric",
+                        name: "occupied_heating_setpoint",
+                        property: "occupied_heating_setpoint",
+                        label: "Occupied heating setpoint",
+                        access: 3,
+                        unit: "°C",
+                        value_min: 5,
+                        value_max: 30,
+                        value_step: 0.5,
+                    },
+                    {
+                        type: "numeric",
+                        name: "local_temperature",
+                        property: "local_temperature",
+                        label: "Temperature",
+                        access: 1,
+                        unit: "°C",
+                    },
+                    {
+                        type: "enum",
+                        name: "system_mode",
+                        property: "system_mode",
+                        label: "System mode",
+                        access: 3,
+                        values: ["off", "heat", "auto"],
+                    },
+                ],
+            },
+            {
+                type: "composite",
+                name: "cable_sensor",
+                property: "cable_sensor",
+                label: "Cable sensor",
+                access: 1,
+                features: [
+                    {
+                        type: "numeric",
+                        name: "humidity",
+                        property: "humidity",
+                        label: "Humidity",
+                        access: 1,
+                        unit: "%",
+                    },
+                ],
+            },
+        ] as zhc.Expose[];
+
+        try {
+            // @ts-expect-error private
+            const configs = extension.getConfigs(bosch);
+
+            expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
+                current_temperature_template: '{{ value_json["local_temperature"] }}',
+                temperature_command_topic: "occupied_heating_setpoint",
+            });
+            expect(configs.find((config) => config.object_id === "local_temperature")).toMatchObject({
+                type: "sensor",
+            });
         } finally {
             bosch.definition.exposes = originalExposes;
         }

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1638,12 +1638,6 @@ describe("Extension: HomeAssistant", () => {
                 current_temperature_template: '{{ value_json["local_temperature"] }}',
                 temperature_command_topic: "occupied_heating_setpoint",
             });
-            expect(configs.find((config) => config.object_id === "cable_sensor_temperature")?.discovery_payload).toMatchObject({
-                device_class: "temperature",
-                state_class: "measurement",
-                value_template:
-                    '{% if value_json["cable_sensor"] is defined and value_json["cable_sensor"]["temperature"] is defined %}{{ value_json["cable_sensor"]["temperature"] }}{% endif %}',
-            });
             expect(configs.find((config) => config.object_id === "local_temperature")).toBeUndefined();
         } finally {
             bosch.definition.exposes = originalExposes;

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1717,6 +1717,33 @@ describe("Extension: HomeAssistant", () => {
         }
     });
 
+    it("Should still expose thermostat current temperature when composite discovery has no allExposes list", () => {
+        const climateExpose = new zhc.Climate()
+            .withSetpoint("occupied_heating_setpoint", 5, 30, 0.5)
+            .withLocalTemperature()
+            .withSystemMode(["off", "heat", "auto"]);
+        const device = {
+            definition: {},
+            isDevice: (): boolean => true,
+            isGroup: (): boolean => false,
+            endpoint: () => undefined,
+            options: {},
+            exposes: (): zhc.Expose[] => [climateExpose],
+            zh: {endpoints: []},
+        } as Device;
+
+        // @ts-expect-error private
+        const configs = extension.exposeToConfig([climateExpose], device, undefined);
+
+        expect(configs.find((config) => config.type === "climate")?.discovery_payload).toMatchObject({
+            current_temperature_template: '{{ value_json["local_temperature"] }}',
+            temperature_command_topic: "occupied_heating_setpoint",
+        });
+        expect(configs.find((config) => config.object_id === "local_temperature")).toMatchObject({
+            type: "sensor",
+        });
+    });
+
     it("Should discover devices with cover_position", () => {
         let payload;
 


### PR DESCRIPTION
Per the message in this thread, Bosch thermostats still need their `local_temperature` sensor in Home Assistant even when the 230V cable-sensor expose is present.

This keeps the thermostat's room-temperature sensor visible and only narrows the duplicate check to nested `local_temperature` sensors, so unrelated cable-sensor readings do not suppress it.

Fixes #25695.
