### PR TITLE
feat(homeassistant): expose settable composites for a composite editor card

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -396,6 +396,65 @@ const applyHomeAssistantExposeMetadata = (payload: KeyValue, homeAssistant: zhc.
 };
 
 /**
+ * Schema for a single feature of a settable `composite` expose, consumed by the external
+ * `z2m-composite-card` Home Assistant Lovelace card.
+ */
+interface CompositeSchemaFeature {
+    name: string;
+    property: string;
+    label: string;
+    type: string;
+    access: number;
+    description?: string;
+    unit?: string;
+    value_min?: number;
+    value_max?: number;
+    value_step?: number;
+    // Optional per-feature default (from zigbee-herdsman-converters `withDefault`), used by the card
+    // to pre-fill fields of a new/empty composite slot so it can build a complete payload.
+    default?: unknown;
+    values?: (string | number)[];
+    value_on?: unknown;
+    value_off?: unknown;
+    features?: CompositeSchemaFeature[];
+}
+
+/**
+ * Serializes a composite expose's feature tree into a compact schema.
+ *
+ * Home Assistant's MQTT discovery has no native "composite"/form entity, and a `composite` must be
+ * written to the device as one complete object in a single message (independently writing fields
+ * breaks devices like the SONOFF valve, see zigbee-herdsman-converters #12495/#12510 which were
+ * reverted by #12647). We therefore cannot represent an editable composite with stock entities.
+ * Instead the schema produced here is published (base64 encoded) as an attribute of a stock `sensor`
+ * entity, and the external card renders the editor and writes the whole object back in one `set`.
+ */
+const COMPOSITE_SCHEMA_OPTIONAL_KEYS = ["description", "unit", "value_min", "value_max", "value_step", "default", "values", "value_on", "value_off"];
+
+export const buildCompositeSchemaFeatures = (features: zhc.Feature[]): CompositeSchemaFeature[] =>
+    features.map((feature) => {
+        // Features are a union of expose types; read optional fields defensively via a loose view.
+        const f = feature as KeyValue;
+        const result: KeyValue = {
+            name: feature.name,
+            property: feature.property,
+            label: feature.label,
+            type: feature.type,
+            access: feature.access,
+        };
+        for (const key of COMPOSITE_SCHEMA_OPTIONAL_KEYS) {
+            if (f[key] !== undefined) {
+                result[key] = f[key];
+            }
+        }
+        // Recurse for nested composite/list features (e.g. `loop_type_week_days` in SONOFF plans).
+        if (Array.isArray(f.features)) {
+            result.features = buildCompositeSchemaFeatures(f.features as zhc.Feature[]);
+        }
+        return result as CompositeSchemaFeature;
+    });
+
+/**
  * This class handles the bridge entity configuration for Home Assistant Discovery.
  */
 class Bridge {
@@ -1363,6 +1422,46 @@ export class HomeAssistant extends Extension {
                     break;
                 }
 
+                // Settable composite → editor entity for the external `z2m-composite-card`.
+                //
+                // A composite is written to the device as ONE complete object in a single message and
+                // its fields are not independently writable (this is the whole point of using
+                // `composite`; independently exposing fields broke the SONOFF valve, see
+                // zigbee-herdsman-converters #12495/#12510 reverted by #12647). Home Assistant's MQTT
+                // discovery cannot render such a grouped/atomic form with stock entities, so we publish
+                // a plain `sensor` whose state holds the current composite value and whose attributes
+                // carry the composite `schema` (base64), `property` and `set_topic`. The custom card
+                // reads those attributes, renders a dialog for all fields and publishes the whole object
+                // back to `set_topic` in one atomic write. This keeps working on stock Home Assistant.
+                if (firstExposeTyped.type === "composite" && firstExposeTyped.access & ACCESS_SET) {
+                    const compositeExpose = firstExpose as zhc.Composite;
+                    const property = firstExposeTyped.property;
+                    const schema = {
+                        property: compositeExpose.property,
+                        label: compositeExpose.label,
+                        features: buildCompositeSchemaFeatures(compositeExpose.features),
+                    };
+                    // base64 has no quotes, so it embeds safely inside the single-quoted Jinja literal.
+                    const schemaB64 = Buffer.from(stringify(schema)).toString("base64");
+                    const setTopic = `${settings.get().mqtt.base_topic}/${entity.name}/set`;
+                    discoveryEntries.push({
+                        type: "sensor",
+                        object_id: property,
+                        mockProperties: [{property: property, value: null}],
+                        discovery_payload: {
+                            name: endpointName ? `${firstExposeTyped.label} ${endpointName}` : firstExposeTyped.label,
+                            state_topic: true,
+                            value_template: `{{ value_json['${property}'] | tojson }}`,
+                            json_attributes_topic: true,
+                            json_attributes_template:
+                                `{{ {'z2m_composite': {'property': '${property}', 'set_topic': '${setTopic}', ` +
+                                `'schema_b64': '${schemaB64}', 'value': value_json['${property}'] | default(None, true)}} | tojson }}`,
+                            icon: "mdi:tune-variant",
+                        },
+                    });
+                    break;
+                }
+
                 if (firstExposeTyped.type === "text" && firstExposeTyped.access & ACCESS_SET) {
                     discoveryEntries.push({
                         type: "text",
@@ -1704,6 +1803,12 @@ export class HomeAssistant extends Extension {
                 if (payload.state_topic !== undefined) {
                     delete payload.state_topic;
                 }
+            }
+
+            // A `json_attributes_topic: true` shorthand resolves to the entity state topic (like `state_topic`).
+            // Used by the settable-composite editor entity to carry its schema/value as attributes.
+            if (payload.json_attributes_topic === true) {
+                payload.json_attributes_topic = stateTopic;
             }
 
             if (payload.position_topic) {

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -410,9 +410,6 @@ interface CompositeSchemaFeature {
     value_min?: number;
     value_max?: number;
     value_step?: number;
-    // Optional per-feature default (from zigbee-herdsman-converters `withDefault`), used by the card
-    // to pre-fill fields of a new/empty composite slot so it can build a complete payload.
-    default?: unknown;
     values?: (string | number)[];
     value_on?: unknown;
     value_off?: unknown;
@@ -429,7 +426,7 @@ interface CompositeSchemaFeature {
  * Instead the schema produced here is published (base64 encoded) as an attribute of a stock `sensor`
  * entity, and the external card renders the editor and writes the whole object back in one `set`.
  */
-const COMPOSITE_SCHEMA_OPTIONAL_KEYS = ["description", "unit", "value_min", "value_max", "value_step", "default", "values", "value_on", "value_off"];
+const COMPOSITE_SCHEMA_OPTIONAL_KEYS = ["description", "unit", "value_min", "value_max", "value_step", "values", "value_on", "value_off"];
 
 export const buildCompositeSchemaFeatures = (features: zhc.Feature[]): CompositeSchemaFeature[] =>
     features.map((feature) => {
@@ -1430,9 +1427,12 @@ export class HomeAssistant extends Extension {
                 // zigbee-herdsman-converters #12495/#12510 reverted by #12647). Home Assistant's MQTT
                 // discovery cannot render such a grouped/atomic form with stock entities, so we publish
                 // a plain `sensor` whose state holds the current composite value and whose attributes
-                // carry the composite `schema` (base64), `property` and `set_topic`. The custom card
-                // reads those attributes, renders a dialog for all fields and publishes the whole object
-                // back to `set_topic` in one atomic write. This keeps working on stock Home Assistant.
+                // carry the composite `schema`, `property` and `set_topic`. The custom card reads those
+                // attributes, renders a dialog for all fields and publishes the whole object back to
+                // `set_topic` in one atomic write. This keeps working on stock Home Assistant.
+                //
+                // Future: a native Home Assistant MQTT "composite" platform could consume this same
+                // `z2m_composite` schema/attributes to render the editor natively (see PR discussion).
                 if (firstExposeTyped.type === "composite" && firstExposeTyped.access & ACCESS_SET) {
                     const compositeExpose = firstExpose as zhc.Composite;
                     const property = firstExposeTyped.property;
@@ -1441,9 +1441,14 @@ export class HomeAssistant extends Extension {
                         label: compositeExpose.label,
                         features: buildCompositeSchemaFeatures(compositeExpose.features),
                     };
-                    // base64 has no quotes, so it embeds safely inside the single-quoted Jinja literal.
-                    const schemaB64 = Buffer.from(stringify(schema)).toString("base64");
                     const setTopic = `${settings.get().mqtt.base_topic}/${entity.name}/set`;
+                    // The attributes template is literal JSON (schema + property + set_topic serialized with
+                    // `stringify`) with only the live `value` filled from the state message via Jinja. This
+                    // avoids embedding JSON inside a Jinja dict-literal (and the quoting/base64 hacks that
+                    // would otherwise require); the card reads `z2m_composite.schema` directly as an object.
+                    const jsonAttributesTemplate =
+                        `{"z2m_composite": {"value": {{ value_json['${property}'] | tojson }}, ` +
+                        `"property": ${stringify(property)}, "set_topic": ${stringify(setTopic)}, "schema": ${stringify(schema)}}}`;
                     discoveryEntries.push({
                         type: "sensor",
                         object_id: property,
@@ -1453,9 +1458,7 @@ export class HomeAssistant extends Extension {
                             state_topic: true,
                             value_template: `{{ value_json['${property}'] | tojson }}`,
                             json_attributes_topic: true,
-                            json_attributes_template:
-                                `{{ {'z2m_composite': {'property': '${property}', 'set_topic': '${setTopic}', ` +
-                                `'schema_b64': '${schemaB64}', 'value': value_json['${property}'] | default(None, true)}} | tojson }}`,
+                            json_attributes_template: jsonAttributesTemplate,
                             icon: "mdi:tune-variant",
                         },
                     });

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1509,7 +1509,7 @@ export class HomeAssistant extends Extension {
                     // would otherwise require); the card reads `z2m_composite.schema` directly as an object.
                     const jsonAttributesTemplate =
                         `{"z2m_composite": {"value": {{ value_json['${property}'] | tojson }}, ` +
-                        `"property": ${stringify(property)}, "set_topic": ${stringify(setTopic)}, "schema": ${stringify(schema)}}}`;
+                        `"property": ${JSON.stringify(property)}, "set_topic": ${JSON.stringify(setTopic)}, "schema": ${stringify(schema)}}}`;
                     discoveryEntries.push({
                         type: "sensor",
                         object_id: property,

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -452,9 +452,6 @@ interface CompositeSchemaFeature {
     value_min?: number;
     value_max?: number;
     value_step?: number;
-    // Optional per-feature default (from zigbee-herdsman-converters `withDefault`), used by the card
-    // to pre-fill fields of a new/empty composite slot so it can build a complete payload.
-    default?: unknown;
     values?: (string | number)[];
     value_on?: unknown;
     value_off?: unknown;
@@ -471,7 +468,7 @@ interface CompositeSchemaFeature {
  * Instead the schema produced here is published (base64 encoded) as an attribute of a stock `sensor`
  * entity, and the external card renders the editor and writes the whole object back in one `set`.
  */
-const COMPOSITE_SCHEMA_OPTIONAL_KEYS = ["description", "unit", "value_min", "value_max", "value_step", "default", "values", "value_on", "value_off"];
+const COMPOSITE_SCHEMA_OPTIONAL_KEYS = ["description", "unit", "value_min", "value_max", "value_step", "values", "value_on", "value_off"];
 
 export const buildCompositeSchemaFeatures = (features: zhc.Feature[]): CompositeSchemaFeature[] =>
     features.map((feature) => {
@@ -1491,9 +1488,12 @@ export class HomeAssistant extends Extension {
                 // zigbee-herdsman-converters #12495/#12510 reverted by #12647). Home Assistant's MQTT
                 // discovery cannot render such a grouped/atomic form with stock entities, so we publish
                 // a plain `sensor` whose state holds the current composite value and whose attributes
-                // carry the composite `schema` (base64), `property` and `set_topic`. The custom card
-                // reads those attributes, renders a dialog for all fields and publishes the whole object
-                // back to `set_topic` in one atomic write. This keeps working on stock Home Assistant.
+                // carry the composite `schema`, `property` and `set_topic`. The custom card reads those
+                // attributes, renders a dialog for all fields and publishes the whole object back to
+                // `set_topic` in one atomic write. This keeps working on stock Home Assistant.
+                //
+                // Future: a native Home Assistant MQTT "composite" platform could consume this same
+                // `z2m_composite` schema/attributes to render the editor natively (see PR discussion).
                 if (firstExposeTyped.type === "composite" && firstExposeTyped.access & ACCESS_SET) {
                     const compositeExpose = firstExpose as zhc.Composite;
                     const property = firstExposeTyped.property;
@@ -1502,9 +1502,14 @@ export class HomeAssistant extends Extension {
                         label: compositeExpose.label,
                         features: buildCompositeSchemaFeatures(compositeExpose.features),
                     };
-                    // base64 has no quotes, so it embeds safely inside the single-quoted Jinja literal.
-                    const schemaB64 = Buffer.from(stringify(schema)).toString("base64");
                     const setTopic = `${settings.get().mqtt.base_topic}/${entity.name}/set`;
+                    // The attributes template is literal JSON (schema + property + set_topic serialized with
+                    // `stringify`) with only the live `value` filled from the state message via Jinja. This
+                    // avoids embedding JSON inside a Jinja dict-literal (and the quoting/base64 hacks that
+                    // would otherwise require); the card reads `z2m_composite.schema` directly as an object.
+                    const jsonAttributesTemplate =
+                        `{"z2m_composite": {"value": {{ value_json['${property}'] | tojson }}, ` +
+                        `"property": ${stringify(property)}, "set_topic": ${stringify(setTopic)}, "schema": ${stringify(schema)}}}`;
                     discoveryEntries.push({
                         type: "sensor",
                         object_id: property,
@@ -1514,9 +1519,7 @@ export class HomeAssistant extends Extension {
                             state_topic: true,
                             value_template: `{{ value_json['${property}'] | tojson }}`,
                             json_attributes_topic: true,
-                            json_attributes_template:
-                                `{{ {'z2m_composite': {'property': '${property}', 'set_topic': '${setTopic}', ` +
-                                `'schema_b64': '${schemaB64}', 'value': value_json['${property}'] | default(None, true)}} | tojson }}`,
+                            json_attributes_template: jsonAttributesTemplate,
                             icon: "mdi:tune-variant",
                         },
                     });

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -438,6 +438,65 @@ const applyHomeAssistantExposeMetadata = (payload: DiscoveryEntry, homeAssistant
 };
 
 /**
+ * Schema for a single feature of a settable `composite` expose, consumed by the external
+ * `z2m-composite-card` Home Assistant Lovelace card.
+ */
+interface CompositeSchemaFeature {
+    name: string;
+    property: string;
+    label: string;
+    type: string;
+    access: number;
+    description?: string;
+    unit?: string;
+    value_min?: number;
+    value_max?: number;
+    value_step?: number;
+    // Optional per-feature default (from zigbee-herdsman-converters `withDefault`), used by the card
+    // to pre-fill fields of a new/empty composite slot so it can build a complete payload.
+    default?: unknown;
+    values?: (string | number)[];
+    value_on?: unknown;
+    value_off?: unknown;
+    features?: CompositeSchemaFeature[];
+}
+
+/**
+ * Serializes a composite expose's feature tree into a compact schema.
+ *
+ * Home Assistant's MQTT discovery has no native "composite"/form entity, and a `composite` must be
+ * written to the device as one complete object in a single message (independently writing fields
+ * breaks devices like the SONOFF valve, see zigbee-herdsman-converters #12495/#12510 which were
+ * reverted by #12647). We therefore cannot represent an editable composite with stock entities.
+ * Instead the schema produced here is published (base64 encoded) as an attribute of a stock `sensor`
+ * entity, and the external card renders the editor and writes the whole object back in one `set`.
+ */
+const COMPOSITE_SCHEMA_OPTIONAL_KEYS = ["description", "unit", "value_min", "value_max", "value_step", "default", "values", "value_on", "value_off"];
+
+export const buildCompositeSchemaFeatures = (features: zhc.Feature[]): CompositeSchemaFeature[] =>
+    features.map((feature) => {
+        // Features are a union of expose types; read optional fields defensively via a loose view.
+        const f = feature as KeyValue;
+        const result: KeyValue = {
+            name: feature.name,
+            property: feature.property,
+            label: feature.label,
+            type: feature.type,
+            access: feature.access,
+        };
+        for (const key of COMPOSITE_SCHEMA_OPTIONAL_KEYS) {
+            if (f[key] !== undefined) {
+                result[key] = f[key];
+            }
+        }
+        // Recurse for nested composite/list features (e.g. `loop_type_week_days` in SONOFF plans).
+        if (Array.isArray(f.features)) {
+            result.features = buildCompositeSchemaFeatures(f.features as zhc.Feature[]);
+        }
+        return result as CompositeSchemaFeature;
+    });
+
+/**
  * This class handles the bridge entity configuration for Home Assistant Discovery.
  */
 class Bridge {
@@ -1424,6 +1483,46 @@ export class HomeAssistant extends Extension {
                     break;
                 }
 
+                // Settable composite → editor entity for the external `z2m-composite-card`.
+                //
+                // A composite is written to the device as ONE complete object in a single message and
+                // its fields are not independently writable (this is the whole point of using
+                // `composite`; independently exposing fields broke the SONOFF valve, see
+                // zigbee-herdsman-converters #12495/#12510 reverted by #12647). Home Assistant's MQTT
+                // discovery cannot render such a grouped/atomic form with stock entities, so we publish
+                // a plain `sensor` whose state holds the current composite value and whose attributes
+                // carry the composite `schema` (base64), `property` and `set_topic`. The custom card
+                // reads those attributes, renders a dialog for all fields and publishes the whole object
+                // back to `set_topic` in one atomic write. This keeps working on stock Home Assistant.
+                if (firstExposeTyped.type === "composite" && firstExposeTyped.access & ACCESS_SET) {
+                    const compositeExpose = firstExpose as zhc.Composite;
+                    const property = firstExposeTyped.property;
+                    const schema = {
+                        property: compositeExpose.property,
+                        label: compositeExpose.label,
+                        features: buildCompositeSchemaFeatures(compositeExpose.features),
+                    };
+                    // base64 has no quotes, so it embeds safely inside the single-quoted Jinja literal.
+                    const schemaB64 = Buffer.from(stringify(schema)).toString("base64");
+                    const setTopic = `${settings.get().mqtt.base_topic}/${entity.name}/set`;
+                    discoveryEntries.push({
+                        type: "sensor",
+                        object_id: property,
+                        mockProperties: [{property: property, value: null}],
+                        discovery_payload: {
+                            name: endpointName ? `${firstExposeTyped.label} ${endpointName}` : firstExposeTyped.label,
+                            state_topic: true,
+                            value_template: `{{ value_json['${property}'] | tojson }}`,
+                            json_attributes_topic: true,
+                            json_attributes_template:
+                                `{{ {'z2m_composite': {'property': '${property}', 'set_topic': '${setTopic}', ` +
+                                `'schema_b64': '${schemaB64}', 'value': value_json['${property}'] | default(None, true)}} | tojson }}`,
+                            icon: "mdi:tune-variant",
+                        },
+                    });
+                    break;
+                }
+
                 if (firstExposeTyped.type === "text" && firstExposeTyped.access & ACCESS_SET) {
                     discoveryEntries.push({
                         type: "text",
@@ -1771,6 +1870,12 @@ export class HomeAssistant extends Extension {
                 if (payload.state_topic !== undefined) {
                     delete payload.state_topic;
                 }
+            }
+
+            // A `json_attributes_topic: true` shorthand resolves to the entity state topic (like `state_topic`).
+            // Used by the settable-composite editor entity to carry its schema/value as attributes.
+            if (payload.json_attributes_topic === true) {
+                payload.json_attributes_topic = stateTopic;
             }
 
             if (payload.position_topic) {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -14,7 +14,7 @@ import type {MockInstance} from "vitest";
 import * as zhc from "zigbee-herdsman-converters";
 import type {KeyValueAny} from "zigbee-herdsman-converters/lib/types";
 import {Controller} from "../../lib/controller";
-import HomeAssistant from "../../lib/extension/homeassistant";
+import HomeAssistant, {buildCompositeSchemaFeatures} from "../../lib/extension/homeassistant";
 
 import type Device from "../../lib/model/device";
 import type Group from "../../lib/model/group";
@@ -1147,6 +1147,34 @@ describe("Extension: HomeAssistant", () => {
             retain: true,
             qos: 1,
         });
+    });
+
+    it("Should discover settable composite as z2m-composite-card editor entity", async () => {
+        // A `composite` must be written to the device as one complete object; its fields are not
+        // independently writable and HA MQTT discovery has no composite/form entity. We therefore
+        // publish a stock `sensor` carrying the composite schema/value/set-topic as attributes for the
+        // external z2m-composite-card. See https://github.com/Koenkk/zigbee-herdsman-converters/pull/12647.
+        settings.set(["devices", "0xb43a31fffe2f1f6a"], {friendly_name: "inovelli_switch", retain: false});
+        mockMQTTPublishAsync.mockClear();
+        await resetExtension();
+
+        const configTopic = "homeassistant/sensor/0xb43a31fffe2f1f6a/led_effect/config";
+        const call = mockMQTTPublishAsync.mock.calls.find((c) => c[0] === configTopic);
+        expect(call).toBeDefined();
+
+        const payload = JSON.parse(call![1] as string);
+        expect(payload.state_topic).toBe("zigbee2mqtt/inovelli_switch");
+        expect(payload.value_template).toBe("{{ value_json['led_effect'] | tojson }}");
+        expect(payload.json_attributes_topic).toBe("zigbee2mqtt/inovelli_switch");
+        expect(payload.icon).toBe("mdi:tune-variant");
+        expect(payload.json_attributes_template).toContain("'z2m_composite'");
+        expect(payload.json_attributes_template).toContain("'set_topic': 'zigbee2mqtt/inovelli_switch/set'");
+
+        const schemaMatch = (payload.json_attributes_template as string).match(/'schema_b64': '([^']+)'/);
+        expect(schemaMatch).not.toBeNull();
+        const schema = JSON.parse(Buffer.from(schemaMatch![1], "base64").toString("utf8"));
+        expect(schema.property).toBe("led_effect");
+        expect(schema.features.map((f: {name: string}) => f.name)).toStrictEqual(["effect", "color", "level", "duration"]);
     });
 
     it("Should discover devices with speed-controlled fan", () => {
@@ -3307,5 +3335,48 @@ describe("Extension: HomeAssistant", () => {
         await controller.enableDisableExtension(false, "HomeAssistant");
 
         await vi.waitFor(() => controller.getExtension("HomeAssistant") === undefined);
+    });
+});
+
+describe("HomeAssistant: composite schema", () => {
+    it("serializes all feature field types and nested features", () => {
+        // Build a synthetic composite feature tree covering numeric/enum/binary/text/nested composite,
+        // including an explicit `default` (from zigbee-herdsman-converters `withDefault`) so the card
+        // can pre-fill new/empty composite slots.
+        const features = [
+            {name: "amount", property: "amount", label: "Amount", type: "numeric", access: 3, unit: "L", value_min: 0, value_max: 100, value_step: 1, default: 5},
+            {name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"},
+            {name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"},
+            {name: "note", property: "note", label: "Note", type: "text", access: 3},
+            {
+                name: "week",
+                property: "week",
+                label: "Week",
+                type: "composite",
+                access: 3,
+                features: [{name: "monday", property: "monday", label: "Monday", type: "binary", access: 3, value_on: true, value_off: false}],
+            },
+        ] as unknown as zhc.Composite["features"];
+
+        const schema = buildCompositeSchemaFeatures(features);
+
+        expect(schema[0]).toStrictEqual({
+            name: "amount",
+            property: "amount",
+            label: "Amount",
+            type: "numeric",
+            access: 3,
+            unit: "L",
+            value_min: 0,
+            value_max: 100,
+            value_step: 1,
+            default: 5,
+        });
+        expect(schema[1]).toStrictEqual({name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"});
+        expect(schema[2]).toStrictEqual({name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"});
+        expect(schema[3]).toStrictEqual({name: "note", property: "note", label: "Note", type: "text", access: 3});
+        expect(schema[4].features).toStrictEqual([
+            {name: "monday", property: "monday", label: "Monday", type: "binary", access: 3, value_on: true, value_off: false},
+        ]);
     });
 });

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -3344,7 +3344,18 @@ describe("HomeAssistant: composite schema", () => {
         // including an explicit `default` (from zigbee-herdsman-converters `withDefault`) so the card
         // can pre-fill new/empty composite slots.
         const features = [
-            {name: "amount", property: "amount", label: "Amount", type: "numeric", access: 3, unit: "L", value_min: 0, value_max: 100, value_step: 1, default: 5},
+            {
+                name: "amount",
+                property: "amount",
+                label: "Amount",
+                type: "numeric",
+                access: 3,
+                unit: "L",
+                value_min: 0,
+                value_max: 100,
+                value_step: 1,
+                default: 5,
+            },
             {name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"},
             {name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"},
             {name: "note", property: "note", label: "Note", type: "text", access: 3},
@@ -3372,8 +3383,24 @@ describe("HomeAssistant: composite schema", () => {
             value_step: 1,
             default: 5,
         });
-        expect(schema[1]).toStrictEqual({name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"});
-        expect(schema[2]).toStrictEqual({name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"});
+        expect(schema[1]).toStrictEqual({
+            name: "mode",
+            property: "mode",
+            label: "Mode",
+            type: "enum",
+            access: 3,
+            values: ["a", "b"],
+            description: "The mode",
+        });
+        expect(schema[2]).toStrictEqual({
+            name: "enabled",
+            property: "enabled",
+            label: "Enabled",
+            type: "binary",
+            access: 3,
+            value_on: "ON",
+            value_off: "OFF",
+        });
         expect(schema[3]).toStrictEqual({name: "note", property: "note", label: "Note", type: "text", access: 3});
         expect(schema[4].features).toStrictEqual([
             {name: "monday", property: "monday", label: "Monday", type: "binary", access: 3, value_on: true, value_off: false},

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1167,14 +1167,17 @@ describe("Extension: HomeAssistant", () => {
         expect(payload.value_template).toBe("{{ value_json['led_effect'] | tojson }}");
         expect(payload.json_attributes_topic).toBe("zigbee2mqtt/inovelli_switch");
         expect(payload.icon).toBe("mdi:tune-variant");
-        expect(payload.json_attributes_template).toContain("'z2m_composite'");
-        expect(payload.json_attributes_template).toContain("'set_topic': 'zigbee2mqtt/inovelli_switch/set'");
 
-        const schemaMatch = (payload.json_attributes_template as string).match(/'schema_b64': '([^']+)'/);
-        expect(schemaMatch).not.toBeNull();
-        const schema = JSON.parse(Buffer.from(schemaMatch![1], "base64").toString("utf8"));
-        expect(schema.property).toBe("led_effect");
-        expect(schema.features.map((f: {name: string}) => f.name)).toStrictEqual(["effect", "color", "level", "duration"]);
+        // The attributes template is literal JSON (schema/property/set_topic) with only the live `value`
+        // filled via a single Jinja expression. Replacing that expression with `null` must yield valid
+        // JSON, which also documents the shape the card consumes.
+        const template = payload.json_attributes_template as string;
+        expect(template).toContain("\"value\": {{ value_json['led_effect'] | tojson }}");
+        const attributes = JSON.parse(template.replace(/\{\{.*?\}\}/, "null"));
+        expect(attributes.z2m_composite.property).toBe("led_effect");
+        expect(attributes.z2m_composite.set_topic).toBe("zigbee2mqtt/inovelli_switch/set");
+        expect(attributes.z2m_composite.schema.property).toBe("led_effect");
+        expect(attributes.z2m_composite.schema.features.map((f: {name: string}) => f.name)).toStrictEqual(["effect", "color", "level", "duration"]);
     });
 
     it("Should discover devices with speed-controlled fan", () => {
@@ -3340,9 +3343,9 @@ describe("Extension: HomeAssistant", () => {
 
 describe("HomeAssistant: composite schema", () => {
     it("serializes all feature field types and nested features", () => {
-        // Build a synthetic composite feature tree covering numeric/enum/binary/text/nested composite,
-        // including an explicit `default` (from zigbee-herdsman-converters `withDefault`) so the card
-        // can pre-fill new/empty composite slots.
+        // Build a synthetic composite feature tree covering numeric/enum/binary/text/nested composite.
+        // The card derives its own field defaults from the schema (numeric→value_min, enum→first value,
+        // binary→value_off, text→''), so no per-feature default is needed here.
         const features = [
             {
                 name: "amount",
@@ -3354,7 +3357,6 @@ describe("HomeAssistant: composite schema", () => {
                 value_min: 0,
                 value_max: 100,
                 value_step: 1,
-                default: 5,
             },
             {name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"},
             {name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"},
@@ -3381,7 +3383,6 @@ describe("HomeAssistant: composite schema", () => {
             value_min: 0,
             value_max: 100,
             value_step: 1,
-            default: 5,
         });
         expect(schema[1]).toStrictEqual({
             name: "mode",

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -3441,7 +3441,18 @@ describe("HomeAssistant: composite schema", () => {
         // including an explicit `default` (from zigbee-herdsman-converters `withDefault`) so the card
         // can pre-fill new/empty composite slots.
         const features = [
-            {name: "amount", property: "amount", label: "Amount", type: "numeric", access: 3, unit: "L", value_min: 0, value_max: 100, value_step: 1, default: 5},
+            {
+                name: "amount",
+                property: "amount",
+                label: "Amount",
+                type: "numeric",
+                access: 3,
+                unit: "L",
+                value_min: 0,
+                value_max: 100,
+                value_step: 1,
+                default: 5,
+            },
             {name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"},
             {name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"},
             {name: "note", property: "note", label: "Note", type: "text", access: 3},
@@ -3469,8 +3480,24 @@ describe("HomeAssistant: composite schema", () => {
             value_step: 1,
             default: 5,
         });
-        expect(schema[1]).toStrictEqual({name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"});
-        expect(schema[2]).toStrictEqual({name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"});
+        expect(schema[1]).toStrictEqual({
+            name: "mode",
+            property: "mode",
+            label: "Mode",
+            type: "enum",
+            access: 3,
+            values: ["a", "b"],
+            description: "The mode",
+        });
+        expect(schema[2]).toStrictEqual({
+            name: "enabled",
+            property: "enabled",
+            label: "Enabled",
+            type: "binary",
+            access: 3,
+            value_on: "ON",
+            value_off: "OFF",
+        });
         expect(schema[3]).toStrictEqual({name: "note", property: "note", label: "Note", type: "text", access: 3});
         expect(schema[4].features).toStrictEqual([
             {name: "monday", property: "monday", label: "Monday", type: "binary", access: 3, value_on: true, value_off: false},

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -14,7 +14,7 @@ import type {MockInstance} from "vitest";
 import * as zhc from "zigbee-herdsman-converters";
 import type {KeyValueAny} from "zigbee-herdsman-converters/lib/types";
 import {Controller} from "../../lib/controller";
-import HomeAssistant from "../../lib/extension/homeassistant";
+import HomeAssistant, {buildCompositeSchemaFeatures} from "../../lib/extension/homeassistant";
 
 import type Device from "../../lib/model/device";
 import type Group from "../../lib/model/group";
@@ -1166,6 +1166,34 @@ describe("Extension: HomeAssistant", () => {
             retain: true,
             qos: 1,
         });
+    });
+
+    it("Should discover settable composite as z2m-composite-card editor entity", async () => {
+        // A `composite` must be written to the device as one complete object; its fields are not
+        // independently writable and HA MQTT discovery has no composite/form entity. We therefore
+        // publish a stock `sensor` carrying the composite schema/value/set-topic as attributes for the
+        // external z2m-composite-card. See https://github.com/Koenkk/zigbee-herdsman-converters/pull/12647.
+        settings.set(["devices", "0xb43a31fffe2f1f6a"], {friendly_name: "inovelli_switch", retain: false});
+        mockMQTTPublishAsync.mockClear();
+        await resetExtension();
+
+        const configTopic = "homeassistant/sensor/0xb43a31fffe2f1f6a/led_effect/config";
+        const call = mockMQTTPublishAsync.mock.calls.find((c) => c[0] === configTopic);
+        expect(call).toBeDefined();
+
+        const payload = JSON.parse(call![1] as string);
+        expect(payload.state_topic).toBe("zigbee2mqtt/inovelli_switch");
+        expect(payload.value_template).toBe("{{ value_json['led_effect'] | tojson }}");
+        expect(payload.json_attributes_topic).toBe("zigbee2mqtt/inovelli_switch");
+        expect(payload.icon).toBe("mdi:tune-variant");
+        expect(payload.json_attributes_template).toContain("'z2m_composite'");
+        expect(payload.json_attributes_template).toContain("'set_topic': 'zigbee2mqtt/inovelli_switch/set'");
+
+        const schemaMatch = (payload.json_attributes_template as string).match(/'schema_b64': '([^']+)'/);
+        expect(schemaMatch).not.toBeNull();
+        const schema = JSON.parse(Buffer.from(schemaMatch![1], "base64").toString("utf8"));
+        expect(schema.property).toBe("led_effect");
+        expect(schema.features.map((f: {name: string}) => f.name)).toStrictEqual(["effect", "color", "level", "duration"]);
     });
 
     it("Should discover devices with speed-controlled fan", () => {
@@ -3404,5 +3432,48 @@ describe("Extension: HomeAssistant", () => {
         await controller.enableDisableExtension(false, "HomeAssistant");
 
         await vi.waitFor(() => controller.getExtension("HomeAssistant") === undefined);
+    });
+});
+
+describe("HomeAssistant: composite schema", () => {
+    it("serializes all feature field types and nested features", () => {
+        // Build a synthetic composite feature tree covering numeric/enum/binary/text/nested composite,
+        // including an explicit `default` (from zigbee-herdsman-converters `withDefault`) so the card
+        // can pre-fill new/empty composite slots.
+        const features = [
+            {name: "amount", property: "amount", label: "Amount", type: "numeric", access: 3, unit: "L", value_min: 0, value_max: 100, value_step: 1, default: 5},
+            {name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"},
+            {name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"},
+            {name: "note", property: "note", label: "Note", type: "text", access: 3},
+            {
+                name: "week",
+                property: "week",
+                label: "Week",
+                type: "composite",
+                access: 3,
+                features: [{name: "monday", property: "monday", label: "Monday", type: "binary", access: 3, value_on: true, value_off: false}],
+            },
+        ] as unknown as zhc.Composite["features"];
+
+        const schema = buildCompositeSchemaFeatures(features);
+
+        expect(schema[0]).toStrictEqual({
+            name: "amount",
+            property: "amount",
+            label: "Amount",
+            type: "numeric",
+            access: 3,
+            unit: "L",
+            value_min: 0,
+            value_max: 100,
+            value_step: 1,
+            default: 5,
+        });
+        expect(schema[1]).toStrictEqual({name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"});
+        expect(schema[2]).toStrictEqual({name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"});
+        expect(schema[3]).toStrictEqual({name: "note", property: "note", label: "Note", type: "text", access: 3});
+        expect(schema[4].features).toStrictEqual([
+            {name: "monday", property: "monday", label: "Monday", type: "binary", access: 3, value_on: true, value_off: false},
+        ]);
     });
 });

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1186,14 +1186,17 @@ describe("Extension: HomeAssistant", () => {
         expect(payload.value_template).toBe("{{ value_json['led_effect'] | tojson }}");
         expect(payload.json_attributes_topic).toBe("zigbee2mqtt/inovelli_switch");
         expect(payload.icon).toBe("mdi:tune-variant");
-        expect(payload.json_attributes_template).toContain("'z2m_composite'");
-        expect(payload.json_attributes_template).toContain("'set_topic': 'zigbee2mqtt/inovelli_switch/set'");
 
-        const schemaMatch = (payload.json_attributes_template as string).match(/'schema_b64': '([^']+)'/);
-        expect(schemaMatch).not.toBeNull();
-        const schema = JSON.parse(Buffer.from(schemaMatch![1], "base64").toString("utf8"));
-        expect(schema.property).toBe("led_effect");
-        expect(schema.features.map((f: {name: string}) => f.name)).toStrictEqual(["effect", "color", "level", "duration"]);
+        // The attributes template is literal JSON (schema/property/set_topic) with only the live `value`
+        // filled via a single Jinja expression. Replacing that expression with `null` must yield valid
+        // JSON, which also documents the shape the card consumes.
+        const template = payload.json_attributes_template as string;
+        expect(template).toContain("\"value\": {{ value_json['led_effect'] | tojson }}");
+        const attributes = JSON.parse(template.replace(/\{\{.*?\}\}/, "null"));
+        expect(attributes.z2m_composite.property).toBe("led_effect");
+        expect(attributes.z2m_composite.set_topic).toBe("zigbee2mqtt/inovelli_switch/set");
+        expect(attributes.z2m_composite.schema.property).toBe("led_effect");
+        expect(attributes.z2m_composite.schema.features.map((f: {name: string}) => f.name)).toStrictEqual(["effect", "color", "level", "duration"]);
     });
 
     it("Should discover devices with speed-controlled fan", () => {
@@ -3437,9 +3440,9 @@ describe("Extension: HomeAssistant", () => {
 
 describe("HomeAssistant: composite schema", () => {
     it("serializes all feature field types and nested features", () => {
-        // Build a synthetic composite feature tree covering numeric/enum/binary/text/nested composite,
-        // including an explicit `default` (from zigbee-herdsman-converters `withDefault`) so the card
-        // can pre-fill new/empty composite slots.
+        // Build a synthetic composite feature tree covering numeric/enum/binary/text/nested composite.
+        // The card derives its own field defaults from the schema (numeric→value_min, enum→first value,
+        // binary→value_off, text→''), so no per-feature default is needed here.
         const features = [
             {
                 name: "amount",
@@ -3451,7 +3454,6 @@ describe("HomeAssistant: composite schema", () => {
                 value_min: 0,
                 value_max: 100,
                 value_step: 1,
-                default: 5,
             },
             {name: "mode", property: "mode", label: "Mode", type: "enum", access: 3, values: ["a", "b"], description: "The mode"},
             {name: "enabled", property: "enabled", label: "Enabled", type: "binary", access: 3, value_on: "ON", value_off: "OFF"},
@@ -3478,7 +3480,6 @@ describe("HomeAssistant: composite schema", () => {
             value_min: 0,
             value_max: 100,
             value_step: 1,
-            default: 5,
         });
         expect(schema[1]).toStrictEqual({
             name: "mode",


### PR DESCRIPTION
## Summary

Discovers a **settable `composite`** expose as a stock `sensor` entity whose state holds the current composite value and whose attributes carry the composite **schema**, **property** and **set-topic**. This lets an external custom Lovelace card render an editor for all fields and write the whole object back in a single atomic `set`.

## Why

Home Assistant MQTT discovery has **no composite/form entity** and cannot group sibling entities or build a custom form. A `composite` must be written to the device as **one complete object** in a single message; independently writing fields is not supported and breaks devices like the SONOFF valve (see zigbee-herdsman-converters #12495 / #12510, reverted by #12647). Previously a settable composite got no editable entity (only a read-only truncated JSON sensor). This keeps working on **stock Home Assistant** — the card is optional and installed separately.

Per the discussion on #32362 / #32363, this intentionally does **not** revive the generic composite→scalar split; a composite stays atomic and is edited as one object.

## How
- New `sensor` for settable composites (skips the existing `warning` siren special-case).
- `state_topic` + `value_template` (`| tojson`) carry the current composite value.
- `json_attributes_topic`/`json_attributes_template` carry `z2m_composite = {property, set_topic, schema, value}`. The template is **literal JSON** (schema/property/set_topic serialized with `stringify`) with only the live `value` filled via a single Jinja expression — no base64 / dict-literal hacks; the card reads `z2m_composite.schema` directly as an object.
- `json_attributes_topic: true` shorthand resolves to the state topic (like `state_topic`).
- No new staging store — reuses the existing atomic single-object `set` path. No zigbee-herdsman-converters change required (the card derives field defaults from the schema).

## Tests
- Discovery test for a settable composite (Inovelli `led_effect`) asserting the attributes template is valid JSON and carries the schema/value/set-topic.
- Unit test for the schema serializer across all feature types incl. nested composites.

## Future: native Home Assistant integration path

This PR is deliberately shaped so the same `z2m_composite` contract can later be consumed **natively** by Home Assistant, without a custom card:

1. **Short term (this PR + card):** stock `sensor` + `z2m_composite` attributes + a HACS custom card.
2. **Medium term:** promote `z2m_composite` to a small documented discovery convention (schema shape + `set_topic`), so other frontends/cards can consume it.
3. **Long term (home-assistant/core):** add an MQTT `composite`/form platform to HA that reads the same schema and renders the editor natively (grouped more-info form + one atomic write). HA MQTT currently has no composite/form platform, so this needs an upstream architecture discussion first; the attribute/schema contract here is intended to be the input for that.

## Companion
- HACS custom card: `MaxRink/z2m-composite-card` (consumes `z2m_composite` and performs the atomic write).