### PR TITLE
Fixes for availability ping

### DIFF
--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -95,35 +95,46 @@ export default class Availability extends Extension {
         clearTimeout(this.timers.get(device.ieeeAddr));
         this.removeFromPingQueue(device);
 
-        // If the timer triggers, the device is not available anymore otherwise resetTimer already has been called
-        if (this.isActiveDevice(device)) {
-            const backoffEnabled = this.getBackoff(device);
-            const jitter = Math.random() * this.getMaxJitter(device);
-            let backoff = 1;
+        try {
+            // If the timer triggers, the device is not available anymore otherwise resetTimer already has been called
+            if (this.isActiveDevice(device)) {
+                const backoffEnabled = this.getBackoff(device);
+                const jitter = Math.random() * this.getMaxJitter(device);
+                let backoff = 1;
 
-            if (resetBackoff) {
-                // always cleanup even if backoff disabled (ensures proper state if changed at runtime)
-                this.backoffPausedDevices.delete(device.ieeeAddr);
-                this.pingBackoffs.delete(device.ieeeAddr);
-            } else if (backoffEnabled) {
-                backoff = this.pingBackoffs.get(device.ieeeAddr) ?? 1;
-            }
+                if (resetBackoff) {
+                    // always cleanup even if backoff disabled (ensures proper state if changed at runtime)
+                    this.backoffPausedDevices.delete(device.ieeeAddr);
+                    this.pingBackoffs.delete(device.ieeeAddr);
+                } else if (backoffEnabled) {
+                    backoff = this.pingBackoffs.get(device.ieeeAddr) ?? 1;
+                }
 
-            // never paused if was reset (just deleted) or backoff disabled, might as well skip the Set lookup
-            if (!backoffEnabled || resetBackoff || !this.backoffPausedDevices.has(device.ieeeAddr)) {
-                // If device did not check in, ping it, if that fails it will be marked as offline
+                // never paused if was reset (just deleted) or backoff disabled, might as well skip the Set lookup
+                if (!backoffEnabled || resetBackoff || !this.backoffPausedDevices.has(device.ieeeAddr)) {
+                    // If device did not check in, ping it, if that fails it will be marked as offline
+                    this.timers.set(
+                        device.ieeeAddr,
+                        setTimeout(
+                            this.addToPingQueue.bind(this, device),
+                            Math.min((this.getTimeout(device) + utils.seconds(1) + jitter) * backoff, MAX_TIMEOUT),
+                        ),
+                    );
+                }
+            } else {
                 this.timers.set(
                     device.ieeeAddr,
-                    setTimeout(
-                        this.addToPingQueue.bind(this, device),
-                        Math.min((this.getTimeout(device) + utils.seconds(1) + jitter) * backoff, MAX_TIMEOUT),
-                    ),
+                    setTimeout(this.publishAvailability.bind(this, device, true), this.getTimeout(device) + utils.seconds(1)),
                 );
             }
-        } else {
+        } catch (error) {
+            logger.error(
+                `resetTimer failed unexpectedly for '${device.name}' (${(error as Error).message}); scheduling fallback retry in 60s`,
+            );
+            // Fallback: always leave the device with SOME active timer, never orphaned.
             this.timers.set(
                 device.ieeeAddr,
-                setTimeout(this.publishAvailability.bind(this, device, true), this.getTimeout(device) + utils.seconds(1)),
+                setTimeout(() => this.resetTimer(device, resetBackoff), 60000),
             );
         }
     }

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -151,56 +151,61 @@ export default class Availability extends Extension {
         }
 
         this.pingQueueExecuting = true;
-        const device = this.pingQueue[0];
-        let pingSuccess = false;
-        const available = this.lastPublishedAvailabilities.get(device.ieeeAddr) || this.isAvailable(device);
-        const attempts = available ? 2 : 1;
 
-        for (let i = 1; i <= attempts; i++) {
-            try {
-                // Enable recovery if device is marked as available and first ping fails.
-                await device.zh.ping(!available || i !== 2);
+        try {
+            const device = this.pingQueue[0];
+            let pingSuccess = false;
+            const available = this.lastPublishedAvailabilities.get(device.ieeeAddr) || this.isAvailable(device);
+            const attempts = available ? 2 : 1;
 
-                pingSuccess = true;
+            for (let i = 1; i <= attempts; i++) {
+                try {
+                    // Enable recovery if device is marked as available and first ping fails.
+                    await device.zh.ping(!available || i !== 2);
 
-                logger.debug(`Successfully pinged '${device.name}' (attempt ${i}/${attempts})`);
-                break;
-            } catch (error) {
-                logger.warning(`Failed to ping '${device.name}' (attempt ${i}/${attempts}, ${(error as Error).message})`);
+                    pingSuccess = true;
 
-                // Try again in 3 seconds.
-                if (i !== attempts) {
-                    await utils.sleep(3);
+                    logger.debug(`Successfully pinged '${device.name}' (attempt ${i}/${attempts})`);
+                    break;
+                } catch (error) {
+                    logger.warning(`Failed to ping '${device.name}' (attempt ${i}/${attempts}, ${(error as Error).message})`);
+
+                    // Try again in 3 seconds.
+                    if (i !== attempts) {
+                        await utils.sleep(3);
+                    }
                 }
             }
-        }
 
-        if (this.stopped) {
-            // Exit here to avoid triggering any follow-up activity (e.g., re-queuing another ping attempt).
-            return;
-        }
-
-        if (!pingSuccess && this.getBackoff(device)) {
-            const currentBackoff = this.pingBackoffs.get(device.ieeeAddr) ?? 1;
-            // setting is "greater than" but since we already did the ping, we use ">=" for comparison below (pause next)
-            const pauseOnBackoff = this.getPauseOnBackoffGt(device);
-
-            if (pauseOnBackoff > 0 && currentBackoff >= pauseOnBackoff) {
-                this.backoffPausedDevices.add(device.ieeeAddr);
-            } else {
-                // results in backoffs: *1.5, *3, *6, *12... (with default timeout: 10, 15, 30, 60, 120)
-                this.pingBackoffs.set(device.ieeeAddr, currentBackoff * (available ? 1.5 : 2));
+            if (this.stopped) {
+                // Exit here to avoid triggering any follow-up activity (e.g., re-queuing another ping attempt).
+                return;
             }
+
+            if (!pingSuccess && this.getBackoff(device)) {
+                const currentBackoff = this.pingBackoffs.get(device.ieeeAddr) ?? 1;
+                // setting is "greater than" but since we already did the ping, we use ">=" for comparison below (pause next)
+                const pauseOnBackoff = this.getPauseOnBackoffGt(device);
+
+                if (pauseOnBackoff > 0 && currentBackoff >= pauseOnBackoff) {
+                    this.backoffPausedDevices.add(device.ieeeAddr);
+                } else {
+                    // results in backoffs: *1.5, *3, *6, *12... (with default timeout: 10, 15, 30, 60, 120)
+                    this.pingBackoffs.set(device.ieeeAddr, currentBackoff * (available ? 1.5 : 2));
+                }
+            }
+
+            await this.publishAvailability(device, !pingSuccess);
+            this.resetTimer(device, pingSuccess);
+            this.removeFromPingQueue(device);
+
+            // Sleep 2 seconds before executing next ping
+            await utils.sleep(2);
+        } catch (error) {
+            logger.error(`Ping queue processing failed unexpectedly: ${(error as Error).message}`);
+        } finally {
+            this.pingQueueExecuting = false;
         }
-
-        await this.publishAvailability(device, !pingSuccess);
-        this.resetTimer(device, pingSuccess);
-        this.removeFromPingQueue(device);
-
-        // Sleep 2 seconds before executing next ping
-        await utils.sleep(2);
-
-        this.pingQueueExecuting = false;
 
         await this.pingQueueExecuteNext();
     }

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -161,8 +161,9 @@ export default class Availability extends Extension {
 
         this.pingQueueExecuting = true;
 
+        const device = this.pingQueue[0];
+
         try {
-            const device = this.pingQueue[0];
             let pingSuccess = false;
             const available = this.lastPublishedAvailabilities.get(device.ieeeAddr) || this.isAvailable(device);
             const attempts = available ? 2 : 1;
@@ -211,7 +212,9 @@ export default class Availability extends Extension {
             // Sleep 2 seconds before executing next ping
             await utils.sleep(2);
         } catch (error) {
-            logger.error(`Ping queue processing failed unexpectedly: ${(error as Error).message}`);
+            logger.error(`Ping queue processing failed unexpectedly for '${device.name}' (${(error as Error).message})`);
+            this.resetTimer(device);
+            this.removeFromPingQueue(device);
         } finally {
             this.pingQueueExecuting = false;
         }

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -300,10 +300,14 @@ export default class Availability extends Extension {
 
     @bind private async onLastSeenChanged(data: eventdata.LastSeenChanged): Promise<void> {
         if (utils.isAvailabilityEnabledForEntity(data.device, settings.get())) {
-            // Remove from ping queue, not necessary anymore since we know the device is online.
-            this.removeFromPingQueue(data.device);
-            this.resetTimer(data.device, true);
-            await this.publishAvailability(data.device, false);
+            try {
+                // Remove from ping queue, not necessary anymore since we know the device is online.
+                this.removeFromPingQueue(data.device);
+                this.resetTimer(data.device, true);
+                await this.publishAvailability(data.device, false);
+            } catch (error) {
+                logger.error(`onLastSeenChanged handling failed for '${data.device.name}' (${(error as Error).message})`);
+            }
         }
     }
 

--- a/lib/extension/availability.ts
+++ b/lib/extension/availability.ts
@@ -128,9 +128,7 @@ export default class Availability extends Extension {
                 );
             }
         } catch (error) {
-            logger.error(
-                `resetTimer failed unexpectedly for '${device.name}' (${(error as Error).message}); scheduling fallback retry in 60s`,
-            );
+            logger.error(`resetTimer failed unexpectedly for '${device.name}' (${(error as Error).message}); scheduling fallback retry in 60s`);
             // Fallback: always leave the device with SOME active timer, never orphaned.
             this.timers.set(
                 device.ieeeAddr,

--- a/test/extensions/availability.test.ts
+++ b/test/extensions/availability.test.ts
@@ -713,12 +713,13 @@ describe("Extension: Availability", () => {
     });
 
     it("keeps draining the ping queue when processing fails unexpectedly", async () => {
+        settings.set(["availability", "active", "max_jitter"], 0); // easier testing
         const availability = controller.getExtension("Availability")! as Availability;
         const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
         mockLogger.error.mockClear();
 
         // @ts-expect-error private
-        vi.spyOn(availability, "publishAvailability").mockImplementationOnce(() => {
+        const publishAvailabilitySpy = vi.spyOn(availability, "publishAvailability").mockImplementationOnce(() => {
             throw new Error("failed");
         });
 
@@ -726,12 +727,19 @@ describe("Extension: Availability", () => {
         availability.addToPingQueue(device);
         await flushPromises();
 
-        expect(mockLogger.error).toHaveBeenCalledWith("Ping queue processing failed unexpectedly: failed");
+        expect(mockLogger.error).toHaveBeenCalledWith("Ping queue processing failed unexpectedly for 'bulb_color' (failed)");
         // the queue is not left blocked by the failure
         // @ts-expect-error private
         expect(availability.pingQueue).toEqual([]);
         // @ts-expect-error private
         expect(availability.pingQueueExecuting).toStrictEqual(false);
+        // the device is dropped from the queue instead of being retried right away in a tight loop
+        expect(publishAvailabilitySpy).toHaveBeenCalledTimes(1);
+        expect(devices.bulb_color.ping).toHaveBeenCalledTimes(1);
+
+        // its timer is re-armed, so it is picked up again on the next interval
+        await setTimeAndAdvanceTimers(utils.minutes(11));
+        expect(devices.bulb_color.ping).toHaveBeenCalledTimes(2);
     });
 
     it("keeps running when handling a last seen change fails", async () => {

--- a/test/extensions/availability.test.ts
+++ b/test/extensions/availability.test.ts
@@ -689,4 +689,67 @@ describe("Extension: Availability", () => {
         await setTimeAndAdvanceTimers(utils.minutes(0.5)); // 40:30
         expect(devices.bulb_color.ping).toHaveBeenCalledTimes(5);
     });
+
+    it("keeps a fallback timer when resetting the ping timer fails", async () => {
+        settings.set(["availability", "active", "max_jitter"], 0); // easier testing
+        const availability = controller.getExtension("Availability")! as Availability;
+        mockLogger.error.mockClear();
+
+        // @ts-expect-error private
+        vi.spyOn(availability, "isActiveDevice").mockImplementationOnce(() => {
+            throw new Error("failed");
+        });
+
+        await mockZHEvents.lastSeenChanged({device: devices.bulb_color});
+
+        expect(mockLogger.error).toHaveBeenCalledWith("resetTimer failed unexpectedly for 'bulb_color' (failed); scheduling fallback retry in 60s");
+
+        // the fallback retry leaves the device with a regular ping timer again, instead of no timer at all
+        await setTimeAndAdvanceTimers(utils.seconds(60));
+        expect(devices.bulb_color.ping).toHaveBeenCalledTimes(0);
+
+        await setTimeAndAdvanceTimers(utils.minutes(11));
+        expect(devices.bulb_color.ping).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps draining the ping queue when processing fails unexpectedly", async () => {
+        const availability = controller.getExtension("Availability")! as Availability;
+        const device = controller.zigbee.resolveEntity(devices.bulb_color.ieeeAddr);
+        mockLogger.error.mockClear();
+
+        // @ts-expect-error private
+        vi.spyOn(availability, "publishAvailability").mockImplementationOnce(() => {
+            throw new Error("failed");
+        });
+
+        // @ts-expect-error private
+        availability.addToPingQueue(device);
+        await flushPromises();
+
+        expect(mockLogger.error).toHaveBeenCalledWith("Ping queue processing failed unexpectedly: failed");
+        // the queue is not left blocked by the failure
+        // @ts-expect-error private
+        expect(availability.pingQueue).toEqual([]);
+        // @ts-expect-error private
+        expect(availability.pingQueueExecuting).toStrictEqual(false);
+    });
+
+    it("keeps running when handling a last seen change fails", async () => {
+        settings.set(["availability", "active", "max_jitter"], 0); // easier testing
+        const availability = controller.getExtension("Availability")! as Availability;
+        mockLogger.error.mockClear();
+
+        // @ts-expect-error private
+        vi.spyOn(availability, "publishAvailability").mockImplementationOnce(() => {
+            throw new Error("failed");
+        });
+
+        await mockZHEvents.lastSeenChanged({device: devices.bulb_color});
+
+        expect(mockLogger.error).toHaveBeenCalledWith("onLastSeenChanged handling failed for 'bulb_color' (failed)");
+
+        // the timer was still reset, so availability tracking continues
+        await setTimeAndAdvanceTimers(utils.minutes(11));
+        expect(devices.bulb_color.ping).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
**ISSUE**

Even after fixing https://github.com/Koenkk/zigbee-herdsman/pull/1851, I still had issues that availability ping stopped working sporadically

**FIXES**

To mitigate problem of stopped availability ping, following changes improved the reliability of availability ping:

**Change 1:** Handle error in pingQueueExecuteNext
Any unhandled error in pingQueueExecuteNext (e.g. publishAvailability's mqtt.publish throwing) left pingQueueExecuting stuck at true forever.
Since this flag is shared across ALL devices, that permanently deadlocks availability checking for the whole bridge, with no error logged (addToPingQueue swallows the rejection via .catch(utils.noop)).
Wrapping in try/finally guarantees the lock always releases and the queue keeps moving, regardless of what fails inside.

**Change 2:** Handle error in resetTimer
resetTimer function runs with no try/catch. The old timer was already cleared above by this point. If anything here threw (isActiveDevice, getBackoff, getMaxJitter, getTimeout), the function exited with the device's timer never re-armed - leaving it permanently unmonitored, with no error logged.
Wrapping in try/catch guarantees a timer always gets set, falling back to a retry of resetTimer itself if something goes wrong.

**Change 3:** Handle error in onLastSeenChanged
This is an event-bus handler with no caller awaiting or catching it.
An unhandled error here silently stops this device's availability tracking from updating.