### PR TITLE
Support opening and closing states for SONOFF MINI-ZBRBS in Home Assistant

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -934,7 +934,7 @@ export class HomeAssistant extends Extension {
                     ?.features.find((f) => f.name === "tilt");
                 const motorState = allExposes
                     ?.filter(isEnumExpose)
-                    .find((e) => ["motor_state", "moving"].includes(e.name) && e.access === ACCESS_STATE);
+                    .find((e) => ["motor_state", "moving"].includes(e.name) && e.access & ACCESS_STATE);
                 const running = allExposes?.filter(isBinaryExpose)?.find((e) => e.name === "running");
 
                 const discoveryEntry: DiscoveryEntry = {


### PR DESCRIPTION
The motor's forward, reverse and stop states are exposed via `motor_run_status` which has the `STATE_GET` access property, hence the operator change. Reference [here](https://github.com/Koenkk/zigbee-herdsman-converters/blob/7c82f5e1ea68bbb88bc112b51634de050c11d35a/src/devices/sonoff.ts#L9797-L9802).

Related: https://github.com/Koenkk/zigbee2mqtt/issues/30923