### PR TITLE
feat(groups): publish aggregate member state as group_state

### DIFF
--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -198,13 +198,12 @@ export default class Groups extends Extension {
 
             if (device?.isDevice() && this.state.exists(device)) {
                 const state = this.state.get(device);
-                const endpointNames = device.getEndpointNames();
+                const endpointName = device.endpointName(member);
                 const stateKey =
-                    endpointNames &&
-                    endpointNames.length >= member.ID &&
-                    device.definition?.meta?.multiEndpoint &&
-                    !device.definition.meta.multiEndpointSkip?.includes("state")
-                        ? `state_${endpointNames[member.ID - 1]}`
+                    endpointName &&
+                    !device.definition?.meta?.multiEndpointSkip?.includes("state") &&
+                    (device.definition?.meta?.multiEndpoint || state.state === undefined)
+                        ? `state_${endpointName}`
                         : "state";
 
                 const memberState = state[stateKey];

--- a/lib/extension/groups.ts
+++ b/lib/extension/groups.ts
@@ -35,9 +35,14 @@ interface ParsedMQTTMessage {
     skipDisableReporting: boolean;
 }
 
+type ActiveState = "ON" | "OPEN";
+type InactiveState = "OFF" | "CLOSE";
+type GroupState = ActiveState | InactiveState | "PARTIAL";
+
 export default class Groups extends Extension {
     #topicRegex = new RegExp(`^${settings.get().mqtt.base_topic}/bridge/request/group/members/(remove|add|remove_all)$`);
     private lastOptimisticState: {[s: string]: KeyValue} = {};
+    private lastGroupState: {[s: string]: GroupState} = {};
 
     // biome-ignore lint/suspicious/useAwait: API
     override async start(): Promise<void> {
@@ -87,14 +92,14 @@ export default class Groups extends Extension {
 
                 if (endpoint) {
                     for (const group of groups) {
-                        if (
-                            group.zh.hasMember(endpoint) &&
-                            !equals(this.lastOptimisticState[group.ID], payload) &&
-                            this.shouldPublishPayloadForGroup(group, payload)
-                        ) {
-                            this.lastOptimisticState[group.ID] = payload;
+                        if (group.zh.hasMember(endpoint)) {
+                            if (!equals(this.lastOptimisticState[group.ID], payload) && this.shouldPublishPayloadForGroup(group, payload)) {
+                                this.lastOptimisticState[group.ID] = payload;
 
-                            await this.publishEntityState(group, payload, reason);
+                                await this.publishEntityState(group, payload, reason);
+                            } else {
+                                await this.publishGroupStateIfChanged(group, reason);
+                            }
                         }
                     }
                 }
@@ -103,6 +108,7 @@ export default class Groups extends Extension {
                 delete this.lastOptimisticState[entity.ID];
 
                 const groupsToPublish = new Set<Group>();
+                const memberStatePublishes: Promise<void>[] = [];
 
                 for (const member of entity.zh.members) {
                     const device = this.zigbee.resolveEntity(member.getDevice()) as Device;
@@ -129,41 +135,70 @@ export default class Groups extends Extension {
                         }
                     }
 
-                    await this.publishEntityState(device, memberPayload, reason);
+                    memberStatePublishes.push(this.publishEntityState(device, memberPayload, reason));
 
                     for (const zigbeeGroup of groups) {
-                        if (zigbeeGroup.zh.hasMember(member) && this.shouldPublishPayloadForGroup(zigbeeGroup, payload)) {
+                        if (zigbeeGroup.zh.hasMember(member)) {
                             groupsToPublish.add(zigbeeGroup);
                         }
                     }
                 }
 
+                // All publishEntityState calls must start before this await: they update the
+                // state cache synchronously, ensuring group_state sees all updated members.
+                await Promise.all(memberStatePublishes);
+
                 groupsToPublish.delete(entity);
 
                 for (const group of groupsToPublish) {
-                    await this.publishEntityState(group, payload, reason);
+                    if (this.shouldPublishPayloadForGroup(group, payload)) {
+                        await this.publishEntityState(group, payload, reason);
+                    } else {
+                        await this.publishGroupStateIfChanged(group, reason);
+                    }
                 }
             }
         }
     }
 
-    private shouldPublishPayloadForGroup(group: Group, payload: KeyValue): boolean {
-        return (
-            group.options.off_state === "last_member_state" ||
-            !payload ||
-            (payload.state !== "OFF" && payload.state !== "CLOSE") ||
-            this.areAllMembersOffOrClosed(group)
-        );
+    private async publishGroupStateIfChanged(group: Group, reason: StateChangeReason): Promise<void> {
+        const groupState = this.getGroupState(group);
+
+        if (groupState && this.lastGroupState[group.ID] !== groupState) {
+            await this.publishEntityState(group, {}, reason);
+        }
     }
 
-    private areAllMembersOffOrClosed(group: Group): boolean {
-        for (const member of group.zh.members) {
-            // biome-ignore lint/style/noNonNullAssertion: TODO: biome migration: valid from loop?
-            const device = this.zigbee.resolveEntity(member.getDevice())!;
+    override adjustMessageBeforePublish(entity: Group | Device, message: KeyValue): void {
+        if (entity instanceof Group) {
+            const groupState = this.getGroupState(entity);
 
-            if (this.state.exists(device)) {
+            if (groupState) {
+                message.group_state = groupState;
+                this.lastGroupState[entity.ID] = groupState;
+            }
+        }
+    }
+
+    private shouldPublishPayloadForGroup(group: Group, payload: KeyValue): boolean {
+        if (group.options.off_state === "last_member_state" || !payload || (payload.state !== "OFF" && payload.state !== "CLOSE")) {
+            return true;
+        }
+
+        const groupState = this.getGroupState(group);
+        return groupState === undefined || groupState === "OFF" || groupState === "CLOSE";
+    }
+
+    private getGroupState(group: Group): GroupState | undefined {
+        let activeState: ActiveState | undefined;
+        let inactiveState: InactiveState | undefined;
+
+        for (const member of group.zh.members) {
+            const device = this.zigbee.resolveEntity(member.getDevice());
+
+            if (device?.isDevice() && this.state.exists(device)) {
                 const state = this.state.get(device);
-                const endpointNames = device.isDevice() && device.getEndpointNames();
+                const endpointNames = device.getEndpointNames();
                 const stateKey =
                     endpointNames &&
                     endpointNames.length >= member.ID &&
@@ -172,13 +207,31 @@ export default class Groups extends Extension {
                         ? `state_${endpointNames[member.ID - 1]}`
                         : "state";
 
-                if (state[stateKey] === "ON" || state[stateKey] === "OPEN") {
-                    return false;
+                const memberState = state[stateKey];
+
+                if (memberState === "ON" || memberState === "OPEN") {
+                    activeState = memberState;
+                } else if (memberState === "OFF" || memberState === "CLOSE") {
+                    inactiveState = memberState;
+                }
+
+                if (activeState && inactiveState) {
+                    return "PARTIAL";
                 }
             }
         }
 
-        return true;
+        const state = this.state.exists(group) ? this.state.get(group).state : undefined;
+
+        if (activeState) {
+            return state === "ON" || state === "OPEN" ? state : activeState;
+        }
+
+        if (inactiveState) {
+            return state === "OFF" || state === "CLOSE" ? state : inactiveState;
+        }
+
+        return undefined;
     }
 
     private parseMQTTMessage(

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -268,7 +268,10 @@ describe("Extension: Groups", () => {
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/GLEDOPTO_2ID", stringify({state_cct: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/gledopto_group", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/gledopto_group", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
         expect(group.command).toHaveBeenCalledTimes(1);
         expect(group.command).toHaveBeenCalledWith("genOnOff", "on", {}, {});
     });
@@ -281,7 +284,10 @@ describe("Extension: Groups", () => {
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/GLEDOPTO_2ID", stringify({state_cct: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/gledopto_group", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/gledopto_group", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
         expect(group.command).toHaveBeenCalledTimes(0);
     });
 

--- a/test/extensions/groups.test.ts
+++ b/test/extensions/groups.test.ts
@@ -61,7 +61,10 @@ describe("Extension: Groups", () => {
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should not republish identical optimistic group states", async () => {
@@ -87,12 +90,24 @@ describe("Extension: Groups", () => {
         });
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(6);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_tradfri_remote", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_tradfri_remote", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_2", stringify({state: "ON"}), {retain: false, qos: 0});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color_2", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_with_tradfri", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/ha_discovery_group", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/switch_group", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_with_tradfri", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/ha_discovery_group", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/switch_group", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should publish state change of all members when a group changes its state", async () => {
@@ -106,7 +121,91 @@ describe("Extension: Groups", () => {
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
+    });
+
+    it("Should ignore unrecognized member states when calculating the group state", async () => {
+        const device1 = devices.bulb_color;
+        const device2 = devices.bulb;
+        const group = groups.group_1;
+        group.members.push(device1.getEndpoint(1)!);
+        group.members.push(device2.getEndpoint(1)!);
+        const resolvedDevice1 = controller.zigbee.resolveEntity(device1)!;
+        const resolvedDevice2 = controller.zigbee.resolveEntity(device2)!;
+        const resolvedGroup = controller.zigbee.resolveEntity(group.groupID)!;
+
+        controller.state.set(resolvedDevice1, {state: "OPEN"}, "groupOptimistic");
+        controller.state.set(resolvedDevice2, {state: "UNKNOWN"}, "groupOptimistic");
+        await controller.publishEntityState(resolvedGroup, {brightness: 100}, "groupOptimistic");
+
+        expect(mockMQTTPublishAsync).toHaveBeenLastCalledWith("zigbee2mqtt/group_1", stringify({brightness: 100, group_state: "OPEN"}), {
+            retain: false,
+            qos: 0,
+        });
+
+        controller.state.set(resolvedDevice2, {state: "CLOSE"}, "groupOptimistic");
+        await controller.publishEntityState(resolvedGroup, {brightness: 101}, "groupOptimistic");
+
+        expect(mockMQTTPublishAsync).toHaveBeenLastCalledWith("zigbee2mqtt/group_1", stringify({brightness: 101, group_state: "PARTIAL"}), {
+            retain: false,
+            qos: 0,
+        });
+
+        controller.state.set(resolvedDevice1, {state: "UNKNOWN"}, "groupOptimistic");
+        await controller.publishEntityState(resolvedGroup, {brightness: 102}, "groupOptimistic");
+
+        expect(mockMQTTPublishAsync).toHaveBeenLastCalledWith("zigbee2mqtt/group_1", stringify({brightness: 102, group_state: "CLOSE"}), {
+            retain: false,
+            qos: 0,
+        });
+
+        controller.state.set(resolvedDevice2, {state: "UNKNOWN"}, "groupOptimistic");
+        await controller.publishEntityState(resolvedGroup, {brightness: 103}, "groupOptimistic");
+
+        expect(mockMQTTPublishAsync).toHaveBeenLastCalledWith("zigbee2mqtt/group_1", stringify({brightness: 103}), {retain: false, qos: 0});
+    });
+
+    it("Should preserve the state value in group_state when members have the same active or inactive status", async () => {
+        const device1 = devices.bulb_color;
+        const device2 = devices.bulb;
+        const group = groups.group_1;
+        group.members.push(device1.getEndpoint(1)!, device2.getEndpoint(1)!);
+        const resolvedDevice1 = controller.zigbee.resolveEntity(device1)!;
+        const resolvedDevice2 = controller.zigbee.resolveEntity(device2)!;
+        const resolvedGroup = controller.zigbee.resolveEntity(group.groupID)!;
+
+        controller.state.set(resolvedDevice1, {state: "ON"}, "groupOptimistic");
+        controller.state.set(resolvedDevice2, {state: "OPEN"}, "groupOptimistic");
+
+        await controller.publishEntityState(resolvedGroup, {state: "OPEN"}, "groupOptimistic");
+        expect(mockMQTTPublishAsync).toHaveBeenLastCalledWith("zigbee2mqtt/group_1", stringify({state: "OPEN", group_state: "OPEN"}), {
+            retain: false,
+            qos: 0,
+        });
+
+        await controller.publishEntityState(resolvedGroup, {state: "ON"}, "groupOptimistic");
+        expect(mockMQTTPublishAsync).toHaveBeenLastCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
+
+        controller.state.set(resolvedDevice1, {state: "OFF"}, "groupOptimistic");
+        controller.state.set(resolvedDevice2, {state: "CLOSE"}, "groupOptimistic");
+
+        await controller.publishEntityState(resolvedGroup, {state: "CLOSE"}, "groupOptimistic");
+        expect(mockMQTTPublishAsync).toHaveBeenLastCalledWith("zigbee2mqtt/group_1", stringify({state: "CLOSE", group_state: "CLOSE"}), {
+            retain: false,
+            qos: 0,
+        });
+
+        await controller.publishEntityState(resolvedGroup, {state: "OFF"}, "groupOptimistic");
+        expect(mockMQTTPublishAsync).toHaveBeenLastCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF", group_state: "OFF"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should not publish state change when group changes state and device is disabled", async () => {
@@ -135,21 +234,30 @@ describe("Extension: Groups", () => {
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
 
         mockMQTTPublishAsync.mockClear();
         await mockMQTTEvents.message("zigbee2mqtt/group_1/set", stringify({state: "OFF"}));
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF", group_state: "OFF"}), {
+            retain: false,
+            qos: 0,
+        });
 
         mockMQTTPublishAsync.mockClear();
         await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "ON"}));
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should publish state of device with endpoint name", async () => {
@@ -192,23 +300,33 @@ describe("Extension: Groups", () => {
             retain: false,
             qos: 0,
         });
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
-    it("Shouldnt publish group state change when a group is not optimistic", async () => {
+    it("Should apply optimistic independently to groups with shared members", async () => {
         const device = devices.bulb_color;
         const endpoint = device.getEndpoint(1)!;
-        const group = groups.group_1;
-        group.members.push(endpoint);
-        settings.set(["groups"], {1: {friendly_name: "group_1", optimistic: false, retain: false}});
+        groups.group_1.members.push(endpoint);
+        groups.group_2.members.push(endpoint);
+        settings.set(["groups"], {
+            1: {friendly_name: "group_1", optimistic: false, retain: false},
+            2: {friendly_name: "group_2", retain: false},
+        });
 
         mockMQTTPublishAsync.mockClear();
         const payload = {data: {onOff: 1}, cluster: "genOnOff", device, endpoint, type: "attributeReport", linkquality: 10};
         await mockZHEvents.message(payload);
         await flushPromises();
 
-        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_2", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should publish state change of another group with shared device when a group changes its state", async () => {
@@ -222,40 +340,38 @@ describe("Extension: Groups", () => {
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_2", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_2", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
-    it("Should not publish state change off if any lights within are still on when changed via device", async () => {
+    it("Should keep independent off_state and group_state for shared groups", async () => {
         const device_1 = devices.bulb_color;
         const device_2 = devices.bulb;
         const endpoint_1 = device_1.getEndpoint(1)!;
         const endpoint_2 = device_2.getEndpoint(1)!;
-        const group = groups.group_1;
-        group.members.push(endpoint_1);
-        group.members.push(endpoint_2);
-
-        await mockMQTTEvents.message("zigbee2mqtt/group_1/set", stringify({state: "ON"}));
-        await flushPromises();
-        mockMQTTPublishAsync.mockClear();
-
-        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "OFF"}));
-        await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
-    });
-
-    it("Should publish state change off if any lights within are still on when changed via device when off_state: last_member_state is used", async () => {
-        const device_1 = devices.bulb_color;
-        const device_2 = devices.bulb;
-        const endpoint_1 = device_1.getEndpoint(1)!;
-        const endpoint_2 = device_2.getEndpoint(1)!;
-        const group = groups.group_1;
-        group.members.push(endpoint_1);
-        group.members.push(endpoint_2);
+        groups.group_1.members.push(endpoint_1, endpoint_2);
+        groups.group_2.members.push(endpoint_1, endpoint_2);
         settings.set(["groups"], {
             1: {friendly_name: "group_1", retain: false, off_state: "last_member_state"},
+            2: {friendly_name: "group_2", retain: false, off_state: "all_members_off"},
         });
+
+        const expectGroupStates = (lastMemberState: string, allMembersState: string, groupState: string): void => {
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: lastMemberState, group_state: groupState}), {
+                retain: false,
+                qos: 0,
+            });
+            expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_2", stringify({state: allMembersState, group_state: groupState}), {
+                retain: false,
+                qos: 0,
+            });
+        };
 
         await mockMQTTEvents.message("zigbee2mqtt/group_1/set", stringify({state: "ON"}));
         await flushPromises();
@@ -263,9 +379,49 @@ describe("Extension: Groups", () => {
 
         await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "OFF"}));
         await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
-        expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(1, "zigbee2mqtt/group_1", stringify({state: "OFF"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(2, "zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
+        expectGroupStates("OFF", "ON", "PARTIAL");
+
+        mockMQTTPublishAsync.mockClear();
+        await mockMQTTEvents.message("zigbee2mqtt/bulb/set", stringify({state: "OFF"}));
+        await flushPromises();
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
+        expectGroupStates("OFF", "OFF", "OFF");
+
+        mockMQTTPublishAsync.mockClear();
+        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "ON"}));
+        await flushPromises();
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
+        expectGroupStates("ON", "ON", "PARTIAL");
+
+        mockMQTTPublishAsync.mockClear();
+        await mockMQTTEvents.message("zigbee2mqtt/bulb/set", stringify({state: "ON"}));
+        await flushPromises();
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
+        expectGroupStates("ON", "ON", "ON");
+    });
+
+    it("Should publish group_state through JSON and attribute output", async () => {
+        const device_1 = devices.bulb_color;
+        const device_2 = devices.bulb;
+        const group = groups.group_1;
+        group.members.push(device_1.getEndpoint(1)!, device_2.getEndpoint(1)!);
+
+        await mockMQTTEvents.message("zigbee2mqtt/group_1/set", stringify({state: "ON"}));
+        await flushPromises();
+        settings.set(["advanced", "output"], "attribute_and_json");
+        mockMQTTPublishAsync.mockClear();
+
+        await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "OFF"}));
+        await flushPromises();
+
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(5);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "PARTIAL"}), {
+            retain: false,
+            qos: 0,
+        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1/state", "ON", {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1/group_state", "PARTIAL", {retain: false, qos: 0});
     });
 
     it("Should not publish state change off if any lights within with non default-ep are still on when changed via device", async () => {
@@ -283,8 +439,12 @@ describe("Extension: Groups", () => {
 
         await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "OFF"}));
         await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "PARTIAL"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should not publish state change off if any lights within are still on when changed via device with non default-ep", async () => {
@@ -305,8 +465,12 @@ describe("Extension: Groups", () => {
 
         await mockMQTTEvents.message("zigbee2mqtt/wall_switch_double/set", stringify({state_left: "OFF"}));
         await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(1);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/wall_switch_double", stringify({state_left: "OFF", state_right: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "PARTIAL"}), {
             retain: false,
             qos: 0,
         });
@@ -331,10 +495,17 @@ describe("Extension: Groups", () => {
         await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "OFF"}));
         await mockMQTTEvents.message("zigbee2mqtt/wall_switch_double/set", stringify({state_left: "OFF"}));
         await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(4);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/wall_switch_double", stringify({state_left: "OFF"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "PARTIAL"}), {
+            retain: false,
+            qos: 0,
+        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF", group_state: "OFF"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should publish state change off if all lights within turn off with non default-ep, but device state does not use them", async () => {
@@ -359,7 +530,10 @@ describe("Extension: Groups", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/wall_switch_double", stringify({state_left: "OFF"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF", group_state: "OFF"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should not publish state change off if any lights within are still on when changed via shared group", async () => {
@@ -377,9 +551,16 @@ describe("Extension: Groups", () => {
 
         await mockMQTTEvents.message("zigbee2mqtt/group_2/set", stringify({state: "OFF"}));
         await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_2", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_2", stringify({state: "OFF", group_state: "OFF"}), {
+            retain: false,
+            qos: 0,
+        });
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "PARTIAL"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should publish state change off if all lights within turn off", async () => {
@@ -401,10 +582,17 @@ describe("Extension: Groups", () => {
         await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({state: "OFF"}));
         await mockMQTTEvents.message("zigbee2mqtt/bulb/set", stringify({state: "OFF"}));
         await flushPromises();
-        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(3);
+        expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(4);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb", stringify({state: "OFF"}), {retain: true, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "ON", group_state: "PARTIAL"}), {
+            retain: false,
+            qos: 0,
+        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF", group_state: "OFF"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should only update group state with changed properties", async () => {
@@ -439,7 +627,7 @@ describe("Extension: Groups", () => {
         });
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
             "zigbee2mqtt/group_1",
-            stringify({color_mode: "color_temp", color_temp: 300, state: "ON"}),
+            stringify({color_mode: "color_temp", color_temp: 300, state: "ON", group_state: "PARTIAL"}),
             {retain: false, qos: 0},
         );
     });
@@ -466,7 +654,10 @@ describe("Extension: Groups", () => {
 
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb_color", stringify({state: "OFF"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/group_1", stringify({state: "OFF", group_state: "OFF"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Add to group via MQTT", async () => {

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -526,7 +526,7 @@ describe("Extension: Publish", () => {
         expect(group.command).toHaveBeenCalledWith("genOnOff", "on", {}, {});
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync.mock.calls[1][0]).toStrictEqual("zigbee2mqtt/hue_twilight_group");
-        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON"});
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON", group_state: "ON"});
     });
 
     it("Should publish messages to groups with on and brightness", async () => {

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -481,7 +481,7 @@ describe("Extension: Publish", () => {
         expect(group.command).toHaveBeenCalledWith("genOnOff", "on", {}, {});
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2); // 'zigbee2mqtt/bulb_color' + below
         expect(mockMQTTPublishAsync.mock.calls[1][0]).toStrictEqual("zigbee2mqtt/group_1");
-        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON"});
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON", group_state: "ON"});
         group.members.pop();
     });
 
@@ -499,7 +499,7 @@ describe("Extension: Publish", () => {
         );
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2); // 'zigbee2mqtt/bulb_color' + below
         expect(mockMQTTPublishAsync.mock.calls[1][0]).toStrictEqual("zigbee2mqtt/group_1");
-        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON", brightness: 128});
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON", brightness: 128, group_state: "ON"});
         group.members.pop();
     });
 
@@ -543,7 +543,7 @@ describe("Extension: Publish", () => {
         );
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2); // 'zigbee2mqtt/bulb_color' + below
         expect(mockMQTTPublishAsync.mock.calls[1][0]).toStrictEqual("zigbee2mqtt/group_1");
-        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON", brightness: 50});
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON", brightness: 50, group_state: "ON"});
         group.members.pop();
     });
 
@@ -556,7 +556,7 @@ describe("Extension: Publish", () => {
         expect(group.command).toHaveBeenCalledWith("genOnOff", "off", {}, {});
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2); // 'zigbee2mqtt/bulb_color' + below
         expect(mockMQTTPublishAsync.mock.calls[1][0]).toStrictEqual("zigbee2mqtt/group_1");
-        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "OFF"});
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "OFF", group_state: "OFF"});
         group.members.pop();
     });
 
@@ -937,7 +937,7 @@ describe("Extension: Publish", () => {
             {},
         );
         expect(group.command).toHaveBeenCalledWith("genOnOff", "on", {}, {});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/switch_group", stringify({state: "ON", brightness: 100}), {
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/switch_group", stringify({state: "ON", brightness: 100, group_state: "ON"}), {
             retain: false,
             qos: 0,
         });
@@ -948,10 +948,14 @@ describe("Extension: Publish", () => {
         await flushPromises();
         expect(group.command).toHaveBeenCalledTimes(1);
         expect(group.command).toHaveBeenCalledWith("genOnOff", "off", {}, {});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/switch_group", stringify({state: "OFF", brightness: 100}), {
-            retain: false,
-            qos: 0,
-        });
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
+            "zigbee2mqtt/switch_group",
+            stringify({state: "OFF", brightness: 100, group_state: "OFF"}),
+            {
+                retain: false,
+                qos: 0,
+            },
+        );
     });
 
     it("Should use transition when brightness with group", async () => {
@@ -969,7 +973,7 @@ describe("Extension: Publish", () => {
         );
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2); // zigbee2mqtt/bulb_color + below
         expect(mockMQTTPublishAsync.mock.calls[1][0]).toStrictEqual("zigbee2mqtt/group_1");
-        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON", brightness: 100});
+        expect(JSON.parse(mockMQTTPublishAsync.mock.calls[1][1])).toStrictEqual({state: "ON", brightness: 100, group_state: "ON"});
         group.members.pop();
     });
 
@@ -1946,7 +1950,7 @@ describe("Extension: Publish", () => {
         expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(
             1,
             "zigbee2mqtt/group_tradfri_remote",
-            stringify({brightness: 50, color_temp: 290, state: "ON", color_mode: "color_temp"}),
+            stringify({brightness: 50, color_temp: 290, state: "ON", color_mode: "color_temp", group_state: "ON"}),
             {retain: false, qos: 0},
         );
         expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(
@@ -1958,13 +1962,13 @@ describe("Extension: Publish", () => {
         expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(
             3,
             "zigbee2mqtt/ha_discovery_group",
-            stringify({brightness: 50, color_mode: "color_temp", color_temp: 290, state: "ON"}),
+            stringify({brightness: 50, color_mode: "color_temp", color_temp: 290, state: "ON", group_state: "ON"}),
             {retain: false, qos: 0},
         );
         expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(
             4,
             "zigbee2mqtt/group_tradfri_remote",
-            stringify({brightness: 100, color_temp: 290, state: "ON", color_mode: "color_temp"}),
+            stringify({brightness: 100, color_temp: 290, state: "ON", color_mode: "color_temp", group_state: "ON"}),
             {retain: false, qos: 0},
         );
         expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(
@@ -1976,19 +1980,19 @@ describe("Extension: Publish", () => {
         expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(
             6,
             "zigbee2mqtt/group_with_tradfri",
-            stringify({brightness: 100, color_mode: "color_temp", color_temp: 290, state: "ON"}),
+            stringify({brightness: 100, color_mode: "color_temp", color_temp: 290, state: "ON", group_state: "ON"}),
             {retain: false, qos: 0},
         );
         expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(
             7,
             "zigbee2mqtt/switch_group",
-            stringify({brightness: 100, color_mode: "color_temp", color_temp: 290, state: "ON"}),
+            stringify({brightness: 100, color_mode: "color_temp", color_temp: 290, state: "ON", group_state: "ON"}),
             {retain: false, qos: 0},
         );
         expect(mockMQTTPublishAsync).toHaveBeenNthCalledWith(
             8,
             "zigbee2mqtt/ha_discovery_group",
-            stringify({brightness: 100, color_mode: "color_temp", color_temp: 290, state: "ON"}),
+            stringify({brightness: 100, color_mode: "color_temp", color_temp: 290, state: "ON", group_state: "ON"}),
             {retain: false, qos: 0},
         );
     });

--- a/test/extensions/receive.test.ts
+++ b/test/extensions/receive.test.ts
@@ -641,7 +641,10 @@ describe("Extension: Receive", () => {
         await flushPromises();
         expect(mockMQTTPublishAsync).toHaveBeenCalledTimes(2);
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/power_plug", stringify({state: "ON"}), {retain: false, qos: 0});
-        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/switch_group", stringify({state: "ON"}), {retain: false, qos: 0});
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/switch_group", stringify({state: "ON", group_state: "ON"}), {
+            retain: false,
+            qos: 0,
+        });
     });
 
     it("Should not handle messages from coordinator", async () => {


### PR DESCRIPTION

## Summary

`state` and `group_state` serve two different purposes:

- `state` preserves the historical group behavior, including the behavior
  selected through `off_state: all_members_off` or
  `off_state: last_member_state`;
- `group_state` summarizes the member states using the same possible values as
  `state` (`ON`, `OFF`, `OPEN`, or `CLOSE`), with `PARTIAL` added when active
  and inactive states are mixed. Members with no state or an unrecognized value
  are ignored.

## Behavior

### With `off_state: all_members_off`

- `state` remains `ON` until the last member is turned off;
- `group_state` provides a more precise view of the members without changing
  the historical behavior of `state`.

Users who need a more detailed view of the group can therefore use
`group_state` independently of the publication rule applied to `state`.

### With `off_state: last_member_state`

- `state` becomes `OFF` as soon as the first member is turned off. Existing
  automations can continue to rely on this signal;
- `group_state` remains `PARTIAL` as long as at least one member is active and
  at least one is inactive.

`group_state` therefore complements rather than replaces `state`. Applying
`off_state` to `group_state` as well would make it redundant with `state`.

`ON`/`OFF` and `OPEN`/`CLOSE` follow the same active/inactive logic.

### Group initially `ON`

| Successive member states | `state` with<br>`off_state: all_members_off` | `state` with<br>`off_state: last_member_state` | `group_state` |
| :---: | :---: | :---: | :---: |
| `ON` / `ON` / `ON` | `ON` | `ON` | `ON` |
| → `OFF` / `ON` / `ON` | `ON` | `OFF` | `PARTIAL` |
| `OFF` / → `OFF` / `ON` | `ON` | `OFF` | `PARTIAL` |
| `OFF` / `OFF` / → `OFF` | `OFF` | `OFF` | `OFF` |

### Group initially `OFF`

| Successive member states | `state` with<br>`off_state: all_members_off` | `state` with<br>`off_state: last_member_state` | `group_state` |
| :---: | :---: | :---: | :---: |
| `OFF` / `OFF` / `OFF` | `OFF` | `OFF` | `OFF` |
| → `ON` / `OFF` / `OFF` | `ON` | `ON` | `PARTIAL` |
| `ON` / → `ON` / `OFF` | `ON` | `ON` | `PARTIAL` |
| `ON` / `ON` / → `ON` | `ON` | `ON` | `ON` |

Adding `group_state` instead of extending `state` with `PARTIAL` preserves
compatibility with the existing `state` and `off_state` behavior.

## Unchanged behavior

Groups sharing members continue to apply their own `off_state` and `optimistic`
settings independently.

Optimistic eligibility continues to be evaluated per group. When eligible, a
`group_state` transition is published even if the corresponding `state` payload
is unchanged or suppressed by `off_state`.

The `advanced.output` setting only determines the MQTT format and topic; it does
not affect this logic.

## Additional fix

This also fixes an issue when determining the member state key used for group
state calculation.

## Testing

Tests cover the complete transitions shown above, `ON`/`OFF` and
`OPEN`/`CLOSE`, shared groups with different settings, optimistic publishing
disabled, missing or unrecognized member states, member state key resolution,
and both JSON and attribute MQTT output.
