### PR TITLE
Refresh exposes after manual device configure

### DIFF
--- a/lib/extension/configure.ts
+++ b/lib/extension/configure.ts
@@ -137,7 +137,7 @@ export default class Configure extends Extension {
             logger.info(`Successfully configured '${device.name}' (definition v${definitionVersion})`);
             device.zh.meta.configured = definitionVersion;
             device.zh.save();
-            this.eventBus.emitDevicesChanged();
+            this.eventBus.emitExposesAndDevicesChanged(device);
         } catch (error) {
             const newAttempts = attempts + 1;
             this.attempts.set(device.ieeeAddr, newAttempts);

--- a/test/extensions/configure.test.ts
+++ b/test/extensions/configure.test.ts
@@ -193,16 +193,28 @@ describe("Extension: Configure", () => {
     });
 
     it("Should allow to configure via MQTT", async () => {
+        const emitDevicesChanged = vi.spyOn(controller.eventBus, "emitDevicesChanged");
+        const emitExposesChanged = vi.spyOn(controller.eventBus, "emitExposesChanged");
+
         mockClear(devices.remote);
         expectRemoteNotConfigured();
-        await mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/configure", "remote");
-        await flushPromises();
-        expectRemoteConfigured();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
-            "zigbee2mqtt/bridge/response/device/configure",
-            stringify({data: {id: "remote"}, status: "ok"}),
-            {},
-        );
+        try {
+            await mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/configure", "remote");
+            await flushPromises();
+            expectRemoteConfigured();
+            expect(emitDevicesChanged).toHaveBeenCalledTimes(1);
+            expect(emitExposesChanged).toHaveBeenCalledWith({
+                device: controller.zigbee.resolveEntity(devices.remote),
+            });
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
+                "zigbee2mqtt/bridge/response/device/configure",
+                stringify({data: {id: "remote"}, status: "ok"}),
+                {},
+            );
+        } finally {
+            emitExposesChanged.mockRestore();
+            emitDevicesChanged.mockRestore();
+        }
     });
 
     it("Fail to configure via MQTT when device does not exist", async () => {


### PR DESCRIPTION
Per the message in this thread, a successful manual configure was only emitting the device-changed path, which could leave Home Assistant discovery stale until a later event.

This switches successful manual configure to the exposes-aware refresh path so discovery updates immediately after configuration.

Fixes #32465.