### PR TITLE
fix(homeassistant): avoid duplicate door names

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1447,7 +1447,11 @@ export class HomeAssistant extends Extension {
 
             // Let Home Assistant generate entity name when device_class is present.
             // preserve_name allows device_class and explicit name to coexist (e.g. derived sensors).
-            if (entry.discovery_payload.device_class && entry.discovery_payload.name !== null && !NUMERIC_DISCOVERY_LOOKUP[firstExpose.name]?.preserve_name) {
+            if (
+                entry.discovery_payload.device_class &&
+                entry.discovery_payload.name !== null &&
+                !NUMERIC_DISCOVERY_LOOKUP[firstExpose.name]?.preserve_name
+            ) {
                 delete entry.discovery_payload.name;
             }
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1447,6 +1447,12 @@ export class HomeAssistant extends Extension {
                 delete entry.discovery_payload.name;
             }
 
+            const isContactSensor = entry.type === "binary_sensor" && firstExpose.name === "contact";
+            const isEndpointNameMissing = endpointName === undefined;
+            if (isContactSensor && isEndpointNameMissing) {
+                entry.discovery_payload.name = null;
+            }
+
             entry.endpoint = entity.isDevice() ? entity.endpoint(endpointName) : undefined;
         }
 

--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -401,6 +401,10 @@ const applyHomeAssistantExposeMetadata = (payload: DiscoveryEntry, homeAssistant
         payload.discovery_payload.icon = homeAssistant.icon;
     }
 
+    if (homeAssistant.name !== undefined) {
+        payload.discovery_payload.name = homeAssistant.name;
+    }
+
     if (homeAssistant.valueTemplate !== undefined) {
         if (homeAssistant.valueTemplate === null) {
             delete payload.discovery_payload.value_template;
@@ -1443,14 +1447,8 @@ export class HomeAssistant extends Extension {
 
             // Let Home Assistant generate entity name when device_class is present.
             // preserve_name allows device_class and explicit name to coexist (e.g. derived sensors).
-            if (entry.discovery_payload.device_class && !NUMERIC_DISCOVERY_LOOKUP[firstExpose.name]?.preserve_name) {
+            if (entry.discovery_payload.device_class && entry.discovery_payload.name !== null && !NUMERIC_DISCOVERY_LOOKUP[firstExpose.name]?.preserve_name) {
                 delete entry.discovery_payload.name;
-            }
-
-            const isContactSensor = entry.type === "binary_sensor" && firstExpose.name === "contact";
-            const isEndpointNameMissing = endpointName === undefined;
-            if (isContactSensor && isEndpointNameMissing) {
-                entry.discovery_payload.name = null;
             }
 
             entry.endpoint = entity.isDevice() ? entity.endpoint(endpointName) : undefined;

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -247,6 +247,33 @@ describe("Extension: HomeAssistant", () => {
         expect(textConfig.discovery_payload.entity_category).toStrictEqual("config");
     });
 
+    it("Should use the device name for contact sensors without an endpoint", () => {
+        const getDiscoveryConfig = (expose: zhc.Expose): KeyValueAny => {
+            const device = {
+                definition: {},
+                isDevice: (): boolean => true,
+                isGroup: (): boolean => false,
+                endpoint: () => undefined,
+                options: {},
+                exposes: (): zhc.Expose[] => [expose],
+                zh: {endpoints: []},
+            };
+            // @ts-expect-error private method and minimal test device
+            return extension.getConfigs(device)[0];
+        };
+
+        const endpointlessContact = new zhc.Binary("contact", zhc.access.STATE, false, true);
+        const contactConfig = getDiscoveryConfig(endpointlessContact);
+
+        expect(contactConfig.discovery_payload.name).toBeNull();
+        expect(contactConfig.discovery_payload.device_class).toStrictEqual("door");
+
+        const endpointContact = new zhc.Binary("contact", zhc.access.STATE, false, true).withEndpoint("left");
+        const endpointConfig = getDiscoveryConfig(endpointContact);
+
+        expect(endpointConfig.discovery_payload).not.toHaveProperty("name");
+    });
+
     it("Should apply expose-level Home Assistant discovery metadata", () => {
         const createDevice = (exposes: zhc.Expose[]): Device =>
             ({

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -247,7 +247,7 @@ describe("Extension: HomeAssistant", () => {
         expect(textConfig.discovery_payload.entity_category).toStrictEqual("config");
     });
 
-    it("Should use the device name for contact sensors without an endpoint", () => {
+    it("Should set the name of contact sensors without an endpoint to null", () => {
         const getDiscoveryConfig = (expose: zhc.Expose): KeyValueAny => {
             const device = {
                 definition: {},

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -247,33 +247,6 @@ describe("Extension: HomeAssistant", () => {
         expect(textConfig.discovery_payload.entity_category).toStrictEqual("config");
     });
 
-    it("Should set the name of contact sensors without an endpoint to null", () => {
-        const getDiscoveryConfig = (expose: zhc.Expose): KeyValueAny => {
-            const device = {
-                definition: {},
-                isDevice: (): boolean => true,
-                isGroup: (): boolean => false,
-                endpoint: () => undefined,
-                options: {},
-                exposes: (): zhc.Expose[] => [expose],
-                zh: {endpoints: []},
-            };
-            // @ts-expect-error private method and minimal test device
-            return extension.getConfigs(device)[0];
-        };
-
-        const endpointlessContact = new zhc.Binary("contact", zhc.access.STATE, false, true);
-        const contactConfig = getDiscoveryConfig(endpointlessContact);
-
-        expect(contactConfig.discovery_payload.name).toBeNull();
-        expect(contactConfig.discovery_payload.device_class).toStrictEqual("door");
-
-        const endpointContact = new zhc.Binary("contact", zhc.access.STATE, false, true).withEndpoint("left");
-        const endpointConfig = getDiscoveryConfig(endpointContact);
-
-        expect(endpointConfig.discovery_payload).not.toHaveProperty("name");
-    });
-
     it("Should apply expose-level Home Assistant discovery metadata", () => {
         const createDevice = (exposes: zhc.Expose[]): Device =>
             ({
@@ -306,6 +279,25 @@ describe("Extension: HomeAssistant", () => {
             icon: "mdi:flash",
         });
         expect(configs.find((config) => config.object_id === "voltage")?.discovery_payload).not.toHaveProperty("type");
+    });
+
+    it("Should set discovery name to null when expose specifies homeassistant name null", () => {
+        const createDevice = (exposes: zhc.Expose[]): Device =>
+            ({
+                definition: {},
+                isDevice: (): boolean => true,
+                isGroup: (): boolean => false,
+                endpoint: () => undefined,
+                options: {},
+                exposes: (): zhc.Expose[] => exposes,
+                zh: {endpoints: []},
+            }) as Device;
+
+        const contactExpose = new zhc.Binary("contact", zhc.access.STATE, false, true).withHomeAssistant({name: null});
+
+        // @ts-expect-error private
+        const configs = extension.getConfigs(createDevice([contactExpose]));
+        expect(configs.find((config) => config.object_id === "contact")?.discovery_payload.name).toBeNull();
     });
 
     it("Should discover devices and groups", async () => {


### PR DESCRIPTION
## Summary

Handles `name` property from exposed Home Assistant metadata. 

## Notes

When set to `null`, the discovery payload keeps name as `null` instead of deleting it, so Home Assistant uses the device name without appending a suffix (e.g. `Washing Machine Door` instead of `Washing Machine Door Door`).

Related to #21092
Depends on https://github.com/Koenkk/zigbee-herdsman-converters/pull/12850