### PR TITLE
fix: store a duration reported by the device

### DIFF
--- a/lib/state.ts
+++ b/lib/state.ts
@@ -22,7 +22,6 @@ const CACHE_IGNORE_PROPERTIES = [
     "no_occupancy_since",
     "step_mode",
     "transition_time",
-    "duration",
     "elapsed",
     "from_side",
     "to_side",

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1100,6 +1100,28 @@ describe("Controller", () => {
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith("zigbee2mqtt/bulb", stringify({state: "ON", brightness: 200}), {qos: 0, retain: true});
     });
 
+    it("Publish entity state caches a duration reported by the device", async () => {
+        await controller.start();
+        mockMQTTPublishAsync.mockClear();
+
+        const device = getZ2MDevice("bulb");
+        await controller.publishEntityState(device, {state: "ON", duration: 30});
+        await flushPromises();
+
+        expect(controller.state.get(device)).toStrictEqual({brightness: 50, color_temp: 370, linkquality: 99, state: "ON", duration: 30});
+    });
+
+    it("Publish entity state keeps an action_duration out of the cache", async () => {
+        await controller.start();
+        mockMQTTPublishAsync.mockClear();
+
+        const device = getZ2MDevice("bulb");
+        await controller.publishEntityState(device, {state: "ON", action_duration: 1500});
+        await flushPromises();
+
+        expect(controller.state.get(device)).toStrictEqual({brightness: 50, color_temp: 370, linkquality: 99, state: "ON"});
+    });
+
     it("Publish entity state attribute_json output filtered cache", async () => {
         await controller.start();
         settings.set(["advanced", "output"], "attribute_and_json");


### PR DESCRIPTION
Fixes #32896.

`duration` sits in the hard-coded `CACHE_IGNORE_PROPERTIES` list in `lib/state.ts`, so `State.set()` strips it before writing the cache. Any device that exposes `duration` as regular state never gets it stored, and it is gone from the next published payload and from `state.json`. The Tuya ZA03 siren in the issue is one case, the Immax TS0219 that reads `maxDuration` back off the device is another.

The entry came in on 2019-05-10 in ee958412, next to `step_mode` and `transition_time`, back when Zigbee2MQTT echoed the published `set` payload into state and command parameters had to be filtered out. That is no longer how it works. The optimistic path in `publish.ts` stores only the `result.state` a converter returns, so the send side no longer needs the entry.

What still needed care was the receive side, where a few button converters published a hold length under the same name. Koenkk/zigbee-herdsman-converters#12968 moves those to `action_duration`, which the `action_.*` pattern in this same list already covers. This pull request should land after a converters release carrying that change, otherwise the WXKG01LM, the WXCJKG13LM and the Leedarson CCTSwitch would start writing the length of the last button press into `state.json`.

## Tests

Two cases in `test/controller.test.ts`. The first publishes a `duration` and asserts it reaches the state cache, and fails on `dev`. The second publishes an `action_duration` and asserts it does not, which pins the pattern the converters change relies on.

`pnpm run check` passes, and the suite is green locally.

## One correction to the issue

`duration` does appear in the payload of the message that carries it, because `publishEntityState` publishes the unfiltered merge and only the cache is filtered. What never happened is that it survived into the next message or into `state.json`.

---

Assisted by Claude. I read and tested every line, and the reasoning above is my own.
