### PR TITLE
fix: Warn when setting unsupported device option

### DIFF
--- a/lib/extension/bridge.ts
+++ b/lib/extension/bridge.ts
@@ -466,6 +466,20 @@ export default class Bridge extends Extension {
 
         const ID = message.id;
         const entity = this.getEntity(entityType, ID);
+
+        if (entity instanceof Device) {
+            const supportedOptions = new Set(Object.keys(settings.schemaJson.definitions.device.properties));
+            for (const option of entity.definition?.options ?? []) {
+                supportedOptions.add(option.property);
+            }
+
+            for (const option of Object.keys(message.options)) {
+                if (!supportedOptions.has(option)) {
+                    logger.warning(`Device '${ID}' does not support option '${option}'`);
+                }
+            }
+        }
+
         const oldOptions = objectAssignDeep({}, cleanup(entity.options));
 
         if (message.options.icon) {

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -3624,6 +3624,28 @@ describe("Extension: Bridge", () => {
         );
     });
 
+    it("Should warn on unsupported device option", async () => {
+        mockMQTTPublishAsync.mockClear();
+        mockLogger.warning.mockClear();
+        mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/options", stringify({options: {unsupported: true}, id: "bulb"}));
+        await flushPromises();
+        expect(settings.getDevice("bulb")).toHaveProperty("unsupported");
+        expect(mockLogger.warning).toHaveBeenCalledWith("Device 'bulb' does not support option 'unsupported'");
+        expect(mockMQTTPublishAsync).toHaveBeenCalledWith(
+            "zigbee2mqtt/bridge/response/device/options",
+            stringify({
+                data: {
+                    from: {retain: true, description: "this is my bulb"},
+                    to: {retain: true, description: "this is my bulb", unsupported: true},
+                    id: "bulb",
+                    restart_required: false,
+                },
+                status: "ok",
+            }),
+            {},
+        );
+    });
+
     it("Should allow to add group by string", async () => {
         mockMQTTPublishAsync.mockClear();
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/group/add", "group_193");

--- a/test/extensions/bridge.test.ts
+++ b/test/extensions/bridge.test.ts
@@ -3627,8 +3627,16 @@ describe("Extension: Bridge", () => {
     it("Should warn on unsupported device option", async () => {
         mockMQTTPublishAsync.mockClear();
         mockLogger.warning.mockClear();
+
+        const device = controller.zigbee.resolveEntity(devices.bulb.ieeeAddr);
+        assert(device && "definition" in device);
+        const definitionOptions = device.definition?.options;
+        device.definition!.options = undefined;
+
         mockMQTTEvents.message("zigbee2mqtt/bridge/request/device/options", stringify({options: {unsupported: true}, id: "bulb"}));
         await flushPromises();
+        device.definition!.options = definitionOptions;
+
         expect(settings.getDevice("bulb")).toHaveProperty("unsupported");
         expect(mockLogger.warning).toHaveBeenCalledWith("Device 'bulb' does not support option 'unsupported'");
         expect(mockMQTTPublishAsync).toHaveBeenCalledWith(


### PR DESCRIPTION
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/32913

When setting a device option, emit a warning if it doesn't exist (but still save it).

Only checking devices.. For groups I'd need to go through every member, doesn't make much sense

<img width="315" height="176" alt="image" src="https://github.com/user-attachments/assets/84ab514f-361d-446e-b388-6d8a65d3bbb0" />
