### PR TITLE
Skip unresolved group members during optimistic publish replay

### DIFF
--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -135,8 +135,18 @@ export default class Publish extends Extension {
         const entityState = this.state.get(re);
         const membersState =
             re instanceof Group
-                ? // biome-ignore lint/style/noNonNullAssertion: TODO: biome migration: might be a bit much assumed here?
-                  Object.fromEntries(re.zh.members.map((e) => [e.deviceIeeeAddress, this.state.get(this.zigbee.resolveEntity(e.deviceIeeeAddress)!)]))
+                ? Object.fromEntries(
+                      re.zh.members.flatMap((e) => {
+                          const member = this.zigbee.resolveEntity(e.deviceIeeeAddress);
+
+                          if (!member) {
+                              logger.warning(`Skipping unresolved group member '${e.deviceIeeeAddress}' while publishing '${re.name}'`);
+                              return [];
+                          }
+
+                          return [[e.deviceIeeeAddress, this.state.get(member)]];
+                      }),
+                  )
                 : undefined;
         const converters = this.getDefinitionConverters(definition);
 

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -140,6 +140,7 @@ export default class Publish extends Extension {
                           const member = this.zigbee.resolveEntity(e.deviceIeeeAddress);
 
                           if (!member) {
+                              // Keep optimistic publish resilient when a group member has been removed or renamed.
                               logger.warning(`Skipping unresolved group member '${e.deviceIeeeAddress}' while publishing '${re.name}'`);
                               return [];
                           }

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -134,8 +134,18 @@ export default class Publish extends Extension {
         const entityState = this.state.get(re);
         const membersState =
             re instanceof Group
-                ? // biome-ignore lint/style/noNonNullAssertion: TODO: biome migration: might be a bit much assumed here?
-                  Object.fromEntries(re.zh.members.map((e) => [e.deviceIeeeAddress, this.state.get(this.zigbee.resolveEntity(e.deviceIeeeAddress)!)]))
+                ? Object.fromEntries(
+                      re.zh.members.flatMap((e) => {
+                          const member = this.zigbee.resolveEntity(e.deviceIeeeAddress);
+
+                          if (!member) {
+                              logger.warning(`Skipping unresolved group member '${e.deviceIeeeAddress}' while publishing '${re.name}'`);
+                              return [];
+                          }
+
+                          return [[e.deviceIeeeAddress, this.state.get(member)]];
+                      }),
+                  )
                 : undefined;
         const converters = this.getDefinitionConverters(definition);
 

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -267,8 +267,11 @@ export default class Publish extends Extension {
 
                     if (result?.membersState && optimistic) {
                         for (const [ieeeAddr, state] of Object.entries(result.membersState)) {
-                            // biome-ignore lint/style/noNonNullAssertion: might be a bit much assumed here?
-                            addToToPublish(this.zigbee.resolveEntity(ieeeAddr)!, state);
+                            const entity = this.zigbee.resolveEntity(ieeeAddr);
+
+                            if (entity) {
+                                addToToPublish(entity, state);
+                            }
                         }
                     }
                 } else if (parsedTopic.type === "get" && converter.convertGet) {

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -139,6 +139,7 @@ export default class Publish extends Extension {
                           const member = this.zigbee.resolveEntity(e.deviceIeeeAddress);
 
                           if (!member) {
+                              // Keep optimistic publish resilient when a group member has been removed or renamed.
                               logger.warning(`Skipping unresolved group member '${e.deviceIeeeAddress}' while publishing '${re.name}'`);
                               return [];
                           }

--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -134,19 +134,7 @@ export default class Publish extends Extension {
         const entityState = this.state.get(re);
         const membersState =
             re instanceof Group
-                ? Object.fromEntries(
-                      re.zh.members.flatMap((e) => {
-                          const member = this.zigbee.resolveEntity(e.deviceIeeeAddress);
-
-                          if (!member) {
-                              // Keep optimistic publish resilient when a group member has been removed or renamed.
-                              logger.warning(`Skipping unresolved group member '${e.deviceIeeeAddress}' while publishing '${re.name}'`);
-                              return [];
-                          }
-
-                          return [[e.deviceIeeeAddress, this.state.get(member)]];
-                      }),
-                  )
+                ? Object.fromEntries(Array.from(re.membersDevices(), (member) => [member.ieeeAddr, this.state.get(member)]))
                 : undefined;
         const converters = this.getDefinitionConverters(definition);
 

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -488,9 +488,9 @@ describe("Extension: Publish", () => {
     it("Should skip unresolved group members when replaying membersState", async () => {
         const group = groups.group_tradfri_remote;
         const resolveEntity = controller.zigbee.resolveEntity.bind(controller.zigbee);
-        const resolveEntitySpy = vi.spyOn(controller.zigbee, "resolveEntity").mockImplementation((id) =>
-            id === devices.bulb_2.ieeeAddr ? undefined : resolveEntity(id),
-        );
+        const resolveEntitySpy = vi
+            .spyOn(controller.zigbee, "resolveEntity")
+            .mockImplementation((id) => (id === devices.bulb_2.ieeeAddr ? undefined : resolveEntity(id)));
 
         try {
             await mockMQTTEvents.message("zigbee2mqtt/group_tradfri_remote/set", stringify({scene_recall: 1}));

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -485,6 +485,25 @@ describe("Extension: Publish", () => {
         group.members.pop();
     });
 
+    it("Should skip unresolved group members when replaying membersState", async () => {
+        const group = groups.group_tradfri_remote;
+        const resolveEntity = controller.zigbee.resolveEntity.bind(controller.zigbee);
+        const resolveEntitySpy = vi.spyOn(controller.zigbee, "resolveEntity").mockImplementation((id) =>
+            id === devices.bulb_2.ieeeAddr ? undefined : resolveEntity(id),
+        );
+
+        try {
+            await mockMQTTEvents.message("zigbee2mqtt/group_tradfri_remote/set", stringify({scene_recall: 1}));
+            await flushPromises();
+            expect(group.command).toHaveBeenCalledTimes(1);
+            expect(mockLogger.warning).toHaveBeenCalledWith(
+                expect.stringContaining(`Skipping unresolved group member '${devices.bulb_2.ieeeAddr}' while publishing 'group_tradfri_remote'`),
+            );
+        } finally {
+            resolveEntitySpy.mockRestore();
+        }
+    });
+
     it("Should publish messages to groups with brightness_percent", async () => {
         const group = groups.group_1;
         group.members.push(devices.bulb_color.getEndpoint(1)!);

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -485,8 +485,18 @@ describe("Extension: Publish", () => {
         group.members.pop();
     });
 
-    it("Should skip unresolved group members when replaying membersState", async () => {
+    it("Should publish remaining membersState when a group member is unresolved", async () => {
         const group = groups.group_tradfri_remote;
+        const originalMembers = group.members;
+        const sceneEndpoints = [devices.bulb_color_2.getEndpoint(1)!, devices.bulb_2.getEndpoint(1)!];
+        const originalScenes = sceneEndpoints.map((endpoint) => endpoint.meta.scenes);
+        group.members = [...originalMembers].reverse();
+        for (const endpoint of sceneEndpoints) {
+            endpoint.meta.scenes = {
+                ...(endpoint.meta.scenes as Record<string, unknown> | undefined),
+                "1_15071": {state: {state: "ON"}},
+            };
+        }
         const resolveEntity = controller.zigbee.resolveEntity.bind(controller.zigbee);
         const resolveEntitySpy = vi
             .spyOn(controller.zigbee, "resolveEntity")
@@ -496,11 +506,16 @@ describe("Extension: Publish", () => {
             await mockMQTTEvents.message("zigbee2mqtt/group_tradfri_remote/set", stringify({scene_recall: 1}));
             await flushPromises();
             expect(group.command).toHaveBeenCalledTimes(1);
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color_2", stringify({state: "ON"}), {retain: false, qos: 0});
             const unresolvedGroupMemberWarnings = mockLogger.warning.mock.calls.filter((call) =>
                 String(call[0]).includes("Skipping unresolved group member"),
             );
             expect(unresolvedGroupMemberWarnings).toHaveLength(0);
         } finally {
+            group.members = originalMembers;
+            sceneEndpoints.forEach((endpoint, index) => {
+                endpoint.meta.scenes = originalScenes[index];
+            });
             resolveEntitySpy.mockRestore();
         }
     });

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -496,9 +496,10 @@ describe("Extension: Publish", () => {
             await mockMQTTEvents.message("zigbee2mqtt/group_tradfri_remote/set", stringify({scene_recall: 1}));
             await flushPromises();
             expect(group.command).toHaveBeenCalledTimes(1);
-            expect(mockLogger.warning).toHaveBeenCalledWith(
-                expect.stringContaining(`Skipping unresolved group member '${devices.bulb_2.ieeeAddr}' while publishing 'group_tradfri_remote'`),
+            const unresolvedGroupMemberWarnings = mockLogger.warning.mock.calls.filter((call) =>
+                String(call[0]).includes("Skipping unresolved group member"),
             );
+            expect(unresolvedGroupMemberWarnings).toHaveLength(0);
         } finally {
             resolveEntitySpy.mockRestore();
         }


### PR DESCRIPTION
Optimistic group publish can crash when a member returned in `membersState` no longer resolves.

Use the existing `membersDevices()` iterator when collecting group state, and skip unresolved entities during optimistic replay. The regression test verifies that resolved members still publish and the missing member produces no warning.
