### PR TITLE
fix(cover): fix Home Assistant cover state reporting when moving from fully opened/closed state

### DIFF
--- a/lib/extension/homeassistant.ts
+++ b/lib/extension/homeassistant.ts
@@ -1002,30 +1002,18 @@ export class HomeAssistant extends Extension {
                         discoveryEntry.discovery_payload.state_open = "OPEN";
                         discoveryEntry.discovery_payload.state_closed = "CLOSE";
                         discoveryEntry.discovery_payload.state_stopped = stoppedState;
-                        // A movement value can remain stale after the cover reaches an endpoint. Prefer a terminal position when `state` agrees.
-                        const terminalPositionTemplate = positionProperty
-                            ? `{% if "${positionProperty}" in value_json and value_json["${positionProperty}"] == 0 and "${stateProperty}" in value_json and value_json["${stateProperty}"] == "CLOSE" %}` +
-                              "CLOSE" +
-                              `{% elif "${positionProperty}" in value_json and value_json["${positionProperty}"] == 100 and "${stateProperty}" in value_json and value_json["${stateProperty}"] == "OPEN" %}` +
-                              "OPEN"
-                            : "";
+                        const positionValue = positionProperty ? `value_json["${positionProperty}"] | default(none)` : "none";
                         discoveryEntry.discovery_payload.value_template =
-                            terminalPositionTemplate +
-                            `${positionProperty ? "{% elif" : "{% if"} "${motorStateProperty}" in value_json and value_json["${motorStateProperty}"] == "${openingState}" %}` +
-                            `${openingState}` +
-                            `{% elif "${motorStateProperty}" in value_json and value_json["${motorStateProperty}"] == "${closingState}" %}` +
-                            `${closingState}` +
-                            (positionProperty
-                                ? `{% elif "${motorStateProperty}" in value_json and value_json["${motorStateProperty}"] == "${stoppedState}" and "${positionProperty}" in value_json %}` +
-                                  `{% if value_json["${positionProperty}"] == 0 %}CLOSE{% else %}OPEN{% endif %}`
-                                : "") +
-                            `{% elif "${stateProperty}" in value_json and value_json["${stateProperty}"] == "OPEN" %}` +
-                            "OPEN" +
-                            `{% elif "${stateProperty}" in value_json and value_json["${stateProperty}"] == "CLOSE" %}` +
-                            "CLOSE" +
-                            "{% else %}" +
-                            `${stoppedState}` +
-                            "{% endif %}";
+                            `{% set motor = value_json["${motorStateProperty}"] | default(none) %}` +
+                            `{% set position = ${positionValue} %}` +
+                            `{% set state = value_json["${stateProperty}"] | default(none) %}` +
+                            `{% if (motor == "${openingState}" and position != 100) or (motor == "${closingState}" and position != 0) %}` +
+                            "{{ motor }}" +
+                            "{% elif position == 0 %}CLOSE" +
+                            "{% elif position == 100 %}OPEN" +
+                            `{% elif motor == "${stoppedState}" and position is not none %}OPEN` +
+                            '{% elif state in ["OPEN", "CLOSE"] %}{{ state }}' +
+                            `{% else %}${stoppedState}{% endif %}`;
                     }
                 }
 

--- a/test/extensions/homeassistant.test.ts
+++ b/test/extensions/homeassistant.test.ts
@@ -1645,6 +1645,8 @@ describe("Extension: HomeAssistant", () => {
     });
 
     it("Should discover dual cover devices", () => {
+        const coverValueTemplate =
+            '{% set motor = value_json["moving"] | default(none) %}{% set position = value_json["position"] | default(none) %}{% set state = value_json["state"] | default(none) %}{% if (motor == "UP" and position != 100) or (motor == "DOWN" and position != 0) %}{{ motor }}{% elif position == 0 %}CLOSE{% elif position == 100 %}OPEN{% elif motor == "STOP" and position is not none %}OPEN{% elif state in ["OPEN", "CLOSE"] %}{{ state }}{% else %}STOP{% endif %}';
         const payload_left = {
             availability: [
                 {
@@ -1676,8 +1678,7 @@ describe("Extension: HomeAssistant", () => {
             state_stopped: "STOP",
             state_topic: "zigbee2mqtt/0xa4c138018cf95021/left",
             unique_id: "0xa4c138018cf95021_cover_left_zigbee2mqtt",
-            value_template:
-                '{% if "position" in value_json and value_json["position"] == 0 and "state" in value_json and value_json["state"] == "CLOSE" %}CLOSE{% elif "position" in value_json and value_json["position"] == 100 and "state" in value_json and value_json["state"] == "OPEN" %}OPEN{% elif "moving" in value_json and value_json["moving"] == "UP" %}UP{% elif "moving" in value_json and value_json["moving"] == "DOWN" %}DOWN{% elif "moving" in value_json and value_json["moving"] == "STOP" and "position" in value_json %}{% if value_json["position"] == 0 %}CLOSE{% else %}OPEN{% endif %}{% elif "state" in value_json and value_json["state"] == "OPEN" %}OPEN{% elif "state" in value_json and value_json["state"] == "CLOSE" %}CLOSE{% else %}STOP{% endif %}',
+            value_template: coverValueTemplate,
         };
         const payload_right = {
             availability: [
@@ -1710,8 +1711,7 @@ describe("Extension: HomeAssistant", () => {
             state_stopped: "STOP",
             state_topic: "zigbee2mqtt/0xa4c138018cf95021/right",
             unique_id: "0xa4c138018cf95021_cover_right_zigbee2mqtt",
-            value_template:
-                '{% if "position" in value_json and value_json["position"] == 0 and "state" in value_json and value_json["state"] == "CLOSE" %}CLOSE{% elif "position" in value_json and value_json["position"] == 100 and "state" in value_json and value_json["state"] == "OPEN" %}OPEN{% elif "moving" in value_json and value_json["moving"] == "UP" %}UP{% elif "moving" in value_json and value_json["moving"] == "DOWN" %}DOWN{% elif "moving" in value_json and value_json["moving"] == "STOP" and "position" in value_json %}{% if value_json["position"] == 0 %}CLOSE{% else %}OPEN{% endif %}{% elif "state" in value_json and value_json["state"] == "OPEN" %}OPEN{% elif "state" in value_json and value_json["state"] == "CLOSE" %}CLOSE{% else %}STOP{% endif %}',
+            value_template: coverValueTemplate,
         };
 
         const coverLeftCalls = mockMQTTPublishAsync.mock.calls.filter(
@@ -1732,7 +1732,7 @@ describe("Extension: HomeAssistant", () => {
         });
     });
 
-    it("Should derive stopped cover state from position for motor_state covers", () => {
+    it("Should derive direction-aware cover state from position for motor_state covers", () => {
         const coverExpose = new zhc.Cover().withPosition();
         const motorStateExpose = new zhc.Enum("motor_state", zhc.access.STATE, ["opening", "closing", "stopped"]);
         const device = {
@@ -1756,7 +1756,7 @@ describe("Extension: HomeAssistant", () => {
             state_closed: "CLOSE",
             state_stopped: "stopped",
             value_template:
-                '{% if "position" in value_json and value_json["position"] == 0 and "state" in value_json and value_json["state"] == "CLOSE" %}CLOSE{% elif "position" in value_json and value_json["position"] == 100 and "state" in value_json and value_json["state"] == "OPEN" %}OPEN{% elif "motor_state" in value_json and value_json["motor_state"] == "opening" %}opening{% elif "motor_state" in value_json and value_json["motor_state"] == "closing" %}closing{% elif "motor_state" in value_json and value_json["motor_state"] == "stopped" and "position" in value_json %}{% if value_json["position"] == 0 %}CLOSE{% else %}OPEN{% endif %}{% elif "state" in value_json and value_json["state"] == "OPEN" %}OPEN{% elif "state" in value_json and value_json["state"] == "CLOSE" %}CLOSE{% else %}stopped{% endif %}',
+                '{% set motor = value_json["motor_state"] | default(none) %}{% set position = value_json["position"] | default(none) %}{% set state = value_json["state"] | default(none) %}{% if (motor == "opening" and position != 100) or (motor == "closing" and position != 0) %}{{ motor }}{% elif position == 0 %}CLOSE{% elif position == 100 %}OPEN{% elif motor == "stopped" and position is not none %}OPEN{% elif state in ["OPEN", "CLOSE"] %}{{ state }}{% else %}stopped{% endif %}',
         });
     });
 
@@ -1784,7 +1784,7 @@ describe("Extension: HomeAssistant", () => {
             state_closed: "CLOSE",
             state_stopped: "stopped",
             value_template:
-                '{% if "motor_state" in value_json and value_json["motor_state"] == "opening" %}opening{% elif "motor_state" in value_json and value_json["motor_state"] == "closing" %}closing{% elif "state" in value_json and value_json["state"] == "OPEN" %}OPEN{% elif "state" in value_json and value_json["state"] == "CLOSE" %}CLOSE{% else %}stopped{% endif %}',
+                '{% set motor = value_json["motor_state"] | default(none) %}{% set position = none %}{% set state = value_json["state"] | default(none) %}{% if (motor == "opening" and position != 100) or (motor == "closing" and position != 0) %}{{ motor }}{% elif position == 0 %}CLOSE{% elif position == 100 %}OPEN{% elif motor == "stopped" and position is not none %}OPEN{% elif state in ["OPEN", "CLOSE"] %}{{ state }}{% else %}stopped{% endif %}',
         });
     });
 


### PR DESCRIPTION
This is a another follow-up to #32907 and #33003.

After fixing issues with PRs mentioned above, we have still two outstanding issues to cope with.

- When opening cover from position `0` it shows as `CLOSE` until it stops, without showing `CLOSING`.
- When closing cover from position `100` it shows as `OPEN` until it stops, without showing `OPENING`.

Any movement starting from an intermediate position is already reported correctly.

## Hopefully final solution

A movement report is now accepted unless it points toward an endpoint the cover has already reached.

| Reported motor state | Position | Interpretation | Result for HA |
|---|---:|---|---|
| Opening | `0` | Starting to move away from fully closed | Opening |
| Closing | `100` | Starting to move away from fully open | Closing |
| Closing | `0` | Stale/impossible movement at the closed endpoint | Closed |
| Opening | `100` | Stale/impossible movement at the open endpoint | Open |
| Stopped | `0` | Fully closed, even if `state` is stale and reports differently | Closed |
| Stopped | `100` | Fully open | Open |
| Stopped | `1–99` | Stopped while partially open | Open |
| Unknown/invalid (like `OFF`) | No useful position or valid state | Cannot determine a better state | Stopped |

This approach should fix the two problems described at the beginning and at the same time preserve previous protections for converters introduced with #32907 and #33003 which:

- Publish stale movement after the cover has reached an endpoint.
- Publish stale `state` values, such as `OPEN` at position `0`.
- Publish invalid Home Assistant cover states, such as `OFF` instead of `STOP`.

Essentially, we do this in the `value_template` now, in this order:

1. Accept opening unless already at position `100` (new).
2. Accept closing unless already at position `0` (new).
3. Derive terminal state from position `0` or `100` (already done via #32907).
4. Treat a stopped cover at an intermediate position as open (already done via #32907).
5. Accept only valid `OPEN` or `CLOSE` state values (already done via #33003).
6. Fall back to the converter's stopped state. (already done via #33003).

Besides handling the missing endpoint-departure cases, this makes the generated template shorter and easier to follow.
