### PR TITLE
fix(homeassistant): add state class for formaldehyde

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -211,6 +211,7 @@ const NUMERIC_DISCOVERY_LOOKUP: {[s: string]: KeyValue} = {
     external_humidity: {device_class: "humidity", icon: "mdi:water-percent", state_class: "measurement"},
     fading_time: {entity_category: "config", icon: "mdi:timer"},
     formaldehyd: {state_class: "measurement"},
+    formaldehyde: {state_class: "measurement"},
     flow: {device_class: "volume_flow_rate", state_class: "measurement"},
     gas: {device_class: "gas", state_class: "total_increasing", icon: "mdi:meter-gas"},
     gas_density: {icon: "mdi:google-circles-communities", state_class: "measurement"},


### PR DESCRIPTION
Adds Home Assistant discovery metadata for the numeric `formaldehyde` expose so it is published with `state_class: measurement`.

Some supported devices expose formaldehyde with this spelling, while the discovery lookup already handled `formaldehyd` and `hcho`. Without this entry, Home Assistant creates a repair warning for entities that previously had long-term statistics because the MQTT sensor no longer has a state class.

This keeps the existing entity/property name unchanged and only restores the statistics metadata.
