### PR TITLE
fix: Discover HA device trigger when mqtt output = attribute_and_json + Add warnings about incompatible settings

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -501,7 +501,10 @@ export class HomeAssistant extends Extension {
 
     override async start(): Promise<void> {
         if (!settings.get().advanced.cache_state) {
-            logger.warning("In order for Home Assistant integration to work properly set `cache_state: true");
+            logger.warning("In order for Home Assistant integration to work properly, set `cache_state: true` under `advanced`");
+        }
+        if (settings.get().advanced.output !== "json") {
+            logger.warning("In order for Home Assistant integration to work properly, set `output: json` under `advanced`");
         }
 
         this.zigbee2MQTTVersion = (await utils.getZigbee2MQTTVersion(false)).version;

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1510,10 +1510,12 @@ export class HomeAssistant extends Extension {
          * Whenever a device publish an {action: *} we discover an MQTT device trigger sensor
          * and republish it to zigbee2mqtt/my_device/action
          */
-        if (settings.get().advanced.output === "json" && entity.isDevice() && entity.definition && data.message.action) {
+        if (entity.isDevice() && entity.definition && data.message.action) {
             const value = data.message.action.toString();
             await this.publishDeviceTriggerDiscover(entity, "action", value);
-            await this.mqtt.publish(`${data.entity.name}/action`, value, {});
+            if (settings.get().advanced.output === "json") {
+                await this.mqtt.publish(`${data.entity.name}/action`, value, {});
+            }
         }
     }
 

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -9,7 +9,7 @@
                 "enabled": {
                     "type": "boolean",
                     "title": "Enabled",
-                    "description": "Enable Home Assistant integration",
+                    "description": "Enable Home Assistant integration. Also check 'cache_state' and 'output' options under 'advanced'.",
                     "default": false,
                     "requiresRestart": true
                 },
@@ -748,7 +748,7 @@
                 "cache_state": {
                     "type": "boolean",
                     "title": "Cache state",
-                    "description": "MQTT message payload will contain all attributes, not only changed ones. Has to be true when integrating via Home Assistant",
+                    "description": "MQTT message payload will contain all attributes, not only changed ones. Must be true when integrating via Home Assistant",
                     "default": true
                 },
                 "cache_state_persistent": {
@@ -815,7 +815,7 @@
                     "type": "string",
                     "enum": ["attribute_and_json", "attribute", "json"],
                     "title": "MQTT output type",
-                    "description": "Examples when 'state' of a device is published json: topic: 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}' attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON' attribute_and_json: both json and attribute (see above)",
+                    "description": "How the 'state' of a device is published. json: topic 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}'. attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON'. attribute_and_json: both json and attribute (see above). Must be json when integrating via Home Assistant",
                     "default": "json"
                 },
                 "enable_external_js": {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1755,7 +1755,14 @@ describe("Extension: HomeAssistant", () => {
         settings.set(["advanced", "cache_state"], false);
         mockLogger.warning.mockClear();
         await resetExtension();
-        expect(mockLogger.warning).toHaveBeenCalledWith("In order for Home Assistant integration to work properly set `cache_state: true");
+        expect(mockLogger.warning).toHaveBeenCalledWith("In order for Home Assistant integration to work properly, set `cache_state: true` under `advanced`");
+    });
+
+    it("Should warn when starting with output attribute_and_json", async () => {
+        settings.set(["advanced", "output"], "attribute_and_json");
+        mockLogger.warning.mockClear();
+        await resetExtension();
+        expect(mockLogger.warning).toHaveBeenCalledWith("In order for Home Assistant integration to work properly, set `output: json` under `advanced`");
     });
 
     it("Should set missing values to null", async () => {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1755,14 +1755,18 @@ describe("Extension: HomeAssistant", () => {
         settings.set(["advanced", "cache_state"], false);
         mockLogger.warning.mockClear();
         await resetExtension();
-        expect(mockLogger.warning).toHaveBeenCalledWith("In order for Home Assistant integration to work properly, set `cache_state: true` under `advanced`");
+        expect(mockLogger.warning).toHaveBeenCalledWith(
+            "In order for Home Assistant integration to work properly, set `cache_state: true` under `advanced`",
+        );
     });
 
     it("Should warn when starting with output attribute_and_json", async () => {
         settings.set(["advanced", "output"], "attribute_and_json");
         mockLogger.warning.mockClear();
         await resetExtension();
-        expect(mockLogger.warning).toHaveBeenCalledWith("In order for Home Assistant integration to work properly, set `output: json` under `advanced`");
+        expect(mockLogger.warning).toHaveBeenCalledWith(
+            "In order for Home Assistant integration to work properly, set `output: json` under `advanced`",
+        );
     });
 
     it("Should set missing values to null", async () => {


### PR DESCRIPTION
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/26564

Thanks @eikelang for pointing this out! I added a warning when Z2M starts, and improved the description.

<img width="1105" height="123" alt="image" src="https://github.com/user-attachments/assets/3dfca8de-641e-4a1e-9dba-e4fe96e1e1af" />
