### PR TITLE
mark esphome devices as supported

### DIFF
--- a/lib/model/device.ts
+++ b/lib/model/device.ts
@@ -34,7 +34,7 @@ export default class Device {
         return this.zh.type === "Coordinator" ? "Coordinator" : this.options?.friendly_name;
     }
     get isSupported(): boolean {
-        return this.zh.type === "Coordinator" || Boolean(this.definition && !this.definition.generated);
+        return this.zh.type === "Coordinator" || Boolean(this.definition && (!this.definition.generated || this.definition.vendor === "esphome"));
     }
     get customClusters(): CustomClusters {
         return this.zh.customClusters;


### PR DESCRIPTION
This PR changes the status of esphome devices with generated definitions from not supported to supported.  

Esphome devices rely on the generated definitions (which have full support for features implemented so far) and users are confused by the generic image and not supported text. Some even try to change device/vendor names to mimic a supported device.