### PR TITLE
fix: `experimental_event_entities` and `legacy_action_sensor` require restart

### DIFF
--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -33,12 +33,14 @@
                     "type": "boolean",
                     "title": "Home Assistant legacy action sensors",
                     "description": "Home Assistant legacy actions sensor, when enabled a action sensor will be discoverd and an empty `action` will be send after every published action.",
+                    "requiresRestart": true,
                     "default": false
                 },
                 "experimental_event_entities": {
                     "type": "boolean",
                     "title": "Home Assistant experimental event entities",
                     "description": "Home Assistant experimental event entities, when enabled Zigbee2MQTT will add event entities for exposed actions. The events and attributes are currently deemed experimental and subject to change.",
+                    "requiresRestart": true,
                     "default": false
                 }
             },


### PR DESCRIPTION
I see the new HA entities appear only after a Z2M restart