### PR TITLE
fix: Require Node `<=26.2` for serialport

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "git+https://github.com/Koenkk/zigbee2mqtt.git"
     },
     "engines": {
-        "node": "^22.2.0 || ^24 || ^26"
+        "node": "^22.2.0 || ^24 || <=26.2"
     },
     "keywords": [
         "xiaomi",


### PR DESCRIPTION
Due to https://github.com/serialport/node-serialport/issues/3148