### PR TITLE
fix(controller): don't crash on a null color in attribute output

### DIFF
--- a/lib/controller.ts
+++ b/lib/controller.ts
@@ -465,7 +465,10 @@ export class Controller {
             let message: string | undefined;
 
             // Special cases
-            if (key === "color" && utils.objectHasProperties(subPayload, ["r", "g", "b"])) {
+            // `objectHasProperties` indexes its argument, so it has to be given an object.
+            // The null check three lines below is too late: `color` is nullable like any
+            // other attribute, and a null one reaches here before that branch runs.
+            if (key === "color" && subPayload != null && utils.objectHasProperties(subPayload, ["r", "g", "b"])) {
                 subPayload = [subPayload.r, subPayload.g, subPayload.b];
             }
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1061,6 +1061,17 @@ describe("Controller", () => {
         );
     });
 
+    it("Publish entity state attribute output with a null color", async () => {
+        await controller.start();
+        settings.set(["advanced", "output"], "attribute_and_json");
+        mockMQTTPublishAsync.mockClear();
+        const device = getZ2MDevice("bulb");
+        await controller.publishEntityState(device, {state: "ON", color: null});
+        await flushPromises();
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb/state", "ON", {qos: 0, retain: true});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb/color", "", {qos: 0, retain: true});
+    });
+
     it("Publish entity state attribute_json output filtered", async () => {
         await controller.start();
         settings.set(["advanced", "output"], "attribute_and_json");


### PR DESCRIPTION
Publishing an entity state where `color` is `null` throws, and the whole publish for that entity is lost:

```
TypeError: Cannot read properties of null (reading 'r')
    at objectHasProperties (lib/util/utils.ts)
    at Controller.iteratePayloadAttributeOutput (lib/controller.ts)
```

`iteratePayloadAttributeOutput` runs the `color` special case before it checks the value:

```ts
// Special cases
if (key === "color" && utils.objectHasProperties(subPayload, ["r", "g", "b"])) {
    subPayload = [subPayload.r, subPayload.g, subPayload.b];
}

// Check Array first, since it is also an Object
if (subPayload === null || subPayload === undefined) {
    message = "";
}
```

`objectHasProperties` indexes what it is given, so a `null` never reaches the branch three lines below that already knows what to do with it. Every other attribute publishes an empty string when it is null, and `color` is nullable like any of them.

Only reachable with `advanced.output` set to `attribute` or `attribute_and_json`; the JSON output does not go through this function.

## The change

One guard in the condition. I put it at the call site rather than inside `objectHasProperties`, because that helper declares its parameter as an object and the value here is still untyped when it arrives from the payload. Happy to move it into the helper instead if you would rather have the class covered once: it is the only caller.

Nothing else changes. A `color` that is a `{r, g, b}` object still becomes `"1,2,3"`, and one that is a string or a number still falls through untouched, since indexing those already answered `false` without throwing.

## Tests

One case added to `test/controller.test.ts`, next to the other `attribute_and_json` output tests. It asserts that `state` still publishes and that `color` publishes an empty string.

```
sem a correcao:  Tests  1 failed   (TypeError: Cannot read properties of null (reading 'r'))
com a correcao:  Tests  85 passed
```

Full suite: 816 passed, 1 failed. The failure is `Extension: HomeAssistant > Should not have duplicate type/object_ids in a mapping`, which times out at 9071 ms under the parallel run and passes on its own in 1411 ms. It behaves the same way on a clean `dev`, so it is not from this change.

`npx biome check --error-on-warnings` is clean on both files.
