### PR TITLE
fix(receive): apply debounce to messages without payload

### DIFF
--- a/lib/extension/receive.ts
+++ b/lib/extension/receive.ts
@@ -180,8 +180,11 @@ export default class Receive extends Extension {
 
         if (!utils.objectIsEmpty(payload)) {
             await publish(payload);
-        } else {
-            await utils.publishLastSeen({device: data.device, reason: "messageEmitted"}, settings.get(), true, this.publishEntityState);
+        } else if (settings.get().advanced.last_seen && settings.get().advanced.last_seen !== "disable") {
+            // A message was received that produced no payload (e.g. a frame the converter has no data
+            // for). Publish through the regular publish() path so the per-device debounce/throttle
+            // still applies, instead of publishing the full cached state immediately via publishLastSeen.
+            await publish({});
         }
     }
 }

--- a/test/extensions/receive.test.ts
+++ b/test/extensions/receive.test.ts
@@ -190,6 +190,30 @@ describe("Extension: Receive", () => {
         expect(mockMQTTPublishAsync.mock.calls[1][0]).toStrictEqual("zigbee2mqtt/bridge/health");
     });
 
+    it("Should not bypass the debounce when a message produces no payload", async () => {
+        const device = devices.WSDCGQ11LM;
+        settings.set(["devices", device.ieeeAddr, "debounce"], 0.1);
+        settings.set(["advanced", "last_seen"], "ISO_8601");
+        // Attribute report without measuredValue: the lumi_temperature converter returns nothing.
+        const payload = {
+            data: {},
+            cluster: "msTemperatureMeasurement",
+            device,
+            endpoint: device.getEndpoint(1),
+            type: "attributeReport",
+            linkquality: 10,
+        };
+        await mockZHEvents.message(payload);
+        await flushPromises();
+        // The empty payload must not be published immediately (bypassing the debounce).
+        vi.advanceTimersByTime(50);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(0);
+        vi.runOnlyPendingTimers();
+        await flushPromises();
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
+        expect(mockMQTTPublishAsync.mock.calls[0][0]).toStrictEqual("zigbee2mqtt/weather_sensor");
+    });
+
     it("Should debounce and retain messages when set via device_options", async () => {
         const device = devices.WSDCGQ11LM;
         settings.set(["device_options", "debounce"], 0.1);


### PR DESCRIPTION
## Problem

When a fromZigbee converter returns no payload for a message (e.g. a frame the converter has no data for, like retransmissions or multi-cluster reports), Z2M falls back to `utils.publishLastSeen(...)`. That calls `publishEntityState` directly, which bypasses the per-device debounce and publishes the full cached state **immediately** for every such message — on top of the debounced publish.

On a PowerTag (greenPower) device with `debounce` set, this added roughly 3 extra full-state publishes per 5s reporting window.

## Fix

Route the empty-payload case through the regular `publish()` path so the per-device debounce/throttle still applies. The last_seen gating is preserved: when `advanced.last_seen` is disabled, nothing is published (same as before).

## Testing

Added a test that sends a message producing no payload to a debounced device and asserts no immediate publish happens and exactly one publish occurs after the debounce window. All 789 tests pass.

Verified in `receive.ts`: with `cache_state` enabled (default), `publishEntityState` publishes the full cached state, so `publishLastSeen` bypassing the debounce produced the extra publishes.