### PR TITLE
ci: compare the PR title from env instead of interpolating it into the shell

### DIFF
--- a/.github/workflows/fail-pr-to-master.yaml
+++ b/.github/workflows/fail-pr-to-master.yaml
@@ -10,8 +10,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Fail PR to master
+              env:
+                  PR_TITLE: ${{ github.event.pull_request.title }}
               run: |
-                  if [[ "${{ github.event.pull_request.title }}" == "chore(dev): release"* ]]; then
+                  if [[ "$PR_TITLE" == "chore(dev): release"* ]]; then
                     echo "PR title starts with 'chore(dev): release', allowing PR"
                   else
                     echo "Pull requests to the master branch are not allowed, target dev branch"


### PR DESCRIPTION
Hi, and thanks for Zigbee2MQTT.

In `.github/workflows/fail-pr-to-master.yaml`, the PR title is compared by interpolating it into the shell:

```yaml
run: |
  if [[ "${{ github.event.pull_request.title }}" == "chore(dev): release"* ]]; then
```

Actions expands `${{ ... }}` into the script text before bash runs, so the title becomes part of the script rather than a value being compared. A PR title is free text that anyone opening a PR chooses, and `$(...)` and backticks still run inside double quotes — so a title containing `$(...)` would execute on the runner instead of being matched against the prefix.

Being straight about the size of it: this workflow is `pull_request` with no explicit permissions block and no secrets in use, so a fork PR has a read-only token and there is nothing here worth stealing. What an injection would get is code execution in a throwaway job — and, more practically, the ability to make this guard behave unexpectedly, which is a shame for a job whose whole purpose is to be a gate.

The change binds the title to an environment variable:

```yaml
env:
    PR_TITLE: ${{ github.event.pull_request.title }}
run: |
    if [[ "$PR_TITLE" == "chore(dev): release"* ]]; then
```

The `"chore(dev): release"*` prefix match behaves identically, and the `exit 1` path is untouched, so PRs to `master` are still rejected exactly as before. Two lines added, one changed.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
