### PR TITLE
fix: Avoid running resolveDefinition in parallel

### DIFF
--- a/lib/model/device.ts
+++ b/lib/model/device.ts
@@ -18,7 +18,7 @@ export default class Device {
     public zh: zh.Device;
     public definition?: zhc.Definition;
     private _definitionModelID?: string;
-    private _isResolving?: boolean;
+    #isResolvingDefinition?: boolean;
 
     get ieeeAddr(): string {
         return this.zh.ieeeAddr;
@@ -65,11 +65,11 @@ export default class Device {
     }
 
     async resolveDefinition(ignoreCache = false): Promise<void> {
-        if (this.interviewed && !this._isResolving && (!this.definition || this._definitionModelID !== this.zh.modelID || ignoreCache)) {
-            this._isResolving = true;
+        if (this.interviewed && !this.#isResolvingDefinition && (!this.definition || this._definitionModelID !== this.zh.modelID || ignoreCache)) {
+            this.#isResolvingDefinition = true;
             this.definition = await zhc.findByDevice(this.zh, true);
             this._definitionModelID = this.zh.modelID;
-            this._isResolving = false;
+            this.#isResolvingDefinition = false;
         }
     }
 

--- a/lib/model/device.ts
+++ b/lib/model/device.ts
@@ -18,6 +18,7 @@ export default class Device {
     public zh: zh.Device;
     public definition?: zhc.Definition;
     private _definitionModelID?: string;
+    private _isResolving?: boolean;
 
     get ieeeAddr(): string {
         return this.zh.ieeeAddr;
@@ -64,9 +65,11 @@ export default class Device {
     }
 
     async resolveDefinition(ignoreCache = false): Promise<void> {
-        if (this.interviewed && (!this.definition || this._definitionModelID !== this.zh.modelID || ignoreCache)) {
+        if (this.interviewed && !this._isResolving && (!this.definition || this._definitionModelID !== this.zh.modelID || ignoreCache)) {
+            this._isResolving = true;
             this.definition = await zhc.findByDevice(this.zh, true);
             this._definitionModelID = this.zh.modelID;
+            this._isResolving = false;
         }
     }
 


### PR DESCRIPTION
Guard the entry of `resolveDefinition` to avoid running it multiple times in parallel.

With large configs or sleepy devices that use analog clusters generateDefinition reads many attributes and thus takes very long. This can lead to parallel executions which results in a infinite readAttr loop.

I believe this could also be related to #32583 when users experience a stuck or corrupted state. In reality it isn't corrupted, just generateDefinition never finishes.