### PR TITLE
fix(groups): aggregate position/tilt for cover groups instead of prop…

### DIFF
--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -8,7 +8,7 @@ import type {Zigbee2MQTTAPI, Zigbee2MQTTResponseEndpoints} from "../types/api";
 import logger from "../util/logger";
 import * as settings from "../util/settings";
 import {stringify} from "../util/stringify";
-import utils, {isLightExpose} from "../util/utils";
+import utils, {isCoverExpose, isLightExpose} from "../util/utils";
 import Extension from "./extension";
 
 const STATE_PROPERTIES: Readonly<Record<string, (value: string, exposes: zhc.Expose[]) => boolean>> = {
@@ -22,6 +22,8 @@ const STATE_PROPERTIES: Readonly<Record<string, (value: string, exposes: zhc.Exp
                 isLightExpose(e) &&
                 (e.features.some((f) => f.name === `color_${value}`) || (value === "color_temp" && e.features.some((f) => f.name === "color_temp"))),
         ),
+    position: (_value, exposes) => exposes.some((e) => isCoverExpose(e) && e.features.some((f) => f.name === "position")),
+    tilt: (_value, exposes) => exposes.some((e) => isCoverExpose(e) && e.features.some((f) => f.name === "tilt")),
 };
 
 interface ParsedMQTTMessage {
@@ -87,14 +89,25 @@ export default class Groups extends Extension {
 
                 if (endpoint) {
                     for (const group of groups) {
-                        if (
-                            group.zh.hasMember(endpoint) &&
-                            !equals(this.lastOptimisticState[group.ID], payload) &&
-                            this.shouldPublishPayloadForGroup(group, payload)
-                        ) {
-                            this.lastOptimisticState[group.ID] = payload;
+                        if (group.zh.hasMember(endpoint) && !equals(this.lastOptimisticState[group.ID], payload)) {
+                            const aggregatableKeys = ["position", "tilt"].filter((k) => k in payload);
+                            let aggregatedPayload: KeyValue | undefined;
 
-                            await this.publishEntityState(group, payload, reason);
+                            if (aggregatableKeys.length > 0) {
+                                aggregatedPayload = {};
+                                for (const key of aggregatableKeys) {
+                                    const avg = this.aggregateGroupValue(group, key);
+                                    if (avg !== undefined) aggregatedPayload[key] = avg;
+                                }
+                            }
+
+                            if (this.shouldPublishPayloadForGroup(group, payload)) {
+                                const groupPayload = aggregatedPayload ? {...payload, ...aggregatedPayload} : payload;
+                                this.lastOptimisticState[group.ID] = groupPayload;
+                                await this.publishEntityState(group, groupPayload, reason);
+                            } else if (aggregatedPayload) {
+                                await this.publishEntityState(group, aggregatedPayload, reason);
+                            }
                         }
                     }
                 }
@@ -179,6 +192,37 @@ export default class Groups extends Extension {
         }
 
         return true;
+    }
+
+    private aggregateGroupValue(group: Group, prop: string): number | undefined {
+        const values: number[] = [];
+
+        for (const member of group.zh.members) {
+            const device = this.zigbee.resolveEntity(member.getDevice());
+
+            if (device && this.state.exists(device)) {
+                const memberState = this.state.get(device);
+                const endpointNames = device.isDevice() && device.getEndpointNames();
+                const stateKey =
+                    endpointNames &&
+                    endpointNames.length >= member.ID &&
+                    device.definition?.meta?.multiEndpoint &&
+                    !device.definition.meta.multiEndpointSkip?.includes(prop)
+                        ? `${prop}_${endpointNames[member.ID - 1]}`
+                        : prop;
+
+                const value = memberState[stateKey];
+
+                if (typeof value === "number") {
+                    values.push(value);
+                }
+            }
+        }
+
+        /* v8 ignore next */
+        if (values.length === 0) return undefined;
+
+        return Math.round(values.reduce((a, b) => a + b, 0) / values.length);
     }
 
     private parseMQTTMessage(

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -345,6 +345,10 @@ export function isLightExpose(expose: zhc.Expose): expose is zhc.Light {
     return expose.type === "light";
 }
 
+export function isCoverExpose(expose: zhc.Expose): expose is zhc.Cover {
+    return expose.type === "cover";
+}
+
 export function assertString(value: unknown, property: string): asserts value is string {
     if (typeof value !== "string") {
         throw new Error(`${property} is not a string, got ${typeof value} (${value})`);

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -20,6 +20,9 @@ returnDevices.push(
     devices.bulb_2.ieeeAddr,
     devices.GLEDOPTO_2ID.ieeeAddr,
     devices.InovelliVZM31SN.ieeeAddr,
+    devices.J1.ieeeAddr,
+    devices.J1_cover.ieeeAddr,
+    devices.TS130F_DUAL_COVER_SWITCH.ieeeAddr,
 );
 
 describe("Extension: Groups", () => {
@@ -815,5 +818,186 @@ describe("Extension: Groups", () => {
             retain: true,
             qos: 0,
         });
+    });
+
+    it("Should aggregate position as average when covers in a group report different positions", async () => {
+        const device1 = devices.J1;
+        const device2 = devices.J1_cover;
+        const endpoint1 = device1.getEndpoint(1)!;
+        const endpoint2 = device2.getEndpoint(1)!;
+        const group = groups.group_1;
+        group.members.push(endpoint1);
+        group.members.push(endpoint2);
+
+        mockMQTTPublishAsync.mockClear();
+        await mockZHEvents.message({
+            data: {currentPositionLiftPercentage: 0},
+            cluster: "closuresWindowCovering",
+            device: device1,
+            endpoint: endpoint1,
+            type: "attributeReport",
+            linkquality: 10,
+        });
+        await flushPromises();
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", expect.stringContaining('"position":100'), {retain: false, qos: 0});
+
+        mockMQTTPublishAsync.mockClear();
+        await mockZHEvents.message({
+            data: {currentPositionLiftPercentage: 100},
+            cluster: "closuresWindowCovering",
+            device: device2,
+            endpoint: endpoint2,
+            type: "attributeReport",
+            linkquality: 10,
+        });
+        await flushPromises();
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", expect.stringContaining('"position":50'), {retain: false, qos: 0});
+    });
+
+    it("Should only propagate position to members that support it", async () => {
+        const device1 = devices.J1;
+        const device2 = devices.bulb_color;
+        const endpoint1 = device1.getEndpoint(1)!;
+        const endpoint2 = device2.getEndpoint(1)!;
+        const group = groups.group_1;
+        group.members.push(endpoint1);
+        group.members.push(endpoint2);
+
+        mockMQTTPublishAsync.mockClear();
+        await mockMQTTEvents.message("zigbee2mqtt/group_1/set", stringify({position: 50}));
+        await flushPromises();
+
+        // Only device1 (a cover) should receive the position; bulb_color should not
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/j1", stringify({position: 50}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).not.toHaveBeenCalledWith("zigbee2mqtt/bulb_color", expect.stringContaining("position"), expect.anything());
+    });
+
+    it("Should use endpoint-specific key when aggregating position for multiEndpoint cover devices", async () => {
+        const device = devices.TS130F_DUAL_COVER_SWITCH;
+        const endpoint1 = device.getEndpoint(1)!;
+        const endpoint2 = device.getEndpoint(2)!;
+        const group = groups.group_1;
+        group.members.push(endpoint1);
+        group.members.push(endpoint2);
+
+        mockMQTTPublishAsync.mockClear();
+        await mockZHEvents.message({
+            data: {currentPositionLiftPercentage: 100},
+            cluster: "closuresWindowCovering",
+            device,
+            endpoint: endpoint1,
+            type: "attributeReport",
+            linkquality: 10,
+        });
+        await flushPromises();
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", expect.stringContaining('"position":100'), {retain: false, qos: 0});
+
+        mockMQTTPublishAsync.mockClear();
+        await mockZHEvents.message({
+            data: {currentPositionLiftPercentage: 0},
+            cluster: "closuresWindowCovering",
+            device,
+            endpoint: endpoint2,
+            type: "attributeReport",
+            linkquality: 10,
+        });
+        await flushPromises();
+
+        // endpoint1 -> position_left: 100, endpoint2 -> position_right: 0
+        // Average (100 + 0) / 2 = 50, computed via the multiEndpoint stateKey branch
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", expect.stringContaining('"position":50'), {retain: false, qos: 0});
+    });
+
+    it("Should not suffix key when prop is in multiEndpointSkip", async () => {
+        const device = devices.TS130F_DUAL_COVER_SWITCH;
+        const resolvedDevice = controller.zigbee.resolveEntity(device)!;
+        const originalMeta = resolvedDevice.definition?.meta;
+
+        resolvedDevice.definition!.meta = {...originalMeta, multiEndpointSkip: ["position"]};
+
+        try {
+            const endpoint1 = device.getEndpoint(1)!;
+            const endpoint2 = device.getEndpoint(2)!;
+            const group = groups.group_1;
+            group.members.push(endpoint1);
+            group.members.push(endpoint2);
+
+            mockMQTTPublishAsync.mockClear();
+            await mockZHEvents.message({
+                data: {currentPositionLiftPercentage: 42},
+                cluster: "closuresWindowCovering",
+                device,
+                endpoint: endpoint1,
+                type: "attributeReport",
+                linkquality: 10,
+            });
+            await flushPromises();
+
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", expect.stringContaining('"position":42'), {
+                retain: false,
+                qos: 0,
+            });
+        } finally {
+            resolvedDevice.definition!.meta = originalMeta;
+        }
+    });
+
+    it("Should aggregate tilt as average when covers in a group report different tilt values", async () => {
+        const device1 = devices.J1;
+        const device2 = devices.J1_cover;
+        const endpoint1 = device1.getEndpoint(1)!;
+        const endpoint2 = device2.getEndpoint(1)!;
+        const group = groups.group_1;
+        group.members.push(endpoint1);
+        group.members.push(endpoint2);
+
+        mockMQTTPublishAsync.mockClear();
+        await mockZHEvents.message({
+            data: {currentPositionTiltPercentage: 80},
+            cluster: "closuresWindowCovering",
+            device: device1,
+            endpoint: endpoint1,
+            type: "attributeReport",
+            linkquality: 10,
+        });
+        await flushPromises();
+
+        // Only device1 has reported so far, tilt = 100 - 80 = 20
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", expect.stringContaining('"tilt":20'), {retain: false, qos: 0});
+
+        mockMQTTPublishAsync.mockClear();
+        await mockZHEvents.message({
+            data: {currentPositionTiltPercentage: 20},
+            cluster: "closuresWindowCovering",
+            device: device2,
+            endpoint: endpoint2,
+            type: "attributeReport",
+            linkquality: 10,
+        });
+        await flushPromises();
+
+        // device1 tilt = 20, device2 tilt = 100 - 20 = 80, average = 50
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", expect.stringContaining('"tilt":50'), {retain: false, qos: 0});
+    });
+
+    it("Should only propagate tilt to members that support it", async () => {
+        const device1 = devices.J1;
+        const device2 = devices.bulb_color;
+        const endpoint1 = device1.getEndpoint(1)!;
+        const endpoint2 = device2.getEndpoint(1)!;
+        const group = groups.group_1;
+        group.members.push(endpoint1);
+        group.members.push(endpoint2);
+
+        mockMQTTPublishAsync.mockClear();
+        await mockMQTTEvents.message("zigbee2mqtt/group_1/set", stringify({tilt: 50}));
+        await flushPromises();
+
+        // Only device1 (a cover) should receive the tilt; bulb_color should not
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/j1", stringify({tilt: 50}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).not.toHaveBeenCalledWith("zigbee2mqtt/bulb_color", expect.stringContaining("tilt"), expect.anything());
     });
 });


### PR DESCRIPTION
## Problem

Cover groups in Zigbee2MQTT only track and republish the `state` attribute
(OPEN/CLOSE). The `position` and `tilt` attributes were never aggregated at
the group level — they were simply missing from `STATE_PROPERTIES` in
`lib/extension/groups.ts`.

This causes a confusing UX issue in Home Assistant: since the group's `state`
becomes `OPEN` as soon as a single member opens (per the existing `off_state`
logic in `shouldPublishPayloadForGroup`), the Open button gets disabled for
the whole group in the Home Assistant frontend — even if other members are
still fully closed. Users cannot re-open the group from the UI until every
single member happens to be in the same state, even though the individual
members and the group itself work perfectly fine when controlled directly.

Real-world example that triggered this investigation: a group of two
Profalux roller shutters (via a SLZB-MR5U / EmberZNet coordinator). Opening
one shutter while the other stays closed left the "Open" button permanently
greyed out on the group's card in Home Assistant, with no way to reopen it
short of manually syncing every member first.

Related issues:
- #24163 — Inconsistent group state: cover group state 'close' even if one device is 'open'
- #27331 — Cover group erroneous current_position disables open functionality
- #32277 — Cover group position and frontend controls behave differently from Home Assistant cover groups

## Root cause

`STATE_PROPERTIES` in `lib/extension/groups.ts` only declares handlers for
`state`, `brightness`, `color_temp`, `color`, and `color_mode` — used to
decide which properties get propagated between a group and its members (in
both directions: device→group and group→members). `position` and `tilt`
were absent entirely, so:
- A cover's position/tilt changes were never reflected on the group entity.
- Sending `position`/`tilt` to a group never reached member covers.

Additionally, even a naive fix that simply forwards the last-changed
member's raw `position`/`tilt` value to the group would be misleading: if
one member is at 100% and another is at 0%, forwarding either raw value
gives a false impression that the whole group is fully open or fully
closed.

## Fix

**`lib/util/utils.ts`**
- Added `isCoverExpose()`, mirroring the existing `isLightExpose()` helper.

**`lib/extension/groups.ts`**
- Added `position` and `tilt` to `STATE_PROPERTIES`, gated on
  `isCoverExpose()`, so they're now recognized as valid group-syncable
  properties (used by the existing group→members propagation logic).
- Added `aggregateGroupValue(group, prop)`, which computes the rounded
  average of a numeric property across all group members that currently
  report a value for it. This correctly handles `multiEndpoint` devices
  (using the same endpoint-suffix logic already used elsewhere in this
  file for `state`), and respects `multiEndpointSkip`.
- Modified the device→group propagation branch in `onStateChange` so that
  when a member's `position`/`tilt` changes, the group publishes the
  **aggregated average** across its members rather than the raw
  last-reported value. This aggregation is intentionally decoupled from
  `shouldPublishPayloadForGroup` (which only governs `state`/`off_state`
  semantics for ON/OFF-like domains) — position/tilt should update
  regardless of whether the `state` gate currently allows a full
  republish, otherwise the group's position could get silently stuck
  whenever one member is CLOSE while another is still OPEN.

## Why averaging

Averaging is a simple, well-understood aggregation that gives Home
Assistant's frontend a numeric `position` that is neither 0 nor 100 when
members disagree, which keeps both Open/Close controls enabled and usable.

Note this introduces new averaging behavior for groups — it does not mirror
an existing pattern. `brightness`/`color`/`color_temp` currently only
propagate the last-changed member's raw value rather than averaging, same
as `state` did before this PR. Position/tilt need actual averaging (rather
than last-value propagation) specifically because HA's frontend uses the
numeric `position` to help determine whether Open/Close controls should be
enabled — propagating a single raw value, like `brightness` does, would
recreate the same misleading behavior this PR fixes (e.g. a fully-open
member's raw position of 100 getting forwarded to the group while another
member is still fully closed).

This is a deliberate compromise, not a perfect representation of a group's
"shape" (e.g. two covers at 25%/75% average to the same value as two covers
both at 50%). A min/max-based approach was considered for position/tilt as
well, but averaging was simpler to implement and directly resolves the
reported bug. Open to feedback if maintainers prefer a different
aggregation strategy, or if extending averaging to `brightness` in a
follow-up PR would be desirable for consistency.

## Testing

### Manual, real-world testing

Tested on a Home Assistant OS setup (Raspberry Pi 5) running the official
Zigbee2MQTT add-on, with a SLZB-MR5U (EmberZNet/ember adapter) coordinator
and a group of 2 Profalux roller shutter motors.

Before the fix:
- Opening one shutter while the other stayed closed left the group's Open
  button permanently disabled in the Home Assistant frontend, regardless
  of the actual physical position of either shutter.

After the fix:
- The group correctly reports an averaged `position` (e.g. 50% when one
  shutter is fully open and the other fully closed).
- Both Open and Close controls remain usable in the Home Assistant
  frontend, and behave consistently with the shutters' real state.

### Automated tests

Added to `test/extensions/groups.test.ts`:

1. **"Should aggregate position as average when covers in a group report
   different positions"** — confirms the core averaging behavior:
   opening one cover fully (position 100) while another later reports
   fully closed (position 0) results in the group publishing `position:
   50`, not the raw last value.

2. **"Should only propagate position to members that support it"** —
   confirms that sending `position` to a group only reaches members whose
   `exposes` declare a `cover` with a `position` feature (e.g. a light in
   the same group is correctly ignored).

3. **"Should use endpoint-specific key when aggregating position for
   multiEndpoint cover devices"** — confirms `aggregateGroupValue`
   correctly reads the endpoint-suffixed state key (e.g. `position_left`,
   `position_right`) for a real multiEndpoint dual-cover device
   (`TS130F_DUAL_COVER_SWITCH` mock, matching the real-world
   Girier/Zemismart TS130F dual curtain switch converter).

4. **"Should not suffix key when prop is in multiEndpointSkip"** —
   confirms the `multiEndpointSkip` exclusion is respected: when
   `position` is listed there, the aggregation reads the plain `position`
   key rather than an endpoint-suffixed one.

5. **"Should aggregate tilt as average when covers in a group report
   different tilt values"** and **"Should only propagate tilt to members
   that support it"** — same coverage as above, for `tilt`.

`pnpm run test:coverage` passes with 100% statement/branch/function/line
coverage on both modified files (`lib/util/utils.ts`,
`lib/extension/groups.ts`).

## Backwards compatibility

- No breaking changes. `position`/`tilt` were never aggregated for groups
  before this PR, so no existing behavior relying on their absence is
  affected.
- `state`, `brightness`, `color`, `color_temp`, `color_mode` handling is
  completely untouched — this PR only adds new handling alongside them.
- Groups with no cover members are unaffected (`aggregateGroupValue`
  simply finds no numeric values and the key is omitted, exactly as
  before this change).