### PR TITLE
fix: clamp availability ping delay to the maximum supported timeout

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -9,6 +9,12 @@ import * as settings from "../util/settings";
 import utils from "../util/utils";
 import Extension from "./extension";
 
+/**
+ * Upper bound for a `setTimeout` delay. Node.js stores the delay as a 32-bit signed integer; anything above this
+ * is coerced to `1`, which would turn an ever-growing backoff into a tight loop instead of an ever-longer wait.
+ */
+const MAX_TIMEOUT = 2147483647;
+
 const RETRIEVE_ON_RECONNECT: readonly {keys: string[]; condition?: (state: KeyValue) => boolean}[] = [
     {keys: ["state"]},
     {keys: ["brightness"], condition: (state: KeyValue): boolean => state.state === "ON"},
@@ -108,7 +114,10 @@ export default class Availability extends Extension {
                 // If device did not check in, ping it, if that fails it will be marked as offline
                 this.timers.set(
                     device.ieeeAddr,
-                    setTimeout(this.addToPingQueue.bind(this, device), (this.getTimeout(device) + utils.seconds(1) + jitter) * backoff),
+                    setTimeout(
+                        this.addToPingQueue.bind(this, device),
+                        Math.min((this.getTimeout(device) + utils.seconds(1) + jitter) * backoff, MAX_TIMEOUT),
+                    ),
                 );
             }
         } else {

--- a/test/extensions/availability.test.ts
+++ b/test/extensions/availability.test.ts
@@ -633,6 +633,19 @@ describe("Extension: Availability", () => {
         expect(devices.QBKG03LM.ping).toHaveBeenCalledTimes(4);
     });
 
+    it("clamps the ping delay to the maximum supported timeout", async () => {
+        // `setTimeout` takes a 32-bit signed integer and coerces anything above it to `1`. A delay can exceed
+        // that either directly, through a long `timeout`, or gradually, once `backoff` has multiplied a normal
+        // one over successive failures. Unclamped, that turns an ever-longer wait into a tight ping loop.
+        settings.set(["devices", devices.bulb_color.ieeeAddr, "availability"], {timeout: 40000, max_jitter: 0}); // ~27.8 days
+        await resetExtension();
+
+        // unclamped, the delay collapses to 1ms, so pings would already be looping by now
+        await setTimeAndAdvanceTimers(utils.seconds(1));
+
+        expect(devices.bulb_color.ping).not.toHaveBeenCalled();
+    });
+
     it("allows to disable backoff", async () => {
         settings.set(["availability", "active", "max_jitter"], 0); // easier testing
         settings.set(["availability", "active", "backoff"], false);


### PR DESCRIPTION
Fixes #32936

`availability.active.backoff` multiplies the ping interval on every failure with no upper bound,
and the resulting delay was passed to `setTimeout` unclamped. Node stores that delay as a 32-bit
signed integer, so once it exceeds `2147483647` ms the delay is coerced to `1` — inverting the
backoff into a continuous ping loop instead of an ever-longer wait.

With default settings this happens after 13 consecutive failures (~43 days of device absence):
the multiplier reaches 6144, making the delay ~42.7 days. From then on the device is pinged as
fast as the ping can fail, and the multiplier keeps doubling until it saturates at `Infinity`,
which is absorbing — so the state never recovers.

Each of those pings to an absent router triggers a network-wide broadcast route discovery. On the
reporter's network a single device unplugged since January produced ~280 pings/hour indefinitely,
accounting for 97% of all APS errors.

Clamping the delay also covers the case behind #17659 and #10853, where a large user-configured
`availability_timeout` overflowed `setTimeout` directly, without any backoff involved.

Capping `pingBackoffs` itself would fix the loop too, but clamping at the `setTimeout` call site
guards every path that can produce an out-of-range delay, not just the backoff one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpAxJ1qhtQqvZ1iK3r41aw
