### PR TITLE
fix: refresh dynamic exposes after device settings change

### DIFF
--- a/lib/extension/publish.ts
+++ b/lib/extension/publish.ts
@@ -224,6 +224,9 @@ export default class Publish extends Extension {
                 state: entityState,
                 membersState,
                 mapped: definition,
+                deviceExposesChanged: (): void => {
+                    if (re instanceof Device) this.eventBus.emitExposesAndDevicesChanged(re);
+                },
                 /* v8 ignore next */
                 publish: (payload: KeyValue) => this.publishEntityState(re, payload),
             };

--- a/test/extensions/publish.test.ts
+++ b/test/extensions/publish.test.ts
@@ -85,6 +85,28 @@ describe("Extension: Publish", () => {
         expect(mockMQTTPublishAsync.mock.calls[0][2]).toStrictEqual({qos: 0, retain: false});
     });
 
+    it("Should refresh dynamic exposes requested by a set converter", async () => {
+        const device = controller.zigbee.resolveEntity("bulb_color")!;
+        const definition = device.definition!;
+        const converter = {
+            key: ["dynamic_expose_test"],
+            convertSet: (_entity: unknown, _key: string, _value: unknown, meta: {deviceExposesChanged: () => void}) => {
+                meta.deviceExposesChanged();
+            },
+        };
+        definition.toZigbee ??= [];
+        definition.toZigbee.push(converter);
+        const exposesChanged = vi.spyOn(controller.eventBus, "emitExposesAndDevicesChanged");
+
+        try {
+            await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", stringify({dynamic_expose_test: true}));
+            await flushPromises();
+            expect(exposesChanged).toHaveBeenCalledWith(device);
+        } finally {
+            definition.toZigbee.pop();
+        }
+    });
+
     it("Should corretly handle mallformed messages", async () => {
         await mockMQTTEvents.message("zigbee2mqtt/foo", "");
         await mockMQTTEvents.message("zigbee2mqtt/bulb_color/set", "");


### PR DESCRIPTION
Allows a toZigbee converter to request a dynamic expose refresh after a successful setting change.

This supports devices whose expose metadata changes at runtime, such as a temperature-unit switch.

Tests:
- test/extensions/publish.test.ts