### PR TITLE
fix(ignore): Remove attribute_and_json warnings for HA

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -503,9 +503,6 @@ export class HomeAssistant extends Extension {
         if (!settings.get().advanced.cache_state) {
             logger.warning("In order for Home Assistant integration to work properly, set `cache_state: true` under `advanced`");
         }
-        if (settings.get().advanced.output !== "json") {
-            logger.warning("In order for Home Assistant integration to work properly, set `output: json` under `advanced`");
-        }
 
         this.zigbee2MQTTVersion = (await utils.getZigbee2MQTTVersion(false)).version;
         this.discoveryOrigin = {name: "Zigbee2MQTT", sw: this.zigbee2MQTTVersion, url: "https://www.zigbee2mqtt.io"};

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -485,6 +485,10 @@ export class HomeAssistant extends Extension {
             throw new Error("Home Assistant integration requires 'output: json' under 'advanced'");
         }
 
+        // TODO (Z2M 3.0.0): Prevent starting without cache_state, instead of warning
+        // if (!settings.get().advanced.cache_state) {
+        //     throw new Error("Home Assistant integration is not possible without caching states! Set `cache_state: true` under `advanced`");
+        // }
         const haSettings = settings.get().homeassistant;
         assert(haSettings.enabled, `Home Assistant extension created with setting 'enabled: false'`);
         this.discoveryTopic = haSettings.discovery_topic;
@@ -500,6 +504,7 @@ export class HomeAssistant extends Extension {
     }
 
     override async start(): Promise<void> {
+        // TODO (Z2M 3.0.0): Prevent starting without cache_state, instead of warning
         if (!settings.get().advanced.cache_state) {
             logger.warning("In order for Home Assistant integration to work properly, set `cache_state: true` under `advanced`");
         }

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -482,7 +482,7 @@ export class HomeAssistant extends Extension {
     ) {
         super(zigbee, mqtt, state, publishEntityState, eventBus, enableDisableExtension, restartCallback, addExtension);
         if (settings.get().advanced.output === "attribute") {
-            throw new Error("Home Assistant integration is not possible with attribute output!");
+            throw new Error("Home Assistant integration requires 'output: json' under 'advanced'");
         }
 
         const haSettings = settings.get().homeassistant;

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -815,7 +815,7 @@
                     "type": "string",
                     "enum": ["attribute_and_json", "attribute", "json"],
                     "title": "MQTT output type",
-                    "description": "How the 'state' of a device is published. json: topic 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}'. attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON'. attribute_and_json: both json and attribute (see above). Must be json when integrating via Home Assistant",
+                    "description": "How the 'state' of a device is published. json: topic 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}'. attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON'. attribute_and_json: both json and attribute (see above). Home Assistant needs json",
                     "default": "json"
                 },
                 "enable_external_js": {

--- a/lib/util/settings.schema.json
+++ b/lib/util/settings.schema.json
@@ -815,7 +815,7 @@
                     "type": "string",
                     "enum": ["attribute_and_json", "attribute", "json"],
                     "title": "MQTT output type",
-                    "description": "How the 'state' of a device is published. json: topic 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}'. attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON'. attribute_and_json: both json and attribute (see above). Home Assistant needs json",
+                    "description": "How the 'state' of a device is published. json: topic 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}'. attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON'. attribute_and_json: both json and attribute (see above). Home Assistant requires json",
                     "default": "json"
                 },
                 "enable_external_js": {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1739,7 +1739,7 @@ describe("Extension: HomeAssistant", () => {
 
         await expect(async () => {
             await controller.start();
-        }).rejects.toThrow("Home Assistant integration is not possible with attribute output!");
+        }).rejects.toThrow("Home Assistant integration requires 'output: json' under 'advanced'");
     });
 
     it("Should throw error when homeassistant.discovery_topic equals the mqtt.base_topic", async () => {

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1760,15 +1760,6 @@ describe("Extension: HomeAssistant", () => {
         );
     });
 
-    it("Should warn when starting with output attribute_and_json", async () => {
-        settings.set(["advanced", "output"], "attribute_and_json");
-        mockLogger.warning.mockClear();
-        await resetExtension();
-        expect(mockLogger.warning).toHaveBeenCalledWith(
-            "In order for Home Assistant integration to work properly, set `output: json` under `advanced`",
-        );
-    });
-
     it("Should set missing values to null", async () => {
         // https://github.com/Koenkk/zigbee2mqtt/issues/6987
         const device = devices.WSDCGQ11LM;


### PR DESCRIPTION
- clean-up previous PR https://github.com/Koenkk/zigbee2mqtt/pull/32603

I asked if I should remove the warning, but it was merged too quick 🙂
 
- HA: enabled + output: `attribute` = Z2M doesn't start, good
- HA: enabled + output: `json` = works, good
- HA: enabled + output: `attribute_and_json` = ?

Discovery for "device trigger" was not enabled for the last option. So I first added a warning.

But then I fixed discovery. I think that was the only issue, so we can remove the warning now?