### PR TITLE
chore: drop redundant types js yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
         "@biomejs/biome": "^2.5.3",
         "@types/finalhandler": "^1.2.3",
         "@types/humanize-duration": "^3.27.4",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^26.1.1",
         "@types/object-assign-deep": "^0.4.3",
         "@types/readable-stream": "4.0.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       '@types/humanize-duration':
         specifier: ^3.27.4
         version: 3.27.4
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -542,9 +539,6 @@ packages:
 
   '@types/humanize-duration@3.27.4':
     resolution: {integrity: sha512-yaf7kan2Sq0goxpbcwTQ+8E9RP6HutFBPv74T/IA/ojcHKhuKVlk2YFYyHhWZeLvZPzzLE3aatuQB4h0iqyyUA==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
@@ -1840,8 +1834,6 @@ snapshots:
   '@types/http-errors@2.0.5': {}
 
   '@types/humanize-duration@3.27.4': {}
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/node@26.1.1':
     dependencies:


### PR DESCRIPTION
`js-yaml` ships its own type definitions since v5.0.0 (`"types": "./dist/js-yaml.d.ts"`, also declared in `exports`). This project is on `^5.2.1`, so `@types/js-yaml` is dead weight — and it was still pinned to `^4.0.9`, types for the previous major.

`tsc --traceResolution` confirms it is already unused; the resolution is identical before and after this change:

```
======== Resolving module 'js-yaml' from 'lib/util/yaml.ts'. ========
Resolving real path for 'node_modules/js-yaml/dist/js-yaml.d.ts'
```

No source changes, `package.json` and the lockfile only.